### PR TITLE
NODE-414 Extend API for /node/status + make it available at start

### DIFF
--- a/src/it/scala/com/wavesplatform/it/NodeApiTestSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/NodeApiTestSuite.scala
@@ -1,0 +1,36 @@
+package com.wavesplatform.it
+
+import com.wavesplatform.it.NodeApiTestSuite._
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import scorex.utils.ScorexLogging
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.concurrent.duration.DurationInt
+
+class NodeApiTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll with ScorexLogging {
+
+  private lazy val docker = Docker(getClass)
+
+  "/node/status should report status" in {
+    val node = docker.startNode(NodeConfig)
+    val f = for {
+      status <- node.status
+      _ = log.trace(s"#### $status")
+      _ = assert(status.blockchainHeight >= status.stateHeight)
+    } yield succeed
+
+    Await.ready(f, 2.minute)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    docker.close()
+  }
+}
+
+private object NodeApiTestSuite {
+
+  private val NodeConfig = NodeConfigs.newBuilder.withDefault(1).build().head
+
+}

--- a/src/main/scala/com/wavesplatform/Importer.scala
+++ b/src/main/scala/com/wavesplatform/Importer.scala
@@ -33,7 +33,7 @@ object Importer extends ScorexLogging {
           case Success(inputStream) =>
             deleteFile(settings.blockchainSettings.blockchainFile)
             deleteFile(settings.blockchainSettings.stateFile)
-            val (history, _, stateWriter, _, blockchainUpdater, _) = StorageFactory(settings).get
+            val (history, _, stateWriter, _, blockchainUpdater, _, _) = StorageFactory(settings).get
             checkGenesis(history, settings, blockchainUpdater)
             val bis = new BufferedInputStream(inputStream)
             var quit = false

--- a/src/main/scala/com/wavesplatform/http/NodeApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/http/NodeApiRoute.scala
@@ -1,19 +1,28 @@
 package com.wavesplatform.http
 
+import java.time.Instant
 import javax.ws.rs.Path
 
 import akka.http.scaladsl.server.Route
 import com.wavesplatform.Shutdownable
+import com.wavesplatform.network.lastObserved
 import com.wavesplatform.settings.{Constants, RestAPISettings}
+import com.wavesplatform.state2.StateWriter
 import io.swagger.annotations._
+import monix.eval.Coeval
+import monix.execution.Scheduler.Implicits.global
 import play.api.libs.json.Json
 import scorex.api.http.{ApiRoute, CommonApiFunctions}
+import scorex.transaction.{BlockchainUpdater, LastBlockInfo}
 import scorex.utils.ScorexLogging
 
 @Path("/node")
 @Api(value = "node")
-case class NodeApiRoute(settings: RestAPISettings, application: Shutdownable)
+case class NodeApiRoute(settings: RestAPISettings, blockchainUpdater: BlockchainUpdater, state: StateWriter, application: Shutdownable)
   extends ApiRoute with CommonApiFunctions with ScorexLogging {
+
+  private val lastHeight: Coeval[Option[LastBlockInfo]] = lastObserved(blockchainUpdater.lastBlockInfo)
+  private val lastState: Coeval[Option[StateWriter.Status]] = lastObserved(state.status)
 
   override lazy val route = pathPrefix("node") {
     stop ~ status ~ version
@@ -39,6 +48,14 @@ case class NodeApiRoute(settings: RestAPISettings, application: Shutdownable)
   @Path("/status")
   @ApiOperation(value = "Status", notes = "Get status of the running core", httpMethod = "GET")
   def status: Route = (get & path("status")) {
-    complete(Json.obj())
+    val (bcHeight, bcTime) = lastHeight().map { case LastBlockInfo(_, h, _, _, t) => (h, t) }.getOrElse((0, 0L))
+    val (stHeight, stTime) = lastState().map { case StateWriter.Status(h, t) => (h, t) }.getOrElse((0, 0L))
+    val lastUpdated = bcTime max stTime
+    complete(Json.obj(
+      "blockchainHeight" -> bcHeight,
+      "stateHeight" -> stHeight,
+      "updatedTimestamp" -> lastUpdated,
+      "updatedDate" -> Instant.ofEpochMilli(lastUpdated).toString
+    ))
   }
 }

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -5,22 +5,36 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import cats.Monoid
 import cats.implicits._
 import com.wavesplatform.metrics.Instrumented
+import com.wavesplatform.state2.StateWriter.Status
 import com.wavesplatform.state2.reader.StateReaderImpl
+import monix.reactive.Observable
+import monix.reactive.subjects.BehaviorSubject
 import scorex.transaction.PaymentTransaction
 import scorex.transaction.assets.TransferTransaction
 import scorex.transaction.assets.exchange.ExchangeTransaction
 import scorex.utils.ScorexLogging
+import scorex.utils.Synchronized.ReadLock
 
 trait StateWriter {
   def applyBlockDiff(blockDiff: BlockDiff): Unit
 
   def clear(): Unit
+
+  def status: Observable[Status]
+}
+
+object StateWriter {
+  case class Status(height: Int, lastUpdated: Long)
 }
 
 class StateWriterImpl(p: StateStorage, storeTransactions: Boolean, synchronizationToken: ReentrantReadWriteLock)
   extends StateReaderImpl(p, synchronizationToken) with StateWriter with AutoCloseable with ScorexLogging with Instrumented {
 
   import StateStorage._
+
+  override val status = read { implicit l =>
+    BehaviorSubject(Status(sp().getHeight, System.currentTimeMillis))
+  }
 
   override def close(): Unit = p.close()
 
@@ -106,7 +120,8 @@ class StateWriterImpl(p: StateStorage, storeTransactions: Boolean, synchronizati
     measureSizeLog("lease info")(blockDiff.txsDiff.leaseState)(
       _.foreach { case (id, isActive) => sp().leaseState.put(id, isActive) })
 
-    sp().setHeight(newHeight)
+    setHeight(newHeight)
+
     val nextChunkOfBlocks = !sameQuotient(newHeight, oldHeight, 1000)
     sp().commit(nextChunkOfBlocks)
     log.info(s"BlockDiff commit complete. Persisted height = $newHeight")
@@ -125,7 +140,12 @@ class StateWriterImpl(p: StateStorage, storeTransactions: Boolean, synchronizati
     sp().aliasToAddress.clear()
     sp().leaseState.clear()
     sp().lastBalanceSnapshotHeight.clear()
-    sp().setHeight(0)
+    setHeight(0)
     sp().commit(compact = true)
+  }
+
+  private def setHeight(newHeight: Int)(implicit lock: ReadLock) = {
+    sp().setHeight(newHeight)
+    status.onNext(Status(newHeight, System.currentTimeMillis))
   }
 }

--- a/src/main/scala/scorex/transaction/BlockchainUpdater.scala
+++ b/src/main/scala/scorex/transaction/BlockchainUpdater.scala
@@ -25,7 +25,7 @@ trait BlockchainDebugInfo {
 
 }
 
-case class LastBlockInfo(id: BlockId, height: Int, score: BlockchainScore, ready: Boolean)
+case class LastBlockInfo(id: BlockId, height: Int, score: BlockchainScore, ready: Boolean, lastUpdated: Long)
 
 case class HashInfo(height: Int, hash: Int)
 

--- a/src/test/scala/com/wavesplatform/UtxPoolSpecification.scala
+++ b/src/test/scala/com/wavesplatform/UtxPoolSpecification.scala
@@ -40,7 +40,7 @@ class UtxPoolSpecification extends FreeSpec
     val genesisSettings = TestHelpers.genesisSettings(Map(senderAccount -> senderBalance))
     val settings = WavesSettings.fromConfig(config).copy(blockchainSettings = BlockchainSettings(None, None, false, None, 'T', 5, 5, FunctionalitySettings.TESTNET, genesisSettings))
 
-    val (history, _, _, state, bcu, _) = StorageFactory(settings).get
+    val (history, _, _, state, bcu, _, _) = StorageFactory(settings).get
 
     bcu.processBlock(Block.genesis(genesisSettings).right.get)
 

--- a/src/test/scala/com/wavesplatform/history/package.scala
+++ b/src/test/scala/com/wavesplatform/history/package.scala
@@ -38,7 +38,7 @@ package object history {
   val DefaultWavesSettings: WavesSettings = settings.copy(blockchainSettings = DefaultBlockchainSettings)
 
   def domain(settings: WavesSettings): Domain = {
-    val (history, _, _, stateReader, blockchainUpdater, _) = StorageFactory(settings).get
+    val (history, _, _, stateReader, blockchainUpdater, _, _) = StorageFactory(settings).get
     Domain(history, stateReader, blockchainUpdater)
   }
 

--- a/src/test/scala/scorex/transaction/BlockchainUpdaterTest.scala
+++ b/src/test/scala/scorex/transaction/BlockchainUpdaterTest.scala
@@ -31,7 +31,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   private def storageFactory() = StorageFactory(WavesSettings).get
 
   ignore ("concurrent access to lastBlock doesn't throw any exception") {
-    val (h, fp, _, _, bu, _) = storageFactory()
+    val (h, fp, _, _, bu, _, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -57,7 +57,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
 
   test("features approved and accepted as height grows") {
 
-    val (h, fp, _, _, bu, _) = storageFactory()
+    val (h, fp, _, _, bu, _, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -94,7 +94,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("features rollback with block rollback") {
-    val (h, fp, _, _, bu, _) = storageFactory()
+    val (h, fp, _, _, bu, _, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -149,7 +149,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("feature activation height is not overrided with further periods") {
-    val (h, fp, _, _, bu, _) = storageFactory()
+    val (h, fp, _, _, bu, _, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -171,7 +171,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("feature activated only by 90% of blocks") {
-    val (h, fp, _, _, bu, _) = storageFactory()
+    val (h, fp, _, _, bu, _, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -194,7 +194,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("features votes resets when voting window changes") {
-    val (h, fp, _, _, bu, _) = storageFactory()
+    val (h, fp, _, _, bu, _, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -234,7 +234,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
     })
 
 
-    val (h, fp, _, _, bu, _) = StorageFactory(WavesSettings).get
+    val (h, fp, _, _, bu, _, _) = storageFactory()
     bu.processBlock(genesisBlock)
 
     (1 to ApprovalPeriod * 2).foreach { i =>
@@ -249,7 +249,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("sunny day test when known feature activated") {
-    val (h, fp, _, _, bu, _) = StorageFactory(WavesSettings).get
+    val (h, fp, _, _, bu, _, _) = storageFactory()
     bu.processBlock(genesisBlock)
 
     (1 until ApprovalPeriod * 2 - 1).foreach { i =>


### PR DESCRIPTION
Changes:
- The REST server now starts immediately on node startup, the only endpoints supported at that time being /node/*
- /node/status returns both blockchain height and state height. This is implemented using Observables.
- I had to make BlockchainUpdaterImpl.syncPersistedAndInMemory() method public, because it was called from the ctor so it was impossible to create a BlockchainUpdater instance without rebuilding state.
- Integration tests were broken by the change, as the REST service now starts way before the node is ready to be tested. I've added a new method, NodeApi.waitForStartup(), that waits for the node to become fully operational