### PR TITLE
T442 state consistency check at start

### DIFF
--- a/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
+++ b/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
@@ -18,7 +18,7 @@ class HistoryWriterImpl(db: MVStore) extends History with HistoryWriter with Sco
 
   {
     if (Set(blockBodyByHeight.size(), blockIdByHeight.size(), heightByBlockId.size(), scoreByHeight.size()).size != 1) {
-      throw new IllegalArgumentException(s"Block storage is corrupt. Please remove blockchain.dat and state.dat and restart the node")
+      throw new IllegalArgumentException(s"Block storage is corrupt. Please remove blockchain.dat and state.dat and restart the node.")
     }
   }
 

--- a/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
+++ b/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
@@ -18,7 +18,7 @@ class HistoryWriterImpl(db: MVStore) extends History with HistoryWriter with Sco
 
   {
     if (Set(blockBodyByHeight.size(), blockIdByHeight.size(), heightByBlockId.size(), scoreByHeight.size()).size != 1) {
-      throw new IllegalArgumentException(s"Block storage is corrupt")
+      throw new IllegalArgumentException(s"Block storage is corrupt. Please remove blockchain.dat and state.dat and restart the node")
     }
   }
 

--- a/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
+++ b/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
@@ -16,6 +16,12 @@ class HistoryWriterImpl(db: MVStore) extends History with HistoryWriter with Sco
   private val heightByBlockId = db.openMap("signaturesReverse", new LogMVMapBuilder[BlockId, Int])
   private val scoreByHeight = db.openMap("score", new LogMVMapBuilder[Int, BigInt])
 
