### PR TITLE
T502 alias network byte

### DIFF
--- a/src/main/scala/scorex/account/Account.scala
+++ b/src/main/scala/scorex/account/Account.scala
@@ -12,12 +12,14 @@ import scala.util.Success
 
 sealed trait Account extends AccountOrAlias {
   lazy val address: String = Base58.encode(bytes)
-  lazy val stringRepr: String = address
+  lazy val stringRepr: String = Account.Prefix + address
 
   val bytes: Array[Byte]
 }
 
 object Account extends ScorexLogging {
+
+  val Prefix: String = "address:"
 
   val AddressVersion: Byte = 1
   val ChecksumLength = 4
@@ -41,7 +43,7 @@ object Account extends ScorexLogging {
     else Left(InvalidAddress)
   }
 
-  def fromBase58String(address: String): Either[ValidationError, Account] =
+  private def fromBase58String(address: String): Either[ValidationError, Account] =
     if (address.length > AddressStringLength) {
       Left(InvalidAddress)
     } else {
@@ -50,6 +52,14 @@ object Account extends ScorexLogging {
         case _ => Left(InvalidAddress)
       }
     }
+
+  def fromString(address: String): Either[ValidationError, Account] = {
+    val base58String = if (address.startsWith(Prefix))
+      address.drop(Prefix.length)
+    else address
+    fromBase58String(base58String)
+  }
+
 
   private def isByteArrayValid(addressBytes: Array[Byte]): Boolean = {
     val version = addressBytes.head

--- a/src/main/scala/scorex/account/AccountOrAlias.scala
+++ b/src/main/scala/scorex/account/AccountOrAlias.scala
@@ -19,7 +19,7 @@ object AccountOrAlias {
         val addressBytes = bytes.slice(position, addressEnd)
         Account.fromBytes(addressBytes).map((_, addressEnd))
       case Alias.AddressVersion =>
-        val (arr, aliasEnd) = Deser.parseArraySize(bytes, position + 1)
+        val (arr, aliasEnd) = Deser.parseArraySize(bytes, position + 2)
         Alias.fromBytes(bytes.slice(position,aliasEnd)).map((_, aliasEnd))
       case _ => Left(ValidationError.InvalidAddress)
     }

--- a/src/main/scala/scorex/account/AccountOrAlias.scala
+++ b/src/main/scala/scorex/account/AccountOrAlias.scala
@@ -20,15 +20,14 @@ object AccountOrAlias {
         Account.fromBytes(addressBytes).map((_, addressEnd))
       case Alias.AddressVersion =>
         val (arr, aliasEnd) = Deser.parseArraySize(bytes, position + 2)
-        Alias.fromBytes(bytes.slice(position,aliasEnd)).map((_, aliasEnd))
+        Alias.fromBytes(bytes.slice(position, aliasEnd)).map((_, aliasEnd))
       case _ => Left(ValidationError.InvalidAddress)
     }
   }
 
   def fromString(s: String): Either[ValidationError, AccountOrAlias] = {
-    Account.fromBase58String(s) match {
-      case Right(a) => Right(a)
-      case Left(_) => Alias(s)
-    }
+    if (s.startsWith(Alias.Prefix))
+      Alias.fromString(s)
+    else Account.fromString(s)
   }
 }

--- a/src/main/scala/scorex/account/Alias.scala
+++ b/src/main/scala/scorex/account/Alias.scala
@@ -3,36 +3,58 @@ package scorex.account
 import scorex.serialization.BytesSerializable
 import scorex.transaction.ValidationError
 import scorex.transaction.ValidationError.TransactionParameterValidationError
