### PR TITLE
NODE-380 Add "height" value to transactions received from API by address

### DIFF
--- a/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
@@ -1,7 +1,9 @@
 package com.wavesplatform.it.transactions
 
+import com.wavesplatform.it.api._
 import com.wavesplatform.it.util._
 import org.scalatest.CancelAfterFailure
+import play.api.libs.json.{JsArray, JsValue}
 import scorex.account.{AddressOrAlias, PrivateKeyAccount}
 import scorex.api.http.Mistiming
 import scorex.api.http.assets.SignedTransferRequest
@@ -205,5 +207,23 @@ class TransferTransactionSuite extends BaseTransactionSuite with CancelAfterFail
     } yield succeed
 
     Await.result(f, waitCompletion)
+  }
+
+  // probably should be moved elsewhere, just don't see any suite that fits the purpose right now
+  test("height should be reported for transactions") {
+    val f = for {
+      txId <- sender.transfer(firstAddress, secondAddress, 1.waves, fee = 1.waves).map(_.id)
+      _ <- waitForHeightAraiseAndTxPresent(txId, 1)
+
+      jsv1 <- sender.get(s"/transactions/info/$txId").as[JsValue]
+      hasPositiveHeight1 = (jsv1 \ "height").asOpt[Int].map(_ > 0)
+      _ = assert(hasPositiveHeight1.getOrElse(false))
+
+      jsv2 <- sender.get(s"/transactions/address/$firstAddress/limit/1").as[JsArray]
+      hasPositiveHeight2 = (jsv2(0)(0) \ "height").asOpt[Int].map(_ > 0)
+      _ = assert(hasPositiveHeight2.getOrElse(false))
+    } yield succeed
+
+    Await.result(f, 2.minutes)
   }
 }

--- a/src/main/scala/com/wavesplatform/state2/reader/SnapshotStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/SnapshotStateReader.scala
@@ -76,8 +76,10 @@ object SnapshotStateReader {
 
     def included(signature: ByteStr): Option[Int] = s.transactionInfo(signature).map(_._1)
 
-    def accountTransactions(account: Address, limit: Int): Seq[_ <: Transaction] = s.read { _ =>
-      s.accountTransactionIds(account, limit).flatMap(s.transactionInfo).flatMap(_._2)
+    def accountTransactions(account: Address, limit: Int): Seq[(Int, _ <: Transaction)] = s.read { _ =>
+      s.accountTransactionIds(account, limit)
+        .flatMap(s.transactionInfo)
+        .flatMap { case (h, txopt) => txopt.map((h, _)) }
     }
 
     def balance(account: Address): Long = s.wavesBalance(account)._1

--- a/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -52,7 +52,10 @@ case class TransactionsApiRoute(
               path(Segment) { limitStr =>
                 Exception.allCatch.opt(limitStr.toInt) match {
                   case Some(limit) if limit > 0 && limit <= MaxTransactionsPerRequest =>
-                    complete(Json.arr(JsArray(state().accountTransactions(a, limit).map(txToExtendedJson))))
+                    complete(Json.arr(JsArray(
+                      state().accountTransactions(a, limit).map { case (h, tx) =>
+                        txToExtendedJson(tx) + ("height" -> JsNumber(h))
+                    })))
                   case Some(limit) if limit > MaxTransactionsPerRequest =>
                     complete(TooBigArrayAllocation)
                   case _ =>

--- a/src/test/scala/com/wavesplatform/state2/reader/StateReaderLastTransactionsTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/reader/StateReaderLastTransactionsTest.scala
@@ -29,12 +29,14 @@ class StateReaderLastTransactionsTest extends PropSpec
     forAll(preconditionsAndPayment) { case ((pre, payment)) =>
       assertDiffAndState(Seq(TestBlock.create(pre)), TestBlock.create(Seq(payment))) { (blockDiff, newState) =>
 
-        newState.accountTransactions(payment.sender, 1) shouldBe Seq(payment)
+        def transactions(count: Int) = newState.accountTransactions(payment.sender, count).map(_._2)
+
+        transactions(1) shouldBe Seq(payment)
         val g = pre.head
         val tx1 = pre(1)
         val tx2 = pre(2)
-        newState.accountTransactions(payment.sender, 3) shouldBe Seq(payment, tx2, tx1)
-        newState.accountTransactions(payment.sender, 10) shouldBe Seq(payment, tx2, tx1, g)
+        transactions(3) shouldBe Seq(payment, tx2, tx1)
+        transactions(10) shouldBe Seq(payment, tx2, tx1, g)
         newState.accountTransactionIds(TestBlock.defaultSigner, 10).size shouldBe 0
       }
     }


### PR DESCRIPTION
https://wavesplatform.atlassian.net/browse/NODE-380
Changed SnapshotStateReader to return both transactions and their heights.