### PR TITLE
NODE-379 Add "cancelled" flag to leasing transaction

### DIFF
--- a/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -126,6 +126,9 @@ case class TransactionsApiRoute(
 
   private def txToExtendedJson(tx: Transaction): JsObject = {
     tx match {
+      case lease: LeaseTransaction =>
+        import LeaseTransaction.Status._
+        lease.json() ++ Json.obj("status" -> (if (state().isLeaseActive(lease)) Active else Canceled))
       case leaseCancel: LeaseCancelTransaction =>
         leaseCancel.json() ++ Json.obj("lease" -> state().findTransaction[LeaseTransaction](leaseCancel.leaseId).map(_.json()).getOrElse[JsValue](JsNull))
       case t => t.json()

--- a/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
@@ -42,6 +42,10 @@ case class LeaseTransaction private(sender: PublicKeyAccount,
 
 object LeaseTransaction {
 
+  object Status extends Enumeration {
+    val Active, Canceled = Value
+  }
+
   def parseTail(bytes: Array[Byte]): Try[LeaseTransaction] = Try {
     import EllipticCurveImpl._
     val sender = PublicKeyAccount(bytes.slice(0, KeyLength))


### PR DESCRIPTION
[Link to JIRA](https://wavesplatform.atlassian.net/browse/NODE-379)

Note that I've named the flag "canceled" (one L) because this is the preferred American English spelling according to [Grammarly](https://www.grammarly.com/blog/canceled-vs-cancelled/)