-import scorex.account.Alias._
 
 sealed trait Alias extends AccountOrAlias {
-  lazy val stringRepr: String = name
-  lazy val bytes: Array[Byte] = Alias.AddressVersion +: schemeByte +: BytesSerializable.arrayWithSize(name.getBytes("UTF-8"))
+  lazy val stringRepr: String = Alias.Prefix + networkByte.toChar + ":" + name
+  lazy val bytes: Array[Byte] = Alias.AddressVersion +: networkByte +: BytesSerializable.arrayWithSize(name.getBytes("UTF-8"))
 
   val name: String
+  val networkByte: Byte
 }
 
 object Alias {
 
-  private def schemeByte: Byte = AddressScheme.current.chainId
+  val Prefix: String = "alias:"
 
   val AddressVersion: Byte = 2
-
   val MinLength = 4
   val MaxLength = 30
 
-  private case class AliasImpl(name: String) extends Alias
+  private def schemeByte: Byte = AddressScheme.current.chainId
 
-  def apply(name: String): Either[ValidationError, Alias] = if (MinLength to MaxLength contains name.length)
-    Right(AliasImpl(name))
-  else Left(TransactionParameterValidationError(s"Alias '$name' length should be between $MinLength and $MaxLength"))
+  private def buildAlias(networkByte: Byte, name: String): Either[ValidationError, Alias] = {
+
+    case class AliasImpl(networkByte: Byte, name: String) extends Alias
+
+    if (!(MinLength to MaxLength contains name.length))
+      Left(TransactionParameterValidationError(s"Alias '$name' length should be between $MinLength and $MaxLength"))
+    if (networkByte != schemeByte)
+      Left(TransactionParameterValidationError("Alias network char doesn't match current scheme"))
+    else
+      Right(AliasImpl(networkByte, name))
+  }
+
+
+  def buildWithCurrentNetworkByte(name: String): Either[ValidationError, Alias] = buildAlias(schemeByte, name)
+
+  def fromString(str: String): Either[ValidationError, Alias] =
+    if (!str.startsWith(Prefix)) {
+      Left(TransactionParameterValidationError("Alias string pattern is 'alias:<chain-id>:<address-alias>"))
+    } else {
+      val charSemicolonAlias = str.drop(Prefix.length)
+      val networkByte = charSemicolonAlias(0).toByte
+      val name = charSemicolonAlias.drop(2)
+      buildAlias(networkByte, name)
+    }
 
   def fromBytes(bytes: Array[Byte]): Either[ValidationError, Alias] = {
     bytes.headOption match {
       case Some(AddressVersion) =>
-        if (bytes.tail.head == schemeByte)
-          Right(AliasImpl(new String(bytes.drop(4), "UTF-8"))) else
+        val networkChar = bytes.tail.head
+        if (networkChar != schemeByte) {
           Left(TransactionParameterValidationError("Alias network byte doesn't match current scheme"))
+        } else
+          buildAlias(networkChar, new String(bytes.drop(4), "UTF-8"))
       case _ => Left(TransactionParameterValidationError("Bad alias bytes"))
     }
   }

--- a/src/main/scala/scorex/account/Alias.scala
+++ b/src/main/scala/scorex/account/Alias.scala
@@ -3,15 +3,18 @@ package scorex.account
 import scorex.serialization.BytesSerializable
 import scorex.transaction.ValidationError
 import scorex.transaction.ValidationError.TransactionParameterValidationError
+import scorex.account.Alias._
 
 sealed trait Alias extends AccountOrAlias {
   lazy val stringRepr: String = name
-  lazy val bytes: Array[Byte] = Alias.AddressVersion +: BytesSerializable.arrayWithSize(name.getBytes("UTF-8"))
+  lazy val bytes: Array[Byte] = Alias.AddressVersion +: schemeByte +: BytesSerializable.arrayWithSize(name.getBytes("UTF-8"))
 
   val name: String
 }
 
 object Alias {
+
+  private def schemeByte: Byte = AddressScheme.current.chainId
 
   val AddressVersion: Byte = 2
 
@@ -26,7 +29,10 @@ object Alias {
 
   def fromBytes(bytes: Array[Byte]): Either[ValidationError, Alias] = {
     bytes.headOption match {
-      case Some(AddressVersion) => Right(AliasImpl(new String(bytes.drop(3), "UTF-8")))
+      case Some(AddressVersion) =>
+        if (bytes.tail.head == schemeByte)
+          Right(AliasImpl(new String(bytes.drop(4), "UTF-8"))) else
+          Left(TransactionParameterValidationError("Alias network byte doesn't match current scheme"))
       case _ => Left(TransactionParameterValidationError("Bad alias bytes"))
     }
   }

--- a/src/main/scala/scorex/api/http/AddressApiRoute.scala
+++ b/src/main/scala/scorex/api/http/AddressApiRoute.scala
@@ -34,7 +34,7 @@ case class AddressApiRoute(settings: RestAPISettings, wallet: Wallet, state: Sta
   ))
   def deleteAddress: Route = path(Segment) { address =>
     (delete & withAuth) {
-      if (Account.fromBase58String(address).isLeft) {
+      if (Account.fromString(address).isLeft) {
         complete(InvalidAddress)
       } else {
         val deleted = wallet.findWallet(address).exists(account =>
@@ -178,7 +178,7 @@ case class AddressApiRoute(settings: RestAPISettings, wallet: Wallet, state: Sta
     new ApiImplicitParam(name = "address", value = "Address", required = true, dataType = "string", paramType = "path")
   ))
   def validate: Route = (path("validate" / Segment) & get) { address =>
-    complete(Json.obj("address" -> address, "valid" -> Account.fromBase58String(address).isRight))
+    complete(Json.obj("address" -> address, "valid" -> Account.fromString(address).isRight))
   }
 
   @Path("/")
@@ -219,7 +219,7 @@ case class AddressApiRoute(settings: RestAPISettings, wallet: Wallet, state: Sta
   }
 
   private def balanceJson(address: String, confirmations: Int): ToResponseMarshallable = {
-    Account.fromBase58String(address).right.map(acc => ToResponseMarshallable(Json.obj(
+    Account.fromString(address).right.map(acc => ToResponseMarshallable(Json.obj(
       "address" -> acc.address,
       "confirmations" -> confirmations,
       "balance" -> state.balanceWithConfirmations(acc, confirmations))))
@@ -227,7 +227,7 @@ case class AddressApiRoute(settings: RestAPISettings, wallet: Wallet, state: Sta
   }
 
   private def effectiveBalanceJson(address: String, confirmations: Int): ToResponseMarshallable = {
-    Account.fromBase58String(address).right.map(acc => ToResponseMarshallable(Json.obj(
+    Account.fromString(address).right.map(acc => ToResponseMarshallable(Json.obj(
       "address" -> acc.address,
       "confirmations" -> confirmations,
       "balance" -> state.effectiveBalanceWithConfirmations(acc, confirmations, state.stateHeight))))
@@ -251,7 +251,7 @@ case class AddressApiRoute(settings: RestAPISettings, wallet: Wallet, state: Sta
 
   private def verifyPath(address: String, decode: Boolean) = withAuth {
     json[SignedMessage] { m =>
-      if (Account.fromBase58String(address).isLeft) {
+      if (Account.fromString(address).isLeft) {
         InvalidAddress
       } else {
         //DECODE SIGNATURE

--- a/src/main/scala/scorex/api/http/BlocksApiRoute.scala
+++ b/src/main/scala/scorex/api/http/BlocksApiRoute.scala
@@ -33,7 +33,7 @@ case class BlocksApiRoute(settings: RestAPISettings, checkpointsSettings: Checkp
   ))
   def address: Route = (path("address" / Segment / IntNumber / IntNumber) & get) { case (address, start, end) =>
     if (end >= 0 && start >= 0 && end - start >= 0 && end - start < MaxBlocksPerRequest) {
-      complete(JsArray(history.generatedBy(Account.fromBase58String(address).right.get, start, end).map(_.json)))
+      complete(JsArray(history.generatedBy(Account.fromString(address).right.get, start, end).map(_.json)))
     } else complete(TooBigArrayAllocation)
   }
 

--- a/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -35,7 +35,7 @@ case class TransactionsApiRoute(
   ))
   def addressLimit: Route = (path("address" / Segment / "limit" / IntNumber) & get) { case (address, limit) =>
     if (limit <= MaxTransactionsPerRequest) {
-      val account = Account.fromBase58String(address).right.get
+      val account = Account.fromString(address).right.get
       val txJsons = state.accountTransactions(account, limit).map(_.json)
       complete(Json.arr(txJsons))
     } else complete(TooBigArrayAllocation)

--- a/src/main/scala/scorex/api/http/alias/AliasApiRoute.scala
+++ b/src/main/scala/scorex/api/http/alias/AliasApiRoute.scala
@@ -45,7 +45,7 @@ case class AliasApiRoute(settings: RestAPISettings, wallet: Wallet, transactionO
     new ApiImplicitParam(name = "alias", value = "Alias", required = true, dataType = "string", paramType = "path")
   ))
   def addressOfAlias: Route = (get & path("by-alias" / Segment)) { aliasString =>
-    val result = Alias(aliasString) match {
+    val result = Alias.buildWithCurrentNetworkByte(aliasString) match {
       case Right(alias) =>
         state.resolveAlias(alias) match {
           case Some(addr) => Right(AliasInfo(addr.address, aliasString))
@@ -62,7 +62,7 @@ case class AliasApiRoute(settings: RestAPISettings, wallet: Wallet, transactionO
     new ApiImplicitParam(name = "address", value = "3Mx2afTZ2KbRrLNbytyzTtXukZvqEB8SkW7", required = true, dataType = "string", paramType = "path")
   ))
   def aliasOfAddress: Route = (get & path("by-address" / Segment)) { addressString =>
-    val result: Either[ApiError, AliasInfo] = Account.fromBase58String(addressString) match {
+    val result: Either[ApiError, AliasInfo] = Account.fromString(addressString) match {
       case Right(address) =>
         state.getAlias(address) match {
           case Some(al) => Right(AliasInfo(address.stringRepr, al.stringRepr))

--- a/src/main/scala/scorex/api/http/alias/SignedCreateAliasRequest.scala
+++ b/src/main/scala/scorex/api/http/alias/SignedCreateAliasRequest.scala
@@ -20,7 +20,7 @@ case class SignedCreateAliasRequest(@ApiModelProperty(value = "Base58 encoded se
   def toTx: Either[ValidationError, CreateAliasTransaction] = for {
     _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
     _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
-    _alias <- Alias(alias)
+    _alias <- Alias.buildWithCurrentNetworkByte(alias)
     _t <- CreateAliasTransaction.create(_sender, _alias, fee, timestamp, _signature)
   } yield _t
 }

--- a/src/main/scala/scorex/api/http/assets/AssetsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/assets/AssetsApiRoute.scala
@@ -145,7 +145,7 @@ case class AssetsApiRoute(settings: RestAPISettings, wallet: Wallet, state: Stat
     Base58.decode(assetIdStr) match {
       case Success(assetId) =>
         (for {
-          acc <- Account.fromBase58String(address)
+          acc <- Account.fromString(address)
         } yield Json.obj(
           "address" -> acc.address,
           "assetId" -> assetIdStr,
@@ -156,7 +156,7 @@ case class AssetsApiRoute(settings: RestAPISettings, wallet: Wallet, state: Stat
   }
 
   private def balanceJson(address: String): Either[ApiError, JsObject] = (for {
-    acc <- Account.fromBase58String(address)
+    acc <- Account.fromString(address)
   } yield {
     val balances: Seq[JsObject] = state.getAccountBalance(acc).map { p =>
       JsObject(Seq(

--- a/src/main/scala/scorex/consensus/nxt/api/http/NxtConsensusApiRoute.scala
+++ b/src/main/scala/scorex/consensus/nxt/api/http/NxtConsensusApiRoute.scala
@@ -33,7 +33,7 @@ class NxtConsensusApiRoute(application: RunnableApplication) extends ApiRoute wi
     new ApiImplicitParam(name = "address", value = "Address", required = true, dataType = "string", paramType = "path")
   ))
   def generatingBalance: Route = (path("generatingbalance" / Segment) & get) { address =>
-    val account = Account.fromBase58String(address)
+    val account = Account.fromString(address)
     if (account.isLeft) {
       complete(InvalidAddress)
     } else {

--- a/src/main/scala/scorex/transaction/SimpleTransactionModule.scala
+++ b/src/main/scala/scorex/transaction/SimpleTransactionModule.scala
@@ -100,7 +100,7 @@ class SimpleTransactionModule(genesisSettings: GenesisSettings)(implicit val set
 
   override def createPayment(request: PaymentRequest, wallet: Wallet): Either[ValidationError, PaymentTransaction] = for {
     pk <- wallet.findWallet(request.sender)
-    rec <- Account.fromBase58String(request.recipient)
+    rec <- Account.fromString(request.recipient)
     pmt <- createPayment(pk, rec, request.amount, request.fee)
   } yield pmt
 
@@ -148,7 +148,7 @@ class SimpleTransactionModule(genesisSettings: GenesisSettings)(implicit val set
 
   override def alias(request: CreateAliasRequest, wallet: Wallet): Either[ValidationError, CreateAliasTransaction] = for {
     senderPrivateKey <- wallet.findWallet(request.sender)
-    alias <- Alias(request.alias)
+    alias <- Alias.buildWithCurrentNetworkByte(request.alias)
     tx <- CreateAliasTransaction.create(senderPrivateKey, alias, request.fee, getTimestamp)
     r <- onNewOffchainTransaction(tx)
   } yield r
@@ -183,7 +183,7 @@ class SimpleTransactionModule(genesisSettings: GenesisSettings)(implicit val set
 
   private def buildTransactions(transactionSettings: List[GenesisTransactionSettings]): Seq[GenesisTransaction] = {
     transactionSettings.map { ts =>
-      val acc = Account.fromBase58String(ts.recipient).right.get
+      val acc = Account.fromString(ts.recipient).right.get
       GenesisTransaction.create(acc, ts.amount, genesisSettings.transactionsTimestamp).right.get
     }
   }
@@ -238,7 +238,7 @@ class SimpleTransactionModule(genesisSettings: GenesisSettings)(implicit val set
     for {
       _signature <- Base58.decode(payment.signature).toOption.toRight(ValidationError.InvalidSignature)
       _sender <- PublicKeyAccount.fromBase58String(payment.senderPublicKey)
-      _recipient <- Account.fromBase58String(payment.recipient)
+      _recipient <- Account.fromString(payment.recipient)
       _t <- PaymentTransaction.create(_sender, _recipient, payment.amount, payment.fee, payment.timestamp, _signature)
       t <- onNewOffchainTransaction(_t)
     } yield t

--- a/src/main/scala/scorex/transaction/state/database/blockchain/StoredState.scala
+++ b/src/main/scala/scorex/transaction/state/database/blockchain/StoredState.scala
@@ -339,11 +339,11 @@ class StoredState(private val storage: StateStorageI with AssetsExtendedStateSto
 
   def resolveAlias(a: Alias): Option[Account] = storage
     .addressByAlias(a.name)
-    .map(addr => Account.fromBase58String(addr).right.get)
+    .map(addr => Account.fromString(addr).right.get)
 
   def getAlias(a: Account): Option[Alias] = storage
     .aliasByAddress(a.address)
-    .map(addr => Alias(addr).right.get)
+    .map(addr => Alias.fromString(addr).right.get)
 
   private def persistAlias(ac: Account, al: Alias): Unit = storage.persistAlias(ac.address, al.name)
 

--- a/src/main/scala/scorex/transaction/state/database/state/storage/MVStoreStateStorage.scala
+++ b/src/main/scala/scorex/transaction/state/database/state/storage/MVStoreStateStorage.scala
@@ -98,7 +98,7 @@ trait MVStoreStateStorage extends StateStorageI {
     accountAssetsMap.entrySet().asScala
       .filter(e => e.getValue.contains(encodedAssetId))
       .map(e => {
-        val assetAcc: AssetAcc = AssetAcc(Account.fromBase58String(e.getKey).right.get, Some(assetId))
+        val assetAcc: AssetAcc = AssetAcc(Account.fromString(e.getKey).right.get, Some(assetId))
         val key = assetAcc.key
         val balance = getAccountChanges(key, getLastStates(key).get).get.state.balance
         (e.getKey, balance)

--- a/src/main/scala/scorex/wallet/Wallet.scala
+++ b/src/main/scala/scorex/wallet/Wallet.scala
@@ -110,7 +110,7 @@ object Wallet {
 
   implicit class WalletExtension(w: Wallet) {
     def findWallet(a: AddressString): Either[ValidationError, PrivateKeyAccount] = for {
-      acc <- Account.fromBase58String(a)
+      acc <- Account.fromString(a)
       privKeyAcc <- w.privateKeyAccount(acc)
     } yield privKeyAcc
 

--- a/src/main/scala/scorex/waves/http/WavesApiRoute.scala
+++ b/src/main/scala/scorex/waves/http/WavesApiRoute.scala
@@ -74,7 +74,7 @@ case class WavesApiRoute(settings: RestAPISettings, wallet: Wallet, transactionM
     json[PaymentRequest] { payment =>
       (for {
         sender <- wallet.findWallet(payment.sender)
-        recipient <- Account.fromBase58String(payment.recipient)
+        recipient <- Account.fromString(payment.recipient)
         pt <- PaymentTransaction.create(sender, recipient, payment.amount, payment.fee, NTP.correctedTime())
       } yield pt)
         .left.map(ApiError.fromValidationError)
@@ -109,7 +109,7 @@ case class WavesApiRoute(settings: RestAPISettings, wallet: Wallet, transactionM
         for {
           _seed <- Base58.decode(payment.senderWalletSeed).toOption.toRight(InvalidSeed)
           senderAccount = Wallet.generateNewAccount(_seed, payment.senderAddressNonce)
-          recipientAccount <- Account.fromBase58String(payment.recipient).left.map(ApiError.fromValidationError)
+          recipientAccount <- Account.fromString(payment.recipient).left.map(ApiError.fromValidationError)
           _tx <- transactionModule
             .createPayment(senderAccount, recipientAccount, payment.amount, payment.fee, payment.timestamp)
             .left.map(ApiError.fromValidationError)

--- a/src/test/scala/scorex/account/AccountOrAliasTests.scala
+++ b/src/test/scala/scorex/account/AccountOrAliasTests.scala
@@ -1,0 +1,45 @@
+package scorex.account
+
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
+
+class AccountOrAliasTests extends PropSpec with PropertyChecks with GeneratorDrivenPropertyChecks with Matchers {
+
+  property("Account should get parsed correctly") {
+    AccountOrAlias.fromString("3My3KZgFQ3CrVHgz6vGRt8687sH4oAA1qp8").right.get shouldBe an[Account]
+    AccountOrAlias.fromString("address:3My3KZgFQ3CrVHgz6vGRt8687sH4oAA1qp8").right.get shouldBe an[Account]
+
+    Account.fromString("3My3KZgFQ3CrVHgz6vGRt8687sH4oAA1qp8").right.get shouldBe an[Account]
+    Account.fromString("address:3My3KZgFQ3CrVHgz6vGRt8687sH4oAA1qp8").right.get shouldBe an[Account]
+  }
+
+  property("Alias should get parsed correctly") {
+    val alias = AccountOrAlias.fromString("alias:T:sasha").right.get.asInstanceOf[Alias]
+    alias.name shouldBe "sasha"
+    alias.networkByte shouldBe 'T'
+
+    val alias2 = Alias.fromString("alias:T:sasha").right.get
+    alias2.name shouldBe "sasha"
+    alias2.networkByte shouldBe 'T'
+
+  }
+  property("Alias cannot be from other network") {
+    AccountOrAlias.fromString("alias:Q:sasha") shouldBe 'left
+  }
+
+  property("Malformed aliases cannot be reconstructed") {
+    AccountOrAlias.fromString("alias::sasha") shouldBe 'left
+    AccountOrAlias.fromString("alias:W:s") shouldBe 'left
+    AccountOrAlias.fromString("alias:WWW:sasha") shouldBe 'left
+
+    Alias.fromString("alias::sasha") shouldBe 'left
+    Alias.fromString("alias:W:s") shouldBe 'left
+    Alias.fromString("alias:WWW:sasha") shouldBe 'left
+
+    Alias.fromString("aliaaas:W:sasha") shouldBe 'left
+  }
+
+  property("Unknown address schemes cannot be parsed") {
+    AccountOrAlias.fromString("postcode:119072") shouldBe 'left
+  }
+}

--- a/src/test/scala/scorex/account/AccountSpecification.scala
+++ b/src/test/scala/scorex/account/AccountSpecification.scala
@@ -12,7 +12,7 @@ class AccountSpecification extends PropSpec with PropertyChecks with GeneratorDr
       val publicKeyHash = hash(data).take(Account.HashLength)
       val withoutChecksum = AddressVersion2 +: AddressScheme.current.chainId +: publicKeyHash
       val addressVersion2 = Base58.encode(withoutChecksum ++ hash(withoutChecksum).take(Account.ChecksumLength))
-      Account.fromBase58String(addressVersion2).isRight shouldBe (AddressVersion2 == Account.AddressVersion)
+      Account.fromString(addressVersion2).isRight shouldBe (AddressVersion2 == Account.AddressVersion)
     }
   }
 }

--- a/src/test/scala/scorex/consensus/nxt/TransactionsOrderingSpecification.scala
+++ b/src/test/scala/scorex/consensus/nxt/TransactionsOrderingSpecification.scala
@@ -13,14 +13,14 @@ class TransactionsOrderingSpecification extends PropSpec with Assertions with Ma
 
   property("TransactionsOrdering.InBlock should sort correctly") {
     val txsDifferentById = (0 to 3).map(i =>
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 5, None, 125L, Array(i.toByte)).right.get).sortBy(t => Base58.encode(t.id))
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 5, None, 125L, Array(i.toByte)).right.get).sortBy(t => Base58.encode(t.id))
 
     val correctSeq = txsDifferentById ++ Seq(
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 125L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, None, 124L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 124L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, Some(Array.empty), 124L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, Some(Array.empty), 124L, Array.empty).right.get)
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 125L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, None, 124L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 124L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, Some(Array.empty), 124L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, Some(Array.empty), 124L, Array.empty).right.get)
 
     val sorted = Random.shuffle(correctSeq).sorted(TransactionsOrdering.InBlock)
 
@@ -29,14 +29,14 @@ class TransactionsOrderingSpecification extends PropSpec with Assertions with Ma
 
   property("TransactionsOrdering.InUTXPool should sort correctly") {
     val txsDifferentById = (0 to 3).map(i =>
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)),Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 5, None, 125L, Array(i.toByte)).right.get).sortBy(t => Base58.encode(t.id))
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)),Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 5, None, 125L, Array(i.toByte)).right.get).sortBy(t => Base58.encode(t.id))
 
     val correctSeq = txsDifferentById ++ Seq(
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 124L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 123L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, None, 123L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, Some(Array.empty), 124L, Array.empty).right.get,
-      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, Some(Array.empty), 124L, Array.empty).right.get)
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 124L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, None, 123L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, None, 123L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, Some(Array.empty), 124L, Array.empty).right.get,
+      TransferTransaction.create(None, PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 2, Some(Array.empty), 124L, Array.empty).right.get)
 
     val sorted = Random.shuffle(correctSeq).sorted(TransactionsOrdering.InUTXPool)
 
@@ -45,16 +45,16 @@ class TransactionsOrderingSpecification extends PropSpec with Assertions with Ma
 
   property("TransactionsOrdering.InBlock should sort txs by decreasing block timestamp") {
     val correctSeq = Seq(
-      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 124L).right.get,
-      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 123L).right.get)
+      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 124L).right.get,
+      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 123L).right.get)
 
     Random.shuffle(correctSeq).sorted(TransactionsOrdering.InBlock) shouldBe correctSeq
   }
 
   property("TransactionsOrdering.InUTXPool should sort txs by ascending block timestamp") {
     val correctSeq = Seq(
-      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 123L).right.get,
-      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromBase58String("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 124L).right.get)
+      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 123L).right.get,
+      PaymentTransaction.create(PrivateKeyAccount(Array.fill(32)(0)), Account.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").right.get, 100000, 1, 124L).right.get)
     Random.shuffle(correctSeq).sorted(TransactionsOrdering.InUTXPool) shouldBe correctSeq
   }
 }

--- a/src/test/scala/scorex/lagonaki/integration/AliasTransactionSpecification.scala
+++ b/src/test/scala/scorex/lagonaki/integration/AliasTransactionSpecification.scala
@@ -52,7 +52,7 @@ class AliasTransactionSpecification extends FunSuite with Matchers with Transact
 
     val creatorBalance0 = state.balance(aliasCreator)
     val fee = 100000L
-    val tx = CreateAliasTransaction.create(aliasCreator, Alias("TRANSFER-ALIAS").right.get, fee, 1L).right.get
+    val tx = CreateAliasTransaction.create(aliasCreator, Alias.buildWithCurrentNetworkByte("TRANSFER-ALIAS").right.get, fee, 1L).right.get
     val block = TestBlock(Seq(tx))
     shouldBeValid(tx)
     state.processBlock(block) shouldBe a[Success[_]]
@@ -65,7 +65,7 @@ class AliasTransactionSpecification extends FunSuite with Matchers with Transact
 
     val fee2 = 100001L
     val amount = 1000L
-    val tx2 = TransferTransaction.create(None, sender, Alias("TRANSFER-ALIAS").right.get, amount, 1L, None, fee2, Array()).right.get
+    val tx2 = TransferTransaction.create(None, sender, Alias.buildWithCurrentNetworkByte("TRANSFER-ALIAS").right.get, amount, 1L, None, fee2, Array()).right.get
     shouldBeValid(tx2)
     state.processBlock(TestBlock(Seq(tx2))) shouldBe a[Success[_]]
     state.balance(aliasCreator) shouldBe (creatorBalance + amount)
@@ -76,7 +76,7 @@ class AliasTransactionSpecification extends FunSuite with Matchers with Transact
 
     val creatorBalance0 = state.balance(aliasCreator)
     val fee = 100000L
-    val tx = CreateAliasTransaction.create(aliasCreator, Alias("LEASE-ALIAS").right.get, fee, 1L).right.get
+    val tx = CreateAliasTransaction.create(aliasCreator, Alias.buildWithCurrentNetworkByte("LEASE-ALIAS").right.get, fee, 1L).right.get
     val block = TestBlock(Seq(tx))
     shouldBeValid(tx)
     state.processBlock(block) shouldBe a[Success[_]]
@@ -89,7 +89,7 @@ class AliasTransactionSpecification extends FunSuite with Matchers with Transact
 
     val fee2 = 100001L
     val amount = 1000L
-    val tx2 = LeaseTransaction.create(sender, amount, fee2, 1L, Alias("LEASE-ALIAS").right.get).right.get
+    val tx2 = LeaseTransaction.create(sender, amount, fee2, 1L, Alias.buildWithCurrentNetworkByte("LEASE-ALIAS").right.get).right.get
     shouldBeValid(tx2)
     state.processBlock(TestBlock(Seq(tx2))) shouldBe a[Success[_]]
     state.effectiveBalance(aliasCreator) shouldBe (creatorEffectiveBalance + amount)
@@ -99,7 +99,7 @@ class AliasTransactionSpecification extends FunSuite with Matchers with Transact
   test("unable to send to non-issued alias") {
     val senderBalance = state.balance(aliasCreator)
 
-    val tx = TransferTransaction.create(None, aliasCreator, Alias("NON-EXISTING ALIAS").right.get, 1000L, 1L, None, 100000L, Array()).right.get
+    val tx = TransferTransaction.create(None, aliasCreator, Alias.buildWithCurrentNetworkByte("NON-EXISTING ALIAS").right.get, 1000L, 1L, None, 100000L, Array()).right.get
     shouldBeInvalid(tx)
     val block = TestBlock(Seq(tx))
     state.processBlock(block) shouldBe a[Failure[_]]
@@ -109,7 +109,7 @@ class AliasTransactionSpecification extends FunSuite with Matchers with Transact
   test("unable to lease to non-issued alias") {
     val senderBalance = state.balance(aliasCreator)
 
-    val tx = LeaseTransaction.create(aliasCreator, 10000L, 100000L, 1L, Alias("NON-EXISTING ALIAS").right.get).right.get
+    val tx = LeaseTransaction.create(aliasCreator, 10000L, 100000L, 1L, Alias.buildWithCurrentNetworkByte("NON-EXISTING ALIAS").right.get).right.get
     shouldBeInvalid(tx)
     val block = TestBlock(Seq(tx))
     state.processBlock(block) shouldBe a[Failure[_]]
@@ -120,21 +120,21 @@ class AliasTransactionSpecification extends FunSuite with Matchers with Transact
   test("unable to create the same alias in the next block") {
     val senderBalance = state.balance(aliasCreator)
     val fee = 100000L
-    val tx = CreateAliasTransaction.create(aliasCreator, Alias("THE ALIAS").right.get, fee, 1L).right.get
+    val tx = CreateAliasTransaction.create(aliasCreator, Alias.buildWithCurrentNetworkByte("THE ALIAS").right.get, fee, 1L).right.get
     val block = TestBlock(Seq(tx))
     state.processBlock(block)
 
-    val tx2 = CreateAliasTransaction.create(aliasCreator, Alias("THE ALIAS").right.get, fee, 1L).right.get
+    val tx2 = CreateAliasTransaction.create(aliasCreator, Alias.buildWithCurrentNetworkByte("THE ALIAS").right.get, fee, 1L).right.get
     shouldBeInvalid(tx2)
 
     val anotherCreator: PrivateKeyAccount = PrivateKeyAccount(randomBytes())
     ensureSenderHasBalance(anotherCreator)
-    val tx3 = CreateAliasTransaction.create(aliasCreator, Alias("THE ALIAS").right.get, fee, 1L).right.get
+    val tx3 = CreateAliasTransaction.create(aliasCreator, Alias.buildWithCurrentNetworkByte("THE ALIAS").right.get, fee, 1L).right.get
     shouldBeInvalid(tx3)
   }
 
   test("able to recreate alias after rollback") {
-    val theAlias = Alias("ALIAS")
+    val theAlias = Alias.buildWithCurrentNetworkByte("ALIAS")
     val tx = CreateAliasTransaction.create(aliasCreator, theAlias.right.get, 100000L, 1L).right.get
     val block = TestBlock(Seq(tx))
     state.processBlock(block)

--- a/src/test/scala/scorex/lagonaki/integration/StoredStateSpecification.scala
+++ b/src/test/scala/scorex/lagonaki/integration/StoredStateSpecification.scala
@@ -308,8 +308,8 @@ class StoredStateSpecification extends FunSuite with Matchers with TransactionTe
 
   test("valid order match transaction with fully executed orders") {
     val wavesBal = state.assetBalance(AssetAcc(acc, None))
-    val bal2 = state.assetBalance(AssetAcc(Account.fromBase58String("3N3keodUiS8WLEw9W4BKDNxgNdUpwSnpb3K").right.get, None))
-    val bal3 = state.assetBalance(AssetAcc(Account.fromBase58String("3N6dsnfD88j5yKgpnEavaaJDzAVSRBRVbMY").right.get, None))
+    val bal2 = state.assetBalance(AssetAcc(Account.fromString("3N3keodUiS8WLEw9W4BKDNxgNdUpwSnpb3K").right.get, None))
+    val bal3 = state.assetBalance(AssetAcc(Account.fromString("3N6dsnfD88j5yKgpnEavaaJDzAVSRBRVbMY").right.get, None))
     wavesBal should be > 0L
   }
 

--- a/src/test/scala/scorex/lagonaki/integration/api/PaymentAPISpecification.scala
+++ b/src/test/scala/scorex/lagonaki/integration/api/PaymentAPISpecification.scala
@@ -27,7 +27,7 @@ class PaymentAPISpecification extends FunSuite with Matchers with TransactionTes
     (req \ "timestamp").asOpt[Long].isDefined shouldBe true
     (req \ "signature").asOpt[String].isDefined shouldBe true
     (req \ "sender").as[String] shouldBe s
-    (req \ "recipient").as[String] shouldBe r
+    (req \ "recipient").as[String] shouldBe ("address:" + r)
 
   }
 

--- a/src/test/scala/scorex/lagonaki/unit/OrderMatchStoredStateSpecification.scala
+++ b/src/test/scala/scorex/lagonaki/unit/OrderMatchStoredStateSpecification.scala
@@ -66,7 +66,7 @@ class OrderMatchStoredStateSpecification extends FunSuite with Matchers with Bef
     val sender = wallet.findWallet(request.sender).right.get
     TransferTransaction.create(request.assetId.map(s => Base58.decode(s).get),
       sender: PrivateKeyAccount,
-      Account.fromBase58String(request.recipient).right.get,
+      Account.fromString(request.recipient).right.get,
       request.amount,
       getTimestamp,
       request.feeAssetId.map(s => Base58.decode(s).get),

--- a/src/test/scala/scorex/lagonaki/unit/StoredStateUnitTests2.scala
+++ b/src/test/scala/scorex/lagonaki/unit/StoredStateUnitTests2.scala
@@ -46,7 +46,7 @@ class StoredStateUnitTests2 extends FunSuite with Matchers with TableDrivenPrope
     val sender = wallet.findWallet(request.sender).right.get
     TransferTransaction.create(request.assetId.map(s => Base58.decode(s).get),
       sender: PrivateKeyAccount,
-      Account.fromBase58String(request.recipient).right.get,
+      Account.fromString(request.recipient).right.get,
       request.amount,
       i.incrementAndGet(),
       request.feeAssetId.map(s => Base58.decode(s).get),
@@ -124,7 +124,7 @@ class StoredStateUnitTests2 extends FunSuite with Matchers with TableDrivenPrope
     }
     state.processBlock(TestBlock(txs, PublicKeyAccount(feeGetter.publicKey))) should be('success)
 
-    val senderAssetBalance = state.assetBalance(AssetAcc(Account.fromBase58String(sender.address).right.get, Some(assetId)))
+    val senderAssetBalance = state.assetBalance(AssetAcc(Account.fromString(sender.address).right.get, Some(assetId)))
     senderAssetBalance shouldBe 10000
     val feeGetterAssetBalace = state.assetBalance(AssetAcc(PublicKeyAccount(accounts.last.publicKey), Some(
       assetId)))
@@ -154,7 +154,7 @@ class StoredStateUnitTests2 extends FunSuite with Matchers with TableDrivenPrope
     }
     state.processBlock(TestBlock(txs ++ txs2, PublicKeyAccount(feeGetter.publicKey))) should be('success)
 
-    val senderAssetBalance = state.assetBalance(AssetAcc(Account.fromBase58String(sender.address).right.get, Some(assetId)))
+    val senderAssetBalance = state.assetBalance(AssetAcc(Account.fromString(sender.address).right.get, Some(assetId)))
     senderAssetBalance shouldBe 10000
     val feeGetterAssetBalace = state.assetBalance(AssetAcc(PublicKeyAccount(accounts.last.publicKey), Some(
       assetId)))

--- a/src/test/scala/scorex/transaction/FeeCalculatorSpecification.scala
+++ b/src/test/scala/scorex/transaction/FeeCalculatorSpecification.scala
@@ -76,7 +76,7 @@ class FeeCalculatorSpecification extends PropSpec with PropertyChecks with Gener
   property("Transfer transaction with fee in asset") {
     val feeCalculator = new FeeCalculator(mySettings)
     val sender = PrivateKeyAccount(Array.emptyByteArray)
-    val recipient = Account.fromBase58String("3NBVqYXrapgJP9atQccdBPAgJPwHDKkh6A8").right.get
+    val recipient = Account.fromString("3NBVqYXrapgJP9atQccdBPAgJPwHDKkh6A8").right.get
     val tx1: TransferTransaction = TransferTransaction.create(Some(WhitelistedAsset), sender, recipient, 1000000, 100000000,
       Some(WhitelistedAsset), 2, Array.emptyByteArray).right.get
     val tx2: TransferTransaction = TransferTransaction.create(Some(WhitelistedAsset), sender, recipient, 1000000, 100000000,

--- a/src/test/scala/scorex/transaction/TransactionGen.scala
+++ b/src/test/scala/scorex/transaction/TransactionGen.scala
@@ -24,7 +24,7 @@ trait TransactionGen {
   }
 
   val accountGen: Gen[PrivateKeyAccount] = bytes32gen.map(seed => PrivateKeyAccount(seed))
-  val aliasGen: Gen[Alias] = genBoundedString(Alias.MinLength, Alias.MaxLength).map(ar => new String(ar)).map(Alias(_).right.get
+  val aliasGen: Gen[Alias] = genBoundedString(Alias.MinLength, Alias.MaxLength).map(ar => new String(ar)).map(Alias.buildWithCurrentNetworkByte(_).right.get
   )
 
   val accountOrAliasGen: Gen[AccountOrAlias] = Gen.oneOf(aliasGen, accountGen.map(PublicKeyAccount.toAddress(_)))


### PR DESCRIPTION
- Network byte is a part of Alias
- uri-like account schemes `address:` and `alias:W` introduced for parsing and string representation of aliased recipient