### PR TITLE
NODE-176: Terminate the Node on java.lang.OutOfMemoryError

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,7 @@ javaOptions in Universal ++= Seq(
   // JVM memory tuning for 1g ram
   "-J-Xms128m",
   "-J-Xmx1g",
+  "-J-XX:+ExitOnOutOfMemoryError",
 
   // from https://groups.google.com/d/msg/akka-user/9s4Yl7aEz3E/zfxmdc0cGQAJ
   "-J-XX:+UseG1GC",


### PR DESCRIPTION
I've already tested this solution on devnet:
1. Specified `Xmx200m` and the `-XX:+ExitOnOutOfMemoryError` flag
2. Saw a log:

```
journalctl -u waves-devnet --since "-10m" -f | grep -E "(OutOfMemoryError|Starting\.\.\.)"
Sep 18 12:34:12 devnet1 waves-devnet[28257]: -XX:+ExitOnOutOfMemoryError
Sep 18 12:34:13 devnet1 waves-devnet[28257]: INFO  c.w.Application$ - Starting...
Sep 18 12:36:13 devnet1 waves-devnet[28257]: Terminating due to java.lang.OutOfMemoryError: GC overhead limit exceeded
Sep 18 12:37:13 devnet1 waves-devnet[28603]: -XX:+ExitOnOutOfMemoryError
Sep 18 12:37:14 devnet1 waves-devnet[28603]: INFO  c.w.Application$ - Starting...
Sep 18 12:39:18 devnet1 waves-devnet[28603]: Terminating due to java.lang.OutOfMemoryError: GC overhead limit exceeded
Sep 18 12:40:18 devnet1 waves-devnet[28822]: -XX:+ExitOnOutOfMemoryError
Sep 18 12:40:19 devnet1 waves-devnet[28822]: INFO  c.w.Application$ - Starting...
```