### PR TITLE
NODE-169: NG metrics: transactions, rollbacks, propagation

### DIFF
--- a/src/main/scala/com/wavesplatform/metrics/BlockStats.scala
+++ b/src/main/scala/com/wavesplatform/metrics/BlockStats.scala
@@ -1,5 +1,8 @@
 package com.wavesplatform.metrics
 
+import java.net.InetSocketAddress
+
+import com.wavesplatform.state2.ByteStr
 import org.influxdb.dto.Point
 import scorex.block.{Block, MicroBlock}
 
@@ -7,35 +10,96 @@ object BlockStats {
 
   private val StringIdLength = 6
 
-  sealed abstract class Event {
+  private sealed abstract class Event {
     val name: String = {
       val className = getClass.getName
       className.slice(className.lastIndexOf('$', className.length - 2) + 1, className.length - 1)
     }
   }
 
-  object Event {
+  private object Event {
     case object Received extends Event
     case object Applied extends Event
-    case object Rejected extends Event
+    case object Declined extends Event
     case object Mined extends Event
   }
 
-  def write(b: Block, event: Event, addFields: (String, String)*): Unit = write(
-    Point
-      .measurement("block")
-      .addField("id", b.uniqueId.toString.take(StringIdLength)),
-    event,
-    addFields
+  def received(b: Block, from: InetSocketAddress): Unit = write(
+    block(b)
+      .addField("from", from.toString)
+      .addField("prop-time", System.currentTimeMillis() - b.timestamp)
+      .addField("score", b.blockScore),
+    Event.Received,
+    Seq.empty
   )
 
-  def write(m: MicroBlock, event: Event, addFields: (String, String)*): Unit = write(
+  def applied(b: Block, height: Int): Unit = write(
+    block(b)
+      .addField("txs", b.transactionData.size)
+      .addField("height", height),
+    Event.Applied,
+    Seq.empty
+  )
+
+  def declined(b: Block): Unit = write(
+    block(b),
+    Event.Declined,
+    Seq.empty
+  )
+
+  def mined(b: Block, height: Int): Unit = write(
+    block(b)
+      .addField("parent-id", b.reference.toString.take(StringIdLength))
+      .addField("txs", b.transactionData.size)
+      .addField("score", b.blockScore)
+      .addField("height", height),
+    Event.Mined,
+    Seq.empty
+  )
+
+
+  def received(m: MicroBlock, from: InetSocketAddress, propagationTime: Long): Unit = write(
+    micro(m)
+      .addField("parent-id", m.prevResBlockSig.toString.take(StringIdLength))
+      .addField("from", from.toString)
+      .addField("prop-time", propagationTime),
+    Event.Received,
+    Seq.empty
+  )
+
+  def applied(m: MicroBlock): Unit = write(
+    micro(m)
+      .addField("txs", m.transactionData.size),
+    Event.Applied,
+    Seq.empty
+  )
+
+  def declined(m: MicroBlock): Unit = write(
+    micro(m),
+    Event.Declined,
+    Seq.empty
+  )
+
+  def mined(m: MicroBlock): Unit = write(
+    micro(m)
+      .addField("txs", m.transactionData.size),
+    Event.Mined,
+    Seq.empty
+  )
+
+  private def block(b: Block): Point.Builder = {
+    Point
+      .measurement("block")
+      .addField("id", id(b.uniqueId))
+  }
+
+  private def micro(m: MicroBlock): Point.Builder = {
     Point
       .measurement("micro")
-      .addField("id", m.uniqueId.toString.take(StringIdLength)),
-    event,
-    addFields
-  )
+      .addField("id", id(m.uniqueId))
+  }
+
+  private def id(x: ByteStr): String = x.toString.take(StringIdLength)
 
   private def write(init: Point.Builder, event: Event, addFields: Seq[(String, String)]): Unit = {
     Metrics.write(addFields.foldLeft(init.addField("event", event.name)) { case (r, (k, v)) => r.addField(k, v) })

--- a/src/main/scala/com/wavesplatform/metrics/TxsInBlockchainStats.scala
+++ b/src/main/scala/com/wavesplatform/metrics/TxsInBlockchainStats.scala
@@ -1,0 +1,11 @@
+package com.wavesplatform.metrics
+
+import org.influxdb.dto.Point
+
+object TxsInBlockchainStats {
+  def record(number: Int): Unit = Metrics.write(
+    Point
+      .measurement("applied-txs")
+      .addField("n", number)
+  )
+}


### PR DESCRIPTION
* Fixed configuration to pass WavesSettingsSpecification tests;
* BlockStats: Rejected -> Declined;
* Send to InfluxDB events about blocks in extensions;
* Send additional data in metrics (parent's id, score, propagation time and other).