### PR TITLE
NODE-282 One format for all NODE's logs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,8 @@ object Dependencies {
 
   lazy val logging = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
-    "org.slf4j" % "slf4j-api" % "1.7.25"
+    "org.slf4j" % "slf4j-api" % "1.7.25",
+    "org.slf4j" % "jul-to-slf4j" % "1.7.25"
   )
 
   lazy val http = Seq("core", "annotations", "models", "jaxrs").map(swaggerModule) ++ Seq(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -382,6 +382,10 @@ kamon {
     #   password = ""
     # }
   }
+
+  internal-config {
+    akka.loggers = ["akka.event.slf4j.Slf4jLogger"]
+  }
 }
 
 metrics {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+
     <property name="default.pattern" value="%date{yyyy-MM-dd HH:mm:ss} %-5level [%.15thread] %logger{26} - %msg%n"/>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>

--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -26,6 +26,7 @@ import io.netty.channel.group.DefaultChannelGroup
 import io.netty.util.concurrent.GlobalEventExecutor
 import kamon.Kamon
 import org.influxdb.dto.Point
+import org.slf4j.bridge.SLF4JBridgeHandler
 import scorex.account.AddressScheme
 import scorex.api.http._
 import scorex.api.http.alias.{AliasApiRoute, AliasBroadcastApiRoute}
@@ -228,6 +229,10 @@ object Application extends ScorexLogging {
   }
 
   def main(args: Array[String]): Unit = {
+    // j.u.l should log messages using the projects' conventions
+    SLF4JBridgeHandler.removeHandlersForRootLogger()
+    SLF4JBridgeHandler.install()
+
     // prevents java from caching successful name resolutions, which is needed e.g. for proper NTP server rotation
     // http://stackoverflow.com/a/17219327
     System.setProperty("sun.net.inetaddr.ttl", "0")


### PR DESCRIPTION
Logs after this PR:
```
2017-10-18 14:20:21 INFO  [run-main-0] c.w.Application$ - Starting...
2017-10-18 14:20:26 INFO  [run-main-0] kamon.Kamon$Instance - Initializing Kamon...
2017-10-18 14:20:26 INFO  [lt-dispatcher-2] a.event.slf4j.Slf4jLogger - Slf4jLogger started
2017-10-18 14:20:31 INFO  [lt-dispatcher-4] k.s.SystemMetricsExtension - Starting the Kamon(SystemMetrics) extension
2017-10-18 14:20:31 INFO  [run-main-0] k.sigar.SigarProvisioner - Sigar library provisioned: /Users/freezy/Projects/work/waves-platform/waves/native/libsigar-universal64-macosx.dylib
2017-10-18 14:20:31 INFO  [lt-dispatcher-3] k.i.InfluxDBExtension - Starting the Kamon(InfluxDB) extension
2017-10-18 14:20:32 INFO  [lt-dispatcher-2] a.event.slf4j.Slf4jLogger - Slf4jLogger started
2017-10-18 14:20:32 INFO  [run-main-0] c.w.Application$ - Waves v0.8.1-46-g6ed4154-DIRTY Blockchain Id: D
```