+  {
+    if (Set(blockBodyByHeight.size(), blockIdByHeight.size(), heightByBlockId.size(), scoreByHeight.size()).size != 1) {
+      throw new IllegalArgumentException(s"Block storage is corrupt")
+    }
+  }
+
   override def appendBlock(block: Block): Either[ValidationError, Unit] = {
     if ((height() == 0) || (this.lastBlock.uniqueId sameElements block.reference)) {
       val h = height() + 1

--- a/src/main/scala/com/wavesplatform/state2/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/wavesplatform/state2/BlockchainUpdaterImpl.scala
@@ -36,12 +36,11 @@ class BlockchainUpdaterImpl(persisted: StateWriter with StateReader, settings: F
     log.info(s"$prefix Total blocks: ${bc.height()}, persisted: ${persisted.height}, imMemDiff: ${inMemoryDiff.heightDiff}")
 
   {
-    logHeights("Start:")
-    if (persisted.height > bc.height()) {
+    if (persisted.height > bc.height())
       throw new IllegalArgumentException(s"storedBlocks = ${bc.height()}, statedBlocks=${persisted.height}")
-    } else {
-      updatePersistedAndInMemory()
-    }
+
+    logHeights("Start:")
+    updatePersistedAndInMemory()
   }
 
   def currentState: StateReader = new CompositeStateReader.Proxy(persisted, () => inMemoryDiff)

--- a/src/main/scala/com/wavesplatform/state2/StateStorage.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateStorage.scala
@@ -11,10 +11,13 @@ class StateStorage(db: MVStore) {
 
   private val variables: MVMap[String, Int] = db.openMap("variables")
   private val heightKey = "height"
+  private val height0Key = "height0"
 
   def getHeight: Int = variables.get(heightKey)
-
   def setHeight(i: Int): Unit = variables.put(heightKey, i)
+
+  def getHeight0: Int = variables.get(height0Key)
+  def setHeight0(i: Int): Unit = variables.put(height0Key, i)
 
   val transactions: util.Map[Array[Byte], (Int, Array[Byte])] = db.openMap("txs")
 

--- a/src/main/scala/com/wavesplatform/state2/StateStorage.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateStorage.scala
@@ -11,13 +11,17 @@ class StateStorage(db: MVStore) {
 
   private val variables: MVMap[String, Int] = db.openMap("variables")
   private val heightKey = "height"
-  private val height0Key = "height0"
+  private val isDirtyFlag = "isDirty"
+
+  if (variables.get(isDirtyFlag) == 1)
+    throw new IllegalArgumentException(s"Persisted state is corrupt." +
+      s" Please remove state.dat and restart the node.")
 
   def getHeight: Int = variables.get(heightKey)
+
   def setHeight(i: Int): Unit = variables.put(heightKey, i)
 
-  def getHeight0: Int = variables.get(height0Key)
-  def setHeight0(i: Int): Unit = variables.put(height0Key, i)
+  def setDirty(isDirty: Boolean): Unit = variables.put(isDirtyFlag, if (isDirty) 1 else 0)
 
   val transactions: util.Map[Array[Byte], (Int, Array[Byte])] = db.openMap("txs")
 
@@ -47,4 +51,11 @@ object StateStorage {
   type SnapshotKey = Array[Byte]
 
   def snapshotKey(acc: Account, height: Int): SnapshotKey = acc.bytes ++ Ints.toByteArray(height)
+
+  def dirty[R](p: StateStorage)(f: => R): R = {
+    p.setDirty(true)
+    val r = f
+    p.setDirty(false)
+    r
+  }
 }

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -22,6 +22,8 @@ class StateWriterImpl(p: StateStorage) extends StateReaderImpl(p) with StateWrit
 
     log.debug(s"Starting persist from ${p.getHeight} to ${p.getHeight + blockDiff.heightDiff}")
 
+    p.setHeight0(p.getHeight + blockDiff.heightDiff)
+
     measureSizeLog("transactions")(txsDiff.transactions) {
       _.foreach { case (id, (h, tx, _)) =>
         p.transactions.put(id.arr, (h, tx.bytes))
@@ -115,6 +117,7 @@ class StateWriterImpl(p: StateStorage) extends StateReaderImpl(p) with StateWrit
     p.lastUpdateHeight.clear()
 
     p.setHeight(0)
+    p.setHeight0(0)
     p.commit()
   }
 }

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -22,103 +22,104 @@ class StateWriterImpl(p: StateStorage) extends StateReaderImpl(p) with StateWrit
 
     log.debug(s"Starting persist from ${p.getHeight} to ${p.getHeight + blockDiff.heightDiff}")
 
-    p.setHeight0(p.getHeight + blockDiff.heightDiff)
-
-    measureSizeLog("transactions")(txsDiff.transactions) {
-      _.foreach { case (id, (h, tx, _)) =>
-        p.transactions.put(id.arr, (h, tx.bytes))
-      }
-    }
-
-    measureSizeLog("previousExchangeTxs")(blockDiff.txsDiff.previousExchangeTxs) {
-      _.foreach { case (oid, txs) =>
-        Option(p.exchangeTransactionsByOrder.get(oid.arr)) match {
-          case Some(ll) =>
-            p.exchangeTransactionsByOrder.put(oid.arr, ll ++ txs.map(_.id))
-          case None =>
-            p.exchangeTransactionsByOrder.put(oid.arr, txs.map(_.id))
+    StateStorage.dirty(p) {
+      measureSizeLog("transactions")(txsDiff.transactions) {
+        _.foreach { case (id, (h, tx, _)) =>
+          p.transactions.put(id.arr, (h, tx.bytes))
         }
       }
-    }
 
-    measureSizeLog("portfolios")(txsDiff.portfolios) {
-      _.foreach { case (account, portfolioDiff) =>
-        val updatedPortfolio = accountPortfolio(account).combine(portfolioDiff)
-        p.portfolios.put(account.bytes,
-          (updatedPortfolio.balance,
-            (updatedPortfolio.leaseInfo.leaseIn, updatedPortfolio.leaseInfo.leaseOut),
-            updatedPortfolio.assets.map { case (k, v) => k.arr -> v }))
-      }
-    }
-
-
-    measureSizeLog("assets")(txsDiff.issuedAssets) {
-      _.foreach { case (id, assetInfo) =>
-        val updated = (Option(p.assets.get(id.arr)) match {
-          case None => Monoid[AssetInfo].empty
-          case Some(existing) => AssetInfo(existing._1, existing._2)
-        }).combine(assetInfo)
-
-        p.assets.put(id.arr, (updated.isReissuable, updated.volume))
-      }
-    }
-
-    measureSizeLog("accountTransactionIds")(blockDiff.txsDiff.accountTransactionIds) {
-      _.foreach { case (acc, txIds) =>
-        Option(p.accountTransactionIds.get(acc.bytes)) match {
-          case Some(ll) =>
-            // [h=12, h=11, h=10] ++ [h=9, ...]
-            p.accountTransactionIds.put(acc.bytes, txIds.map(_.arr) ++ ll)
-          case None =>
-            // [h=2, h=1, h=0]
-            p.accountTransactionIds.put(acc.bytes, txIds.map(_.arr))
+      measureSizeLog("previousExchangeTxs")(blockDiff.txsDiff.previousExchangeTxs) {
+        _.foreach { case (oid, txs) =>
+          Option(p.exchangeTransactionsByOrder.get(oid.arr)) match {
+            case Some(ll) =>
+              p.exchangeTransactionsByOrder.put(oid.arr, ll ++ txs.map(_.id))
+            case None =>
+              p.exchangeTransactionsByOrder.put(oid.arr, txs.map(_.id))
+          }
         }
       }
-    }
 
-    measureSizeLog("paymentTransactionIdsByHashes")(blockDiff.txsDiff.paymentTransactionIdsByHashes) {
-      _.foreach { case (EqByteArray(hash), EqByteArray(id)) =>
-        p.paymentTransactionHashes.put(hash, id)
-      }
-    }
-
-    measureSizeLog("effectiveBalanceSnapshots")(blockDiff.snapshots)(
-      _.foreach { case (acc, snapshotsByHeight) =>
-        snapshotsByHeight.foreach { case (h, snapshot) =>
-          p.balanceSnapshots.put(StateStorage.snapshotKey(acc, h), (snapshot.prevHeight, snapshot.balance, snapshot.effectiveBalance))
+      measureSizeLog("portfolios")(txsDiff.portfolios) {
+        _.foreach { case (account, portfolioDiff) =>
+          val updatedPortfolio = accountPortfolio(account).combine(portfolioDiff)
+          p.portfolios.put(account.bytes,
+            (updatedPortfolio.balance,
+              (updatedPortfolio.leaseInfo.leaseIn, updatedPortfolio.leaseInfo.leaseOut),
+              updatedPortfolio.assets.map { case (k, v) => k.arr -> v }))
         }
-        p.lastUpdateHeight.put(acc.bytes, snapshotsByHeight.keys.max)
-      })
-
-    measureSizeLog("aliases")(blockDiff.txsDiff.aliases) {
-      _.foreach { case (alias, acc) =>
-        p.aliasToAddress.put(alias.name, acc.bytes)
       }
+
+
+      measureSizeLog("assets")(txsDiff.issuedAssets) {
+        _.foreach { case (id, assetInfo) =>
+          val updated = (Option(p.assets.get(id.arr)) match {
+            case None => Monoid[AssetInfo].empty
+            case Some(existing) => AssetInfo(existing._1, existing._2)
+          }).combine(assetInfo)
+
+          p.assets.put(id.arr, (updated.isReissuable, updated.volume))
+        }
+      }
+
+      measureSizeLog("accountTransactionIds")(blockDiff.txsDiff.accountTransactionIds) {
+        _.foreach { case (acc, txIds) =>
+          Option(p.accountTransactionIds.get(acc.bytes)) match {
+            case Some(ll) =>
+              // [h=12, h=11, h=10] ++ [h=9, ...]
+              p.accountTransactionIds.put(acc.bytes, txIds.map(_.arr) ++ ll)
+            case None =>
+              // [h=2, h=1, h=0]
+              p.accountTransactionIds.put(acc.bytes, txIds.map(_.arr))
+          }
+        }
+      }
+
+      measureSizeLog("paymentTransactionIdsByHashes")(blockDiff.txsDiff.paymentTransactionIdsByHashes) {
+        _.foreach { case (EqByteArray(hash), EqByteArray(id)) =>
+          p.paymentTransactionHashes.put(hash, id)
+        }
+      }
+
+      measureSizeLog("effectiveBalanceSnapshots")(blockDiff.snapshots)(
+        _.foreach { case (acc, snapshotsByHeight) =>
+          snapshotsByHeight.foreach { case (h, snapshot) =>
+            p.balanceSnapshots.put(StateStorage.snapshotKey(acc, h), (snapshot.prevHeight, snapshot.balance, snapshot.effectiveBalance))
+          }
+          p.lastUpdateHeight.put(acc.bytes, snapshotsByHeight.keys.max)
+        })
+
+      measureSizeLog("aliases")(blockDiff.txsDiff.aliases) {
+        _.foreach { case (alias, acc) =>
+          p.aliasToAddress.put(alias.name, acc.bytes)
+        }
+      }
+
+      measureSizeLog("lease info")(blockDiff.txsDiff.leaseState)(
+        _.foreach { case (id, isActive) => p.leaseState.put(id.arr, isActive) })
+
+      p.setHeight(p.getHeight + blockDiff.heightDiff)
+      p.commit()
     }
-
-    measureSizeLog("lease info")(blockDiff.txsDiff.leaseState)(
-      _.foreach { case (id, isActive) => p.leaseState.put(id.arr, isActive) })
-
-    p.setHeight(p.getHeight + blockDiff.heightDiff)
-    p.commit()
     log.debug("BlockDiff commit complete")
   }
 
   override def clear(): Unit = {
-    p.transactions.clear()
-    p.portfolios.clear()
-    p.assets.clear()
-    p.accountTransactionIds.clear()
-    p.balanceSnapshots.clear()
-    p.paymentTransactionHashes.clear()
-    p.exchangeTransactionsByOrder.clear()
-    p.aliasToAddress.clear()
-    p.leaseState.clear()
-    p.lastUpdateHeight.clear()
+    StateStorage.dirty(p) {
+      p.transactions.clear()
+      p.portfolios.clear()
+      p.assets.clear()
+      p.accountTransactionIds.clear()
+      p.balanceSnapshots.clear()
+      p.paymentTransactionHashes.clear()
+      p.exchangeTransactionsByOrder.clear()
+      p.aliasToAddress.clear()
+      p.leaseState.clear()
+      p.lastUpdateHeight.clear()
+      p.setHeight(0)
+      p.commit()
 
-    p.setHeight(0)
-    p.setHeight0(0)
-    p.commit()
+    }
   }
 }
 

--- a/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
@@ -11,6 +11,11 @@ import scala.collection.JavaConverters._
 
 class StateReaderImpl(p: StateStorage) extends StateReader {
 
+  {
+    if (p.getHeight0 != p.getHeight)
+      throw new IllegalArgumentException(s"Persisted state is corrupt, height0=${p.getHeight0}, height=${p.getHeight}")
+  }
+
   override def transactionInfo(id: ByteArray): Option[(Int, Transaction)] = Option(p.transactions.get(id.arr)).map {
     case (h, bytes) => (h, TransactionParser.parseBytes(bytes).get)
   }

--- a/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
@@ -13,7 +13,8 @@ class StateReaderImpl(p: StateStorage) extends StateReader {
 
   {
     if (p.getHeight0 != p.getHeight)
-      throw new IllegalArgumentException(s"Persisted state is corrupt, height0=${p.getHeight0}, height=${p.getHeight}")
+      throw new IllegalArgumentException(s"Persisted state is corrupt, height0=${p.getHeight0}, height=${p.getHeight}." +
+        s" Please remove state.dat and restart the node")
   }
 
   override def transactionInfo(id: ByteArray): Option[(Int, Transaction)] = Option(p.transactions.get(id.arr)).map {

--- a/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
@@ -11,12 +11,6 @@ import scala.collection.JavaConverters._
 
 class StateReaderImpl(p: StateStorage) extends StateReader {
 
-  {
-    if (p.getHeight0 != p.getHeight)
-      throw new IllegalArgumentException(s"Persisted state is corrupt, height0=${p.getHeight0}, height=${p.getHeight}." +
-        s" Please remove state.dat and restart the node")
-  }
-
   override def transactionInfo(id: ByteArray): Option[(Int, Transaction)] = Option(p.transactions.get(id.arr)).map {
     case (h, bytes) => (h, TransactionParser.parseBytes(bytes).get)
   }

--- a/src/test/scala/com/wavesplatform/state2/reader/StateReaderEffectiveBalanceTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/reader/StateReaderEffectiveBalanceTest.scala
@@ -15,7 +15,6 @@ class StateReaderEffectiveBalanceTest extends fixture.FunSuite with Matchers {
 
   override protected def withFixture(test: OneArgTest): Outcome = {
     val storage = new StateStorage(new MVStore.Builder().open())
-    storage.setHeight0(stateHeight)
     storage.setHeight(stateHeight)
     test(storage)
   }

--- a/src/test/scala/com/wavesplatform/state2/reader/StateReaderEffectiveBalanceTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/reader/StateReaderEffectiveBalanceTest.scala
@@ -21,7 +21,6 @@ class StateReaderEffectiveBalanceTest extends fixture.FunSuite with Matchers {
   }
 
   test("exposes minimum of all 'current' and  one 'previous' of oldest record") { storage =>
-
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 20), (0, 0, 1))
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 75), (20, 0, 200))
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 90), (75, 0, 100))

--- a/src/test/scala/com/wavesplatform/state2/reader/StateReaderEffectiveBalanceTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/reader/StateReaderEffectiveBalanceTest.scala
@@ -1,21 +1,26 @@
 package com.wavesplatform.state2.reader
 
-import com.wavesplatform.state2.{StateStorage}
+import com.wavesplatform.state2.StateStorage
 import org.h2.mvstore.MVStore
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{Matchers, Outcome, fixture}
 import scorex.account.Account
 
 
-class StateReaderEffectiveBalanceTest extends FunSuite with Matchers {
+class StateReaderEffectiveBalanceTest extends fixture.FunSuite with Matchers {
 
   val acc: Account = Account.fromPublicKey(Array.emptyByteArray)
   val stateHeight = 100
 
-  test("exposes minimum of all 'current' and  one 'previous' of oldest record") {
+  override type FixtureParam = StateStorage
 
+  override protected def withFixture(test: OneArgTest): Outcome = {
     val storage = new StateStorage(new MVStore.Builder().open())
-
+    storage.setHeight0(stateHeight)
     storage.setHeight(stateHeight)
+    test(storage)
+  }
+
+  test("exposes minimum of all 'current' and  one 'previous' of oldest record") { storage =>
 
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 20), (0, 0, 1))
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 75), (20, 0, 200))
@@ -25,11 +30,7 @@ class StateReaderEffectiveBalanceTest extends FunSuite with Matchers {
     new StateReaderImpl(storage).effectiveBalanceAtHeightWithConfirmations(acc, stateHeight, 50) shouldBe 1
   }
 
-  test("exposes current effective balance if no records in past N blocks are made") {
-
-    val storage = new StateStorage(new MVStore.Builder().open())
-
-    storage.setHeight(stateHeight)
+  test("exposes current effective balance if no records in past N blocks are made") { storage =>
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 20), (0, 0, 1))
     storage.portfolios.put(acc.bytes, (1, (0, 0), Map.empty))
     storage.lastUpdateHeight.put(acc.bytes, 20)
@@ -37,23 +38,16 @@ class StateReaderEffectiveBalanceTest extends FunSuite with Matchers {
     new StateReaderImpl(storage).effectiveBalanceAtHeightWithConfirmations(acc, stateHeight, 50) shouldBe 1
   }
 
-  test("doesn't include info older than N blocks") {
-    val storage = new StateStorage(new MVStore.Builder().open())
-
-    storage.setHeight(stateHeight)
+  test("doesn't include info older than N blocks") { storage =>
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 20), (0, 0, 1000))
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 50), (20, 0, 50000))
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 75), (50, 0, 100000))
     storage.lastUpdateHeight.put(acc.bytes, 75)
 
-
     new StateReaderImpl(storage).effectiveBalanceAtHeightWithConfirmations(acc, stateHeight, 50) shouldBe 50000
   }
 
-  test("includes most recent update") {
-    val storage = new StateStorage(new MVStore.Builder().open())
-
-    storage.setHeight(stateHeight)
+  test("includes most recent update") { storage =>
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 20), (0, 0, 1000))
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 51), (20, 0, 50000))
     storage.balanceSnapshots.put(StateStorage.snapshotKey(acc, 100), (51, 0, 1))


### PR DESCRIPTION
Node doesn't start if state is corrupt:

```
2017-05-02 12:38:08 INFO  [main] c.w.Application$ - Starting...
2017-05-02 12:38:10 INFO  [lt-dispatcher-8] a.event.slf4j.Slf4jLogger - Slf4jLogger started
2017-05-02 12:38:10 INFO  [main] c.w.Application$ - Waves v0.7.0-SNAPSHOT Blockchain Id: T
2017-05-02 12:38:10 INFO  [main] scorex.wallet.Wallet - Opening wallet from C:\Users\ilyas/waves/wallet/wallet.dat
2017-05-02 12:38:10 ERROR [main] c.w.actor.RootActorSystem$ - Error while initializing actor system wavesplatform
java.lang.IllegalArgumentException: Persisted state is corrupt, height0=24000, height=23800. Please remove state.dat and restart the node
	at com.wavesplatform.state2.reader.StateReaderImpl.<init>(StateReaderImpl.scala:17)
	at com.wavesplatform.state2.StateWriterImpl.<init>(StateWriter.scala:16)
	at com.wavesplatform.history.BlockStorageImpl.<init>(BlockStorageImpl.scala:19)
	at scorex.transaction.SimpleTransactionModule.<init>(SimpleTransactionModule.scala:41)
	at com.wavesplatform.Application.transactionModule$lzycompute(Application.scala:43)
	at com.wavesplatform.Application.transactionModule(Application.scala:43)
	at com.wavesplatform.Application.<init>(Application.scala:89)
	at com.wavesplatform.Application$.$anonfun$main$2(Application.scala:151)
	at com.wavesplatform.Application$.$anonfun$main$2$adapted(Application.scala:141)
	at com.wavesplatform.actor.RootActorSystem$.start(RootActorSystem.scala:38)
	at com.wavesplatform.Application$.main(Application.scala:141)
	at com.wavesplatform.Application.main(Application.scala)

Process finished with exit code 1
```