### PR TITLE
NODE-73: Get account balance after application of transactions in UTX pool

### DIFF
--- a/src/it/scala/com/wavesplatform/it/TestFourNodesSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/TestFourNodesSuite.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.it
 
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.it.transactions._
+import com.wavesplatform.it.transactions.debug._
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, Suite}
 import scorex.utils.ScorexLogging
 
@@ -55,7 +56,8 @@ class TestFourNodesSuite extends FreeSpec with BeforeAndAfterAll with ScorexLogg
     new PaymentTransactionSpecification(allNodes, notMiner),
     new ReissueTransactionSpecification(allNodes, notMiner),
     new TransferTransactionSpecification(allNodes, notMiner),
-    new AliasTransactionSpecification(allNodes, notMiner)
+    new AliasTransactionSpecification(allNodes, notMiner),
+    new DebugPortfoliosSpecification(allNodes, notMiner)
   )
 
   override protected def afterAll(): Unit = docker.close()

--- a/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
+++ b/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeoutException
 
 import com.wavesplatform.it.util._
 import com.wavesplatform.matcher.api.CancelOrderRequest
+import com.wavesplatform.state2.Portfolio
 import io.netty.util.{HashedWheelTimer, Timer}
 import org.asynchttpclient.Dsl.{get => _get, post => _post}
 import org.asynchttpclient._
@@ -12,12 +13,14 @@ import org.asynchttpclient.util.HttpConstants
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json.{parse, stringify, toJson}
 import play.api.libs.json._
+import scorex.account.Address
 import scorex.api.http.alias.CreateAliasRequest
 import scorex.api.http.assets._
 import scorex.api.http.leasing.{LeaseCancelRequest, LeaseRequest}
 import scorex.transaction.assets.exchange.Order
 import scorex.utils.{LoggerFacade, ScorexLogging}
 import scorex.waves.http.RollbackParams
+import scorex.waves.http.DebugApiRoute.portfolioFormat
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -108,6 +111,12 @@ trait NodeApi {
     case Failure(UnexpectedStatusCodeException(_, r)) if r.getStatusCode == 404 => Success(None)
     case Failure(ex) => Failure(ex)
   }, tOpt => tOpt.exists(_.id == txId), 1.second).map(_.get)
+
+  def waitForUtxIncreased(fromSize: Int): Future[Int] = waitFor[Int](
+    utxSize,
+    _ > fromSize,
+    100.millis
+  )
 
   def waitForHeight(expectedHeight: Int): Future[Int] = waitFor[Int](height, h => h >= expectedHeight, 1.second)
 
