### PR TITLE
NODE-220 added BUILD_NUMBER to jar name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,10 @@ scalacOptions ++= Seq(
 logBuffered := false
 
 //assembly settings
-assemblyJarName in assembly := s"waves-all-${version.value}.jar"
+assemblyJarName in assembly := {
+  val buildId = sys.env.get("BUILD_NUMBER").map(x => s".$x").getOrElse("")
+  s"waves-all-${version.value}$buildId.jar"
+}
 assemblyMergeStrategy in assembly := {
   case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.concat
   case other => (assemblyMergeStrategy in assembly).value(other)


### PR DESCRIPTION
rename waves-all- $ version.jar to waves-all- $ version. $ buildnumber.jar when builds in TeamCity and leave old name if local build.