### PR TITLE
NODE-94: verbose blacklist information in /peers

### DIFF
--- a/src/main/scala/com/wavesplatform/network/PeerDatabase.scala
+++ b/src/main/scala/com/wavesplatform/network/PeerDatabase.scala
@@ -12,7 +12,7 @@ trait PeerDatabase {
 
   def touch(socketAddress: InetSocketAddress)
 
-  def blacklist(host: InetAddress)
+  def blacklist(host: InetAddress, reason: String)
 
   def knownPeers: Map[InetSocketAddress, Long]
 
@@ -20,15 +20,18 @@ trait PeerDatabase {
 
   def randomPeer(excluded: Set[InetSocketAddress]): Option[InetSocketAddress]
 
+  def detailedBlacklist: Map[InetAddress, (Long, String)]
 }
 
 object PeerDatabase extends ScorexLogging {
+
   implicit class PeerDatabaseExt(peerDatabase: PeerDatabase) {
     def blacklistAndClose(channel: Channel, reason: String): Unit = {
       val address = channel.asInstanceOf[NioSocketChannel].remoteAddress().getAddress
       log.debug(s"Blacklisting ${id(channel)}: $reason")
-      peerDatabase.blacklist(address)
+      peerDatabase.blacklist(address, reason)
       channel.close()
     }
   }
+
 }

--- a/src/main/scala/scorex/api/http/PeersApiRoute.scala
+++ b/src/main/scala/scorex/api/http/PeersApiRoute.scala
@@ -17,10 +17,11 @@ import scala.collection.JavaConverters._
 @Path("/peers")
 @Api(value = "/peers", description = "Get info about peers", position = 2)
 case class PeersApiRoute(
-    settings: RestAPISettings,
-    connectToPeer: InetSocketAddress => Unit,
-    peerDatabase: PeerDatabase,
-    establishedConnections: ConcurrentMap[Channel, PeerInfo]) extends ApiRoute {
+                            settings: RestAPISettings,
+                            connectToPeer: InetSocketAddress => Unit,
+                            peerDatabase: PeerDatabase,
+                            establishedConnections: ConcurrentMap[Channel, PeerInfo]) extends ApiRoute {
+
   import PeersApiRoute._
 
   override lazy val route =
@@ -88,7 +89,9 @@ case class PeersApiRoute(
     new ApiResponse(code = 200, message = "Json with connected peers or error")
   ))
   def blacklistedPeers: Route = (path("blacklisted") & get) {
-    complete(JsArray(peerDatabase.blacklistedHosts.take(MaxPeersInResponse).map(a => JsString(a.toString)).toSeq))
+    complete(JsArray(peerDatabase.detailedBlacklist.take(MaxPeersInResponse)
+      .map { case (h, (t, r)) => Json.obj("hostname" -> h.toString, "timestamp" -> t, "reason" -> r) }
+      .toList))
   }
 }
 
@@ -96,5 +99,6 @@ object PeersApiRoute {
   val MaxPeersInResponse = 1000
 
   case class ConnectReq(host: String, port: Int)
+
   implicit val connectFormat: Format[ConnectReq] = Json.format
 }

--- a/src/test/scala/scorex/network/BlacklistParallelSpecification.scala
+++ b/src/test/scala/scorex/network/BlacklistParallelSpecification.scala
@@ -49,9 +49,12 @@ class BlacklistParallelSpecification extends FeatureSpec with GivenWhenThen with
       assert(!peerDatabase.blacklistedHosts.contains(host1))
 
       And("Peer blacklists another peer")
-      peerDatabase.blacklist(host1)
+      val reason = "because"
+      peerDatabase.blacklist(host1, reason)
       assert(isBlacklisted(address1))
       assert(peerDatabase.blacklistedHosts.contains(host1))
+      assert(peerDatabase.detailedBlacklist(host1)._2 == reason)
+      assert(!peerDatabase.knownPeers.contains(address1))
       assert(!peerDatabase.knownPeers.contains(address1))
 
       And("Peer waits for some time")
@@ -79,9 +82,9 @@ class BlacklistParallelSpecification extends FeatureSpec with GivenWhenThen with
       assert(!isBlacklisted(address3))
 
       And("Peer blacklists other peers")
-      peerDatabase.blacklist(address1.getAddress)
-      peerDatabase.blacklist(address2.getAddress)
-      peerDatabase.blacklist(address3.getAddress)
+      peerDatabase.blacklist(address1.getAddress,"")
+      peerDatabase.blacklist(address2.getAddress,"")
+      peerDatabase.blacklist(address3.getAddress,"")
       assert(isBlacklisted(address1))
       assert(isBlacklisted(address2))
       assert(isBlacklisted(address3))
@@ -90,7 +93,7 @@ class BlacklistParallelSpecification extends FeatureSpec with GivenWhenThen with
       Thread.sleep(networkSettings.blackListResidenceTime.toMillis / 2)
 
       And("Adds one peer to blacklist one more time")
-      peerDatabase.blacklist(address2.getAddress)
+      peerDatabase.blacklist(address2.getAddress,"")
 
       And("Waits another half of period")
       Thread.sleep((networkSettings.blackListResidenceTime.toMillis / 1.9).toLong)

--- a/src/test/scala/scorex/network/BlacklistSpecification.scala
+++ b/src/test/scala/scorex/network/BlacklistSpecification.scala
@@ -40,7 +40,7 @@ class BlacklistSpecification extends FeatureSpec with GivenWhenThen {
       assert(!isBlacklisted(address))
 
       And("Peer blacklists another peer")
-      peerDatabase.blacklist(address.getAddress)
+      peerDatabase.blacklist(address.getAddress, "")
       assert(isBlacklisted(address))
       assert(!peerDatabase.knownPeers.contains(address))
 

--- a/src/test/scala/scorex/network/peer/PeerDatabaseImplSpecification.scala
+++ b/src/test/scala/scorex/network/peer/PeerDatabaseImplSpecification.scala
@@ -72,12 +72,12 @@ class PeerDatabaseImplSpecification extends path.FreeSpecLike with Matchers {
       database.knownPeers.keys should contain(address1)
       database.knownPeers.keys should not contain address2
 
-      database.blacklist(InetAddress.getByName(host1))
+      database.blacklist(InetAddress.getByName(host1), "")
       database.knownPeers.keys should not contain address1
       database.knownPeers should be(empty)
 
       database.randomPeer(Set()) should contain(address2)
-      database.blacklist(InetAddress.getByName(host2))
+      database.blacklist(InetAddress.getByName(host2), "")
       database.randomPeer(Set()) should not contain address2
       database.randomPeer(Set()) should be(empty)
     }


### PR DESCRIPTION
`/peers/blacklisted` to respond with 
```
[ {
  "hostname" : "/34.251.200.245",
  "timestamp" : 1502197286570,
  "reason" : "Timeout loading blocks"
}, {
  "hostname" : "/35.157.212.173",
  "timestamp" : 1502197312796,
  "reason" : "Malformed network message"
} ]
```