@@ -249,6 +258,13 @@ trait NodeApi {
   def waitForDebugInfoAt(height: Long): Future[DebugInfo] = waitFor[DebugInfo](get("/debug/info").as[DebugInfo], _.stateHeight >= height, 1.seconds)
 
   def debugStateAt(height: Long): Future[Map[String, Long]] = get(s"/debug/stateWaves/$height").as[Map[String, Long]]
+
+  def debugPortfoliosFor(address: Address) = retrying {
+    _get(s"http://$restAddress:$nodeRestPort/debug/portfolios/${address.address}?considerUnspent=true")
+    .setHeader("api_key", "integration-test-rest-api")
+    .build()
+  }.as[Portfolio]
+
 }
 
 object NodeApi extends ScorexLogging {

--- a/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
+++ b/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
@@ -59,6 +59,12 @@ trait NodeApi {
   def get(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] =
     retrying(f(_get(s"http://$restAddress:$nodeRestPort$path")).build())
 
+  def getDebug(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] = retrying {
+    _get(s"http://$restAddress:$nodeRestPort$path")
+      .setHeader("api_key", "integration-test-rest-api")
+      .build()
+  }
+
   def post(url: String, port: Int, path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] =
     retrying(f(
       _post(s"$url:$port$path").setHeader("api_key", "integration-test-rest-api")
@@ -259,10 +265,8 @@ trait NodeApi {
 
   def debugStateAt(height: Long): Future[Map[String, Long]] = get(s"/debug/stateWaves/$height").as[Map[String, Long]]
 
-  def debugPortfoliosFor(address: Address) = retrying {
-    _get(s"http://$restAddress:$nodeRestPort/debug/portfolios/${address.address}?considerUnspent=true")
-    .setHeader("api_key", "integration-test-rest-api")
-    .build()
+  def debugPortfoliosFor(address: Address, considerUnspent: Boolean) = {
+    getDebug(s"/debug/portfolios/${address.address}?considerUnspent=$considerUnspent")
   }.as[Portfolio]
 
 }

--- a/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
+++ b/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
@@ -59,7 +59,7 @@ trait NodeApi {
   def get(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] =
     retrying(f(_get(s"http://$restAddress:$nodeRestPort$path")).build())
 
-  def getDebug(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] = retrying {
+  def getWihApiKey(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] = retrying {
     _get(s"http://$restAddress:$nodeRestPort$path")
       .setHeader("api_key", "integration-test-rest-api")
       .build()
@@ -266,7 +266,7 @@ trait NodeApi {
   def debugStateAt(height: Long): Future[Map[String, Long]] = get(s"/debug/stateWaves/$height").as[Map[String, Long]]
 
   def debugPortfoliosFor(address: Address, considerUnspent: Boolean) = {
-    getDebug(s"/debug/portfolios/${address.address}?considerUnspent=$considerUnspent")
+    getWihApiKey(s"/debug/portfolios/${address.address}?considerUnspent=$considerUnspent")
   }.as[Portfolio]
 
 }

--- a/src/it/scala/com/wavesplatform/it/transactions/debug/DebugPortfoliosSpecification.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/debug/DebugPortfoliosSpecification.scala
@@ -11,23 +11,44 @@ import scala.concurrent.duration._
 class DebugPortfoliosSpecification(override val allNodes: Seq[Node], override val notMiner: Node)
   extends IntegrationSuiteWithThreeAddresses {
 
-  test("getting a balance considering pessimistic transactions from UTX pool") {
+  test("getting a balance considering pessimistic transactions from UTX pool - changed after UTX") {
     val firstAddr = Address.fromString(firstAddress).right.get
 
     val f = for {
       _ <- assertBalances(firstAddress, 100.waves, 100.waves)
       _ <- assertBalances(secondAddress, 100.waves, 100.waves)
 
-      portfolioBefore <- sender.debugPortfoliosFor(firstAddr)
+      portfolioBefore <- sender.debugPortfoliosFor(firstAddr, considerUnspent = true)
       utxSizeBefore <- sender.utxSize
 
       _ <- sender.payment(firstAddress, secondAddress, 5.waves, fee = 5.waves)
       _ <- sender.waitForUtxIncreased(utxSizeBefore)
 
-      portfolioAfter <- sender.debugPortfoliosFor(firstAddr)
+      portfolioAfter <- sender.debugPortfoliosFor(firstAddr, considerUnspent = true)
     } yield {
       val expectedBalance = portfolioBefore.balance - 10.waves // withdraw + fee
       assert(portfolioAfter.balance == expectedBalance)
+    }
+
+    Await.result(f, 1.minute)
+  }
+
+  test("getting a balance without pessimistic transactions from UTX pool - not changed after UTX") {
+    val firstAddr = Address.fromString(firstAddress).right.get
+
+    val f = for {
+      _ <- assertBalances(firstAddress, 100.waves, 100.waves)
+      _ <- assertBalances(secondAddress, 100.waves, 100.waves)
+
+      portfolioBefore <- sender.debugPortfoliosFor(firstAddr, considerUnspent = false)
+      utxSizeBefore <- sender.utxSize
+
+      _ <- sender.payment(firstAddress, secondAddress, 5.waves, fee = 5.waves)
+      _ <- sender.waitForUtxIncreased(utxSizeBefore)
+
+      portfolioAfter <- sender.debugPortfoliosFor(firstAddr, considerUnspent = false)
+    } yield {
+      assert(portfolioAfter.balance == portfolioBefore.balance)
     }
 
     Await.result(f, 1.minute)

--- a/src/it/scala/com/wavesplatform/it/transactions/debug/DebugPortfoliosSpecification.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/debug/DebugPortfoliosSpecification.scala
@@ -1,0 +1,35 @@
+package com.wavesplatform.it.transactions.debug
+
+import com.wavesplatform.it.util._
+import com.wavesplatform.it.{IntegrationSuiteWithThreeAddresses, Node}
+import scorex.account.Address
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class DebugPortfoliosSpecification(override val allNodes: Seq[Node], override val notMiner: Node)
+  extends IntegrationSuiteWithThreeAddresses {
+
+  test("getting a balance considering pessimistic transactions from UTX pool") {
+    val firstAddr = Address.fromString(firstAddress).right.get
+
+    val f = for {
+      _ <- assertBalances(firstAddress, 100.waves, 100.waves)
+      _ <- assertBalances(secondAddress, 100.waves, 100.waves)
+
+      portfolioBefore <- sender.debugPortfoliosFor(firstAddr)
+      utxSizeBefore <- sender.utxSize
+
+      _ <- sender.payment(firstAddress, secondAddress, 5.waves, fee = 5.waves)
+      _ <- sender.waitForUtxIncreased(utxSizeBefore)
+
+      portfolioAfter <- sender.debugPortfoliosFor(firstAddr)
+    } yield {
+      val expectedBalance = portfolioBefore.balance - 10.waves // withdraw + fee
+      assert(portfolioAfter.balance == expectedBalance)
+    }
+
+    Await.result(f, 1.minute)
+  }
+}

--- a/src/main/scala/com/wavesplatform/UtxPool.scala
+++ b/src/main/scala/com/wavesplatform/UtxPool.scala
@@ -2,22 +2,25 @@ package com.wavesplatform
 
 import java.util.concurrent.ConcurrentHashMap
 
-import cats.Monoid
+import cats._
 import com.google.common.cache.CacheBuilder
 import com.wavesplatform.settings.{FunctionalitySettings, UtxSettings}
 import com.wavesplatform.state2.diffs.TransactionDiffer
 import com.wavesplatform.state2.reader.{CompositeStateReader, StateReader}
-import com.wavesplatform.state2.{ByteStr, Diff}
+import com.wavesplatform.state2.{ByteStr, Diff, Portfolio}
+import scorex.account.Address
 import scorex.consensus.TransactionsOrdering
 import scorex.transaction.ValidationError.GenericError
-import scorex.transaction.{FeeCalculator, History, Transaction, ValidationError}
+import scorex.transaction._
 import scorex.utils.{ScorexLogging, Time}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.{Left, Right}
 
-
+/**
+  * A pool with unconfirmed transactions
+  */
 class UtxPool(
                  time: Time,
                  stateReader: StateReader,
@@ -26,13 +29,36 @@ class UtxPool(
                  fs: FunctionalitySettings,
                  utxSettings: UtxSettings) extends ScorexLogging {
 
+  private type Portfolios = Map[Address, Portfolio]
+
   private val transactions = new ConcurrentHashMap[ByteStr, Transaction]
+
   private lazy val knownTransactions = CacheBuilder.newBuilder()
     .maximumSize(utxSettings.maxSize * 2)
     .build[ByteStr, Either[ValidationError, Transaction]]()
 
-  private def removeExpired(currentTs: Long): Unit =
-    transactions.entrySet().removeIf(tx => (currentTs - tx.getValue.timestamp).millis > utxSettings.maxTransactionAge)
+  /**
+    * Transaction.id -> diff
+    * Transactions which withdraw
+    */
+  private val txPessimisticPortfolios = new ConcurrentHashMap[ByteStr, Portfolios]
+
+  private def removeExpired(currentTs: Long): Unit = {
+    def isExpired(tx: Transaction) = (currentTs - tx.timestamp).millis > utxSettings.maxTransactionAge
+
+    if (!transactions.isEmpty) {
+      val expiredTxs = transactions.reduceValues[Vector[Transaction]](
+        1, // maximal parallelism
+        { tx => if (isExpired(tx)) Vector(tx) else Vector.empty },
+        _ ++ _
+      )
+
+      expiredTxs.foreach { tx =>
+        transactions.remove(tx.id)
+        txPessimisticPortfolios.remove(tx.id)
+      }
+    }
+  }
 
   def putIfNew(tx: Transaction): Either[ValidationError, Transaction] =
     if (transactions.size >= utxSettings.maxSize) {
@@ -40,7 +66,18 @@ class UtxPool(
     } else knownTransactions.get(tx.id, () => {
       val validationResult = for {
         _ <- feeCalculator.enoughFee(tx)
-        _ <- TransactionDiffer.apply(fs, history.lastBlock.map(_.timestamp), time.correctedTime(), stateReader.height)(stateReader, tx)
+        diff <- TransactionDiffer(fs, history.lastBlock.map(_.timestamp), time.correctedTime(), stateReader.height)(stateReader, tx)
+        _ = {
+          val nonEmptyPessimisticPortfolios = diff.portfolios
+            .mapValues(_.pessimistic)
+            .filterNot {
+              case (_, portfolio) => portfolio.isEmpty
+            }
+
+          if (nonEmptyPessimisticPortfolios.nonEmpty) {
+            txPessimisticPortfolios.put(tx.id, nonEmptyPessimisticPortfolios)
+          }
+        }
         _ = transactions.putIfAbsent(tx.id, tx)
       } yield tx
 
@@ -53,6 +90,23 @@ class UtxPool(
       knownTransactions.invalidate(id)
       transactions.remove(id)
     }
+  }
+
+  def portfolio(addr: Address): Portfolio = {
+    val empty = Monoid.empty[Portfolio]
+    val base = stateReader.accountPortfolio(addr)
+
+    val foundInUtx = if (txPessimisticPortfolios.isEmpty) {
+      empty
+    } else {
+      txPessimisticPortfolios.reduceValues[Portfolio](
+        1,
+        _.getOrElse(addr, empty),
+        Monoid.combine[Portfolio]
+      )
+    }
+
+    Monoid.combine(base, foundInUtx)
   }
 
   def all(): Seq[Transaction] = transactions.values.asScala.toSeq.sorted(TransactionsOrdering.InUTXPool)

--- a/src/main/scala/com/wavesplatform/UtxPool.scala
+++ b/src/main/scala/com/wavesplatform/UtxPool.scala
@@ -18,9 +18,6 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.{Left, Right}
 
-/**
-  * A pool with unconfirmed transactions
-  */
 class UtxPool(
                  time: Time,
                  stateReader: StateReader,

--- a/src/main/scala/com/wavesplatform/state2/Portfolio.scala
+++ b/src/main/scala/com/wavesplatform/state2/Portfolio.scala
@@ -7,6 +7,20 @@ import cats.Monoid
 case class Portfolio(balance: Long, leaseInfo: LeaseInfo, assets: Map[ByteStr, Long]) {
   lazy val effectiveBalance: Long = safeSum(balance, leaseInfo.leaseIn) - leaseInfo.leaseOut
   lazy val spendableBalance: Long = balance - leaseInfo.leaseOut
+
+  /**
+    * The Portfolio with only the withdraw part
+    */
+  def pessimistic: Portfolio = Portfolio(
+    balance = Math.min(balance, 0),
+    leaseInfo = LeaseInfo(
+      leaseIn = 0,
+      leaseOut = Math.min(leaseInfo.leaseOut, 0)
+    ),
+    assets = assets.filter { case (_, v) => v < 0 }
+  )
+
+  def isEmpty: Boolean = this == Monoid.empty[Portfolio]
 }
 
 object Portfolio {

--- a/src/main/scala/com/wavesplatform/state2/Portfolio.scala
+++ b/src/main/scala/com/wavesplatform/state2/Portfolio.scala
@@ -15,7 +15,7 @@ case class Portfolio(balance: Long, leaseInfo: LeaseInfo, assets: Map[ByteStr, L
     balance = Math.min(balance, 0),
     leaseInfo = LeaseInfo(
       leaseIn = 0,
-      leaseOut = Math.min(leaseInfo.leaseOut, 0)
+      leaseOut = Math.max(leaseInfo.leaseOut, 0)
     ),
     assets = assets.filter { case (_, v) => v < 0 }
   )

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -9,6 +9,9 @@ import scorex.account.{Address, Alias}
 import scorex.transaction.Transaction
 import scorex.transaction.lease.LeaseTransaction
 
+/**
+  * Reads the state including an in-memory diff
+  */
 class CompositeStateReader(inner: StateReader, blockDiff: BlockDiff) extends StateReader {
 
   def synchronizationToken: ReentrantReadWriteLock = inner.synchronizationToken

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -9,9 +9,6 @@ import scorex.account.{Address, Alias}
 import scorex.transaction.Transaction
 import scorex.transaction.lease.LeaseTransaction
 
-/**
-  * Reads the state including an in-memory diff
-  */
 class CompositeStateReader(inner: StateReader, blockDiff: BlockDiff) extends StateReader {
 
   def synchronizationToken: ReentrantReadWriteLock = inner.synchronizationToken

--- a/src/main/scala/scorex/utils/Synchronized.scala
+++ b/src/main/scala/scorex/utils/Synchronized.scala
@@ -58,6 +58,11 @@ trait Synchronized {
       f(value)
     }
 
+    def transform(newVal: T => T)(implicit readWriteLock: WriteLock): T = {
+      value = newVal(value)
+      value
+    }
+
     def set(newVal: => T)(implicit readWriteLock: WriteLock): T = {
       val oldVal = value
       value = newVal

--- a/src/main/scala/scorex/waves/http/DebugApiRoute.scala
+++ b/src/main/scala/scorex/waves/http/DebugApiRoute.scala
@@ -82,18 +82,23 @@ case class DebugApiRoute(settings: RestAPISettings,
     notes = "Get current portfolio considering pessimistic transactions in the UTX pool",
     httpMethod = "GET"
   )
-  @ApiImplicitParam(
-    name = "address",
-    value = "An address of portfolio",
-    required = true,
-    dataType = "string",
-    paramType = "path"
-  )
-  @ApiParam(
-    name = "considerUnspent",
-    value = "Taking into account pessimistic transactions from UTX pool",
-    `type` = "Boolean"
-  )
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(
+      name = "address",
+      value = "An address of portfolio",
+      required = true,
+      dataType = "string",
+      paramType = "path"
+    ),
+    new ApiImplicitParam(
+      name = "considerUnspent",
+      value = "Taking into account pessimistic transactions from UTX pool",
+      required = false,
+      dataType = "boolean",
+      paramType = "query",
+      defaultValue = "true"
+    )
+  ))
   @ApiResponses(Array(new ApiResponse(code = 200, message = "Json portfolio")))
   def portfolios: Route = path("portfolios" / Segment) { (rawAddress) =>
     (get & parameter('considerUnspent.as[Boolean])) { (considerUnspent) =>

--- a/src/main/scala/scorex/waves/http/DebugApiRoute.scala
+++ b/src/main/scala/scorex/waves/http/DebugApiRoute.scala
@@ -82,15 +82,13 @@ case class DebugApiRoute(settings: RestAPISettings,
     notes = "Get current portfolio considering pessimistic transactions in the UTX pool",
     httpMethod = "GET"
   )
-  @ApiImplicitParams(Array(
-    new ApiImplicitParam(
-      name = "address",
-      value = "An address of portfolio",
-      required = true,
-      dataType = "string",
-      paramType = "path"
-    )
-  ))
+  @ApiImplicitParam(
+    name = "address",
+    value = "An address of portfolio",
+    required = true,
+    dataType = "string",
+    paramType = "path"
+  )
   @ApiParam(
     name = "considerUnspent",
     value = "Taking into account pessimistic transactions from UTX pool",
@@ -237,7 +235,6 @@ object DebugApiRoute {
     },
     m => Json.toJson(m.map { case (assetId, count) => assetId.base58 -> count })
   )
-
   implicit val leaseInfoFormat: Format[LeaseInfo] = Json.format
   implicit val portfolioFormat: Format[Portfolio] = Json.format
 }

--- a/src/main/scala/scorex/waves/http/DebugApiRoute.scala
+++ b/src/main/scala/scorex/waves/http/DebugApiRoute.scala
@@ -10,12 +10,13 @@ import akka.http.scaladsl.server.Route
 import com.wavesplatform.UtxPool
 import com.wavesplatform.network.{LocalScoreChanged, PeerDatabase, PeerInfo, _}
 import com.wavesplatform.settings.RestAPISettings
-import com.wavesplatform.state2.ByteStr
+import com.wavesplatform.state2.{ByteStr, LeaseInfo, Portfolio}
 import com.wavesplatform.state2.reader.StateReader
 import io.netty.channel.Channel
 import io.netty.channel.group.ChannelGroup
 import io.swagger.annotations._
-import play.api.libs.json.{JsArray, Json}
+import play.api.libs.json._
+import scorex.account.Address
 import scorex.api.http._
 import scorex.crypto.encode.Base58
 import scorex.crypto.hash.FastCryptographicHash
@@ -24,8 +25,9 @@ import scorex.wallet.Wallet
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.Success
+import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
+import DebugApiRoute._
 
 
 @Path("/debug")
@@ -41,7 +43,7 @@ case class DebugApiRoute(settings: RestAPISettings,
                          utxStorage: UtxPool) extends ApiRoute {
 
   override lazy val route = pathPrefix("debug") {
-    blocks ~ state ~ info ~ stateWaves ~ rollback ~ rollbackTo ~ blacklist
+    blocks ~ state ~ info ~ stateWaves ~ rollback ~ rollbackTo ~ blacklist ~ portfolios
   }
 
   @Path("/blocks/{howMany}")
@@ -74,6 +76,37 @@ case class DebugApiRoute(settings: RestAPISettings,
     )
   }
 
+  @Path("/portfolios/{address}")
+  @ApiOperation(
+    value = "Portfolio",
+    notes = "Get current portfolio considering pessimistic transactions in the UTX pool",
+    httpMethod = "GET"
+  )
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(
+      name = "address",
+      value = "An address of portfolio",
+      required = true,
+      dataType = "string",
+      paramType = "path"
+    )
+  ))
+  @ApiParam(
+    name = "considerUnspent",
+    value = "Taking into account pessimistic transactions from UTX pool",
+    `type` = "Boolean"
+  )
+  @ApiResponses(Array(new ApiResponse(code = 200, message = "Json portfolio")))
+  def portfolios: Route = path("portfolios" / Segment) { (rawAddress) =>
+    (get & parameter('considerUnspent.as[Boolean])) { (considerUnspent) =>
+      Address.fromString(rawAddress) match {
+        case Left(_) => complete(InvalidAddress)
+        case Right(address) =>
+          val portfolio = if (considerUnspent) utxStorage.portfolio(address) else stateReader.accountPortfolio(address)
+          complete(Json.toJson(portfolio))
+      }
+    }
+  }
 
   @Path("/stateWaves/{height}")
   @ApiOperation(value = "State at block", notes = "Get state at specified height", httpMethod = "GET")
@@ -184,4 +217,27 @@ case class DebugApiRoute(settings: RestAPISettings,
     }
   }
 
+}
+
+object DebugApiRoute {
+  implicit val assetsFormat: Format[Map[ByteStr, Long]] = Format[Map[ByteStr, Long]](
+    _ match {
+      case JsObject(m) => m.foldLeft[JsResult[Map[ByteStr, Long]]](JsSuccess(Map.empty)) {
+        case (e: JsError, _) => e
+        case (JsSuccess(m, _), (rawAssetId, JsNumber(count))) =>
+          (ByteStr.decodeBase58(rawAssetId), count) match {
+            case (Success(assetId), count) if count.isValidLong => JsSuccess(m.updated(assetId, count.toLong))
+            case (Failure(_), _) => JsError(s"Can't parse '$rawAssetId' as base58 string")
+            case (_, count) => JsError(s"Invalid count of assets: $count")
+          }
+        case (_, (_, rawCount)) =>
+          JsError(s"Invalid count of assets: $rawCount")
+      }
+      case _ => JsError("The map is expected")
+    },
+    m => Json.toJson(m.map { case (assetId, count) => assetId.base58 -> count })
+  )
+
+  implicit val leaseInfoFormat: Format[LeaseInfo] = Json.format
+  implicit val portfolioFormat: Format[Portfolio] = Json.format
 }

--- a/src/test/scala/com/wavesplatform/state2/PortfolioTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/PortfolioTest.scala
@@ -1,9 +1,47 @@
 package com.wavesplatform.state2
 
+import java.nio.charset.StandardCharsets
+
 import cats._
 import org.scalatest.{FunSuite, Matchers}
 
 class PortfolioTest extends FunSuite with Matchers {
+  test("pessimistic - should return only withdraws") {
+    val Seq(fooKey, barKey, bazKey) = Seq("foo", "bar", "baz").map(x => ByteStr(x.getBytes(StandardCharsets.UTF_8)))
+
+    val orig = Portfolio(
+      balance = -10,
+      leaseInfo = LeaseInfo(
+        leaseIn = 11,
+        leaseOut = 12
+      ),
+      assets = Map(
+        fooKey -> -13,
+        barKey -> 14,
+        bazKey -> 0
+      )
+    )
+
+    val p = orig.pessimistic
+    p.balance shouldBe orig.balance
+    p.leaseInfo.leaseIn shouldBe 0
+    p.leaseInfo.leaseOut shouldBe orig.leaseInfo.leaseOut
+    p.assets(fooKey) shouldBe orig.assets(fooKey)
+    p.assets shouldNot contain(barKey)
+    p.assets shouldNot contain(bazKey)
+  }
+
+  test("pessimistic - positive balance is turned into zero") {
+    val orig = Portfolio(
+      balance = 10,
+      leaseInfo = LeaseInfo(0, 0),
+      assets = Map.empty
+    )
+
+    val p = orig.pessimistic
+    p.balance shouldBe 0
+  }
+
   test("prevents overflow of assets") {
     val assetId = ByteStr(Array.empty)
     val arg1 = Portfolio(0L, LeaseInfo.empty, Map(assetId -> (Long.MaxValue - 1L)))


### PR DESCRIPTION
You can check a portfolio (including the balance) through a debug API-method:
```
/debug/portfolios/{address}?considerUnspent=true|false
```
, but don't forget to provide an API key ;)

* considerUnspent=*true* - including transactions from UTX pool;
* considerUnspent=*false* - without it.