### PR TITLE
NODE-364 Batch txs in tests

### DIFF
--- a/generator/src/main/scala/com.wavesplatform.generator/GeneratorSettings.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/GeneratorSettings.scala
@@ -16,7 +16,7 @@ case class GeneratorSettings(chainId: String,
                              wide: WideTransactionGenerator.Settings,
                              dynWide: DynamicWideTransactionGenerator.Settings) {
   val addressScheme: Char = chainId.head
-  val privateKeyAccounts: Seq[PrivateKeyAccount] = accounts.map(s => PrivateKeyAccount(Base58.decode(s).get))
+  val privateKeyAccounts: Seq[PrivateKeyAccount] = accounts.map(s => PrivateKeyAccount.fromSeed(s).right.get)
 }
 
 object GeneratorSettings {

--- a/src/it/scala/com/wavesplatform/it/BlockHeadersTestSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/BlockHeadersTestSuite.scala
@@ -26,7 +26,7 @@ class BlockHeadersTestSuite extends FreeSpec with Matchers with BeforeAndAfterAl
       .build()
   )
 
-  private lazy val notMiner: Node = nodes.last
+  private def notMiner: Node = nodes.last
 
   private def firstAddress = nodes(1).address
 

--- a/src/it/scala/com/wavesplatform/it/Docker.scala
+++ b/src/it/scala/com/wavesplatform/it/Docker.scala
@@ -101,6 +101,7 @@ class Docker(suiteConfig: Config = ConfigFactory.empty,
   }
 
   def startNodes(nodeConfigs: Seq[Config]): Seq[Node] = {
+    log.trace(s"Starting ${nodeConfigs.size} containers")
     val all = nodeConfigs.map(startNodeInternal)
     Await.result(
       for {

--- a/src/it/scala/com/wavesplatform/it/Docker.scala
+++ b/src/it/scala/com/wavesplatform/it/Docker.scala
@@ -2,24 +2,25 @@ package com.wavesplatform.it
 
 import java.io.FileOutputStream
 import java.nio.file.{Files, Paths}
-import java.util.{Collections, Properties, List => JList, Map => JMap}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.{Collections, Properties, List => JList, Map => JMap}
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper
 import com.google.common.collect.ImmutableMap
-import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
-import com.spotify.docker.client.messages._
 import com.spotify.docker.client.messages.EndpointConfig.EndpointIpamConfig
+import com.spotify.docker.client.messages._
+import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
 import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
+import com.wavesplatform.it.util.GlobalTimer.{instance => timer}
 import org.asynchttpclient.Dsl._
 import scorex.utils.ScorexLogging
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{blocking, Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, blocking}
 import scala.util.Random
 import scala.util.control.NonFatal
 
@@ -37,6 +38,7 @@ class Docker(suiteConfig: Config = ConfigFactory.empty,
   import Docker._
 
   private val http = asyncHttpClient(config()
+    .setNettyTimer(timer)
     .setMaxConnections(18)
     .setMaxConnectionsPerHost(3)
     .setMaxRequestRetry(1)
@@ -247,7 +249,6 @@ class Docker(suiteConfig: Config = ConfigFactory.empty,
       log.info("Stopping containers")
 
       nodes.asScala.foreach { node =>
-        node.close()
         client.stopContainer(node.nodeInfo.containerId, 0)
 
         saveLog(node)

--- a/src/it/scala/com/wavesplatform/it/MicroblocksFeeTestSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/MicroblocksFeeTestSuite.scala
@@ -78,12 +78,12 @@ class MicroblocksFeeTestSuite extends FreeSpec with Matchers with BeforeAndAfter
       }
 
       balancesOnActivation(blockOnActivation.generator) shouldBe {
-        balancesBeforeActivation(blockOnActivation.generator) + blockOnActivation.fee * 0.4
+        balancesBeforeActivation(blockOnActivation.generator) + blockOnActivation.fee * 4 / 10
       }
 
       balancesAfterActivation(blockAfterActivation.generator) shouldBe {
-        balancesOnActivation(blockAfterActivation.generator) +
-          blockOnActivation.fee * 0.6 + blockAfterActivation.fee * 0.4
+        balancesOnActivation(blockAfterActivation.generator) + blockOnActivation.fee * 6 / 10 +
+          blockAfterActivation.fee * 4 / 10
       }
     }
 

--- a/src/it/scala/com/wavesplatform/it/MicroblocksGenerationSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/MicroblocksGenerationSuite.scala
@@ -57,7 +57,7 @@ class MicroblocksGenerationSuite extends FreeSpec with BeforeAndAfterAll
 
   lazy val docker: Docker = Docker(getClass)
   lazy val nodes: Seq[Node] = docker.startNodes(Seq(config))
-  private lazy val miner = nodes.head
+  private def miner = nodes.head
 
   s"Generate transactions and wait for one block with $maxTxs txs" in result(for {
     richAccountsWithBalance <- Future.traverse(nodes)(balanceForNode).map(_.toMap)

--- a/src/it/scala/com/wavesplatform/it/NodeConfigs.scala
+++ b/src/it/scala/com/wavesplatform/it/NodeConfigs.scala
@@ -18,7 +18,7 @@ object NodeConfigs {
                      specialsConfigs: Seq[Config]) {
     def overrideBase(f: Templates.type => String): Builder = {
       val priorityConfig = ConfigFactory.parseString(f(Templates))
-      copy(baseConfigs = baseConfigs.map(priorityConfig.withFallback))
+      copy(baseConfigs = this.baseConfigs.map(priorityConfig.withFallback))
     }
 
     def withDefault(entitiesNumber: Int): Builder = copy(defaultEntities = entitiesNumber)
@@ -27,14 +27,14 @@ object NodeConfigs {
 
     def withSpecial(entitiesNumber: Int, f: Templates.type => String): Builder = {
       val newSpecialConfig = ConfigFactory.parseString(f(Templates))
-      copy(specialsConfigs = specialsConfigs ++ (1 to entitiesNumber).map(_ => newSpecialConfig))
+      copy(specialsConfigs = this.specialsConfigs ++ (1 to entitiesNumber).map(_ => newSpecialConfig))
     }
 
-    def build(shuffling: Boolean = true): Seq[Config] = {
+    def build(shuffleNodes: Boolean = true): Seq[Config] = {
       val totalEntities = defaultEntities + specialsConfigs.size
       require(totalEntities < baseConfigs.size)
 
-      val baseConfigsShuffled = if (shuffling) Random.shuffle(baseConfigs) else baseConfigs
+      val baseConfigsShuffled = if (shuffleNodes) Random.shuffle(baseConfigs) else baseConfigs
       val (defaultNodes: Seq[Config], specialNodes: Seq[Config]) = baseConfigsShuffled
         .take(totalEntities)
         .splitAt(defaultEntities)

--- a/src/it/scala/com/wavesplatform/it/RollbackSpecSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/RollbackSpecSuite.scala
@@ -26,9 +26,7 @@ class RollbackSpecSuite extends FreeSpec with ScalaFutures with IntegrationPatie
       startHeight <- Future.traverse(nodes)(_.height).map(_.min)
 
       b <- traverse(nodes)(balanceForNode).map(_.toMap)
-
-      requests = generateTransfersBetweenAccounts(transactionsCount, b)
-      _ <- processRequests(requests)
+      _ <- processRequests(generateTransfersBetweenAccounts(transactionsCount, b))
 
       hashAfterFirstTry <- traverse(nodes)(_.waitForDebugInfoAt(startHeight + waitBlocks).map(_.stateHash)).map(infos => {
         all(infos) shouldEqual infos.head

--- a/src/it/scala/com/wavesplatform/it/TransferSending.scala
+++ b/src/it/scala/com/wavesplatform/it/TransferSending.scala
@@ -27,9 +27,9 @@ trait TransferSending extends ScorexLogging {
 
   def generateTransfersBetweenAccounts(n: Int, balances: Map[String, Long]): Seq[Req] = {
     val fee = 100000
-    val privateKeys = nodes.map { x => (x.accountSeed, PrivateKeyAccount.fromSeed(x.accountSeed).right.get) }
+    val srcDest = nodes.map { x => (x.accountSeed, PrivateKeyAccount.fromSeed(x.accountSeed).right.get) }
     val sourceAndDest = (1 to n).map { _ =>
-      val Seq((srcSeed, _), (_, destPrivateKey)) = Random.shuffle(privateKeys).take(2)
+      val Seq((srcSeed, _), (_, destPrivateKey)) = Random.shuffle(srcDest).take(2)
       (srcSeed, destPrivateKey.address)
     }
     val requests = sourceAndDest.foldLeft(List.empty[Req]) {
@@ -90,7 +90,7 @@ trait TransferSending extends ScorexLogging {
     nodes.head.batchSignedTransfer(xs).map(_.lastOption)
   }
 
-  private def createSignedTransferRequest(tx: TransferTransaction): SignedTransferRequest = {
+  protected def createSignedTransferRequest(tx: TransferTransaction): SignedTransferRequest = {
     import tx._
     SignedTransferRequest(
       Base58.encode(tx.sender.publicKey),

--- a/src/it/scala/com/wavesplatform/it/TransferSending.scala
+++ b/src/it/scala/com/wavesplatform/it/TransferSending.scala
@@ -30,7 +30,7 @@ trait TransferSending extends ScorexLogging {
     val privateKeys = nodes.map(_.accountSeed)
     val sourceAndDest = (1 to n).map { _ =>
       val Seq(srcSeed, destSeed) = Random.shuffle(privateKeys).take(2)
-      (srcSeed, PrivateKeyAccount.fromBase58Seed(destSeed).right.get.address)
+      (srcSeed, PrivateKeyAccount.fromSeed(destSeed).right.get.address)
     }
     val requests = sourceAndDest.foldLeft(List.empty[Req]) {
       case (rs, (src, dest)) =>
@@ -76,7 +76,7 @@ trait TransferSending extends ScorexLogging {
       createSignedTransferRequest(TransferTransaction
         .create(
           assetId = None,
-          sender = PrivateKeyAccount.fromBase58Seed(x.senderSeed).right.get,
+          sender = PrivateKeyAccount.fromSeed(x.senderSeed).right.get,
           recipient = AddressOrAlias.fromString(x.targetAddress).right.get,
           amount = x.amount,
           timestamp = start + i,

--- a/src/it/scala/com/wavesplatform/it/WideStateGenerationSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/WideStateGenerationSuite.scala
@@ -28,7 +28,7 @@ class WideStateGenerationSuite extends FreeSpec with IntegrationNodesInitializat
   private val requestsCount = 10000
 
   "Generate a lot of transactions and synchronise" in result(for {
-    b <- traverse(nodes)(balanceForNode1).map(_.toMap)
+    b <- traverse(nodes)(balanceForNode).map(_.toMap)
     lastTx <- {
       log.debug(
         s"""Balances:

--- a/src/it/scala/com/wavesplatform/it/WideStateGenerationSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/WideStateGenerationSuite.scala
@@ -34,7 +34,6 @@ class WideStateGenerationSuite extends FreeSpec with IntegrationNodesInitializat
         s"""Balances:
            |${b.map { case (account, balance) => s"$account -> $balance" }.mkString("\n")}""".stripMargin)
 
-      // Can take up to 10 minutes!
       processRequests(generateTransfersToRandomAddresses(requestsCount / 2, b) ++ generateTransfersBetweenAccounts(requestsCount / 2, b))
     }
 
@@ -49,6 +48,6 @@ class WideStateGenerationSuite extends FreeSpec with IntegrationNodesInitializat
       log.debug(s"waitForSameBlocksAt($height)")
       waitForSameBlocksAt(nodes, 5.seconds, height)
     }
-  } yield (), 7.minutes)
+  } yield (), 15.minutes)
 
 }

--- a/src/it/scala/com/wavesplatform/it/activation/VoteForFeatureByDefaultTestSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/activation/VoteForFeatureByDefaultTestSuite.scala
@@ -18,7 +18,8 @@ class VoteForFeatureByDefaultTestSuite extends FreeSpec with Matchers with Befor
   private lazy val docker = Docker(getClass)
   override lazy val nodes: Seq[Node] = docker.startNodes(Configs)
 
-  private lazy val notSupportedNode +: supportedNodes = nodes
+  private def notSupportedNode = nodes.head
+  private def supportedNodes = nodes.tail
 
   val defaultVotingFeatureNum: Short = 1
 

--- a/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
+++ b/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
@@ -230,7 +230,7 @@ trait NodeApi {
       .recoverWith {
         case e@(_: IOException | _: TimeoutException) =>
           log.debug(s"Failed to execute request '$request' with error: ${e.getMessage}")
-          aux
+          timer.schedule(aux, 20.seconds)
       }
 
     aux.as[Seq[Transaction]]

--- a/src/it/scala/com/wavesplatform/it/matcher/MatcherTestSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/matcher/MatcherTestSuite.scala
@@ -93,10 +93,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
 
   "froze amount should be listed via matcherBalance REST endpoint" in {
     val ts = System.currentTimeMillis()
-    val privateKey = PrivateKeyAccount(Base58.decode(aliceNode.accountSeed).get)
-
-    val pk = Base58.decode(aliceNode.publicKey).get
-    val signature = Base58.encode(EllipticCurveImpl.sign(privateKey, pk ++ Longs.toByteArray(ts)))
+    val privateKey = PrivateKeyAccount.fromSeed(aliceNode.accountSeed).right.get
+    val signature = Base58.encode(EllipticCurveImpl.sign(privateKey, privateKey.publicKey ++ Longs.toByteArray(ts)))
 
     val json = parse(Await.result(matcherNode.matcherGet(s"/matcher/matcherBalance/${aliceNode.publicKey}", _
       .addHeader("Timestamp", ts)
@@ -107,10 +105,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
 
   "and should be listed by trader's publiс key via REST" in {
     val ts = System.currentTimeMillis()
-    val privateKey = PrivateKeyAccount(Base58.decode(aliceNode.accountSeed).get)
-
-    val pk = Base58.decode(aliceNode.publicKey).get
-    val signature = Base58.encode(EllipticCurveImpl.sign(privateKey, pk ++ Longs.toByteArray(ts)))
+    val privateKey = PrivateKeyAccount.fromSeed(aliceNode.accountSeed).right.get
+    val signature = Base58.encode(EllipticCurveImpl.sign(privateKey, privateKey.publicKey ++ Longs.toByteArray(ts)))
 
     val json = parse(Await.result(matcherNode.matcherGet(s"/matcher/orderbook/${aliceNode.publicKey}", _
       .addHeader("Timestamp", ts)
@@ -321,7 +317,7 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
     val creationTime = System.currentTimeMillis()
     val timeToLive = creationTime + Order.MaxLiveTime - 1000
 
-    val privateKey = PrivateKeyAccount(Base58.decode(node.accountSeed).get)
+    val privateKey = PrivateKeyAccount.fromSeed(node.accountSeed).right.get
     val matcherPublicKey = PublicKeyAccount(Base58.decode(matcherNode.publicKey).get)
 
     Order(privateKey, matcherPublicKey, pair, orderType, price, amount, creationTime, timeToLive, MatcherFee)
@@ -363,8 +359,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
   }
 
   private def matcherCancelOrder(node: Node, pair: AssetPair, orderId: String): String = {
-    val privateKey = PrivateKeyAccount(Base58.decode(node.accountSeed).get)
-    val publicKey = PublicKeyAccount(Base58.decode(node.publicKey).get)
+    val privateKey = PrivateKeyAccount.fromSeed(node.accountSeed).right.get
+    val publicKey = PublicKeyAccount(privateKey.publicKey)
     val request = CancelOrderRequest(publicKey, Base58.decode(orderId).get, Array.emptyByteArray)
     val signedRequest = CancelOrderRequest.sign(request, privateKey)
     val futureResult = matcherNode.cancelOrder(pair.amountAssetStr, pair.priceAssetStr, signedRequest)

--- a/src/it/scala/com/wavesplatform/it/matcher/OrderExclusionTestSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/matcher/OrderExclusionTestSuite.scala
@@ -82,7 +82,7 @@ class OrderExclusionTestSuite extends FreeSpec with Matchers with BeforeAndAfter
 
   private def orderStatus(node: Node) = {
     val ts = System.currentTimeMillis()
-    val privateKey = PrivateKeyAccount(Base58.decode(aliceNode.accountSeed).get)
+    val privateKey = PrivateKeyAccount.fromSeed(aliceNode.accountSeed).right.get
 
     val pk = Base58.decode(node.publicKey).get
     val signature = ByteStr(EllipticCurveImpl.sign(privateKey, pk ++ Longs.toByteArray(ts)))

--- a/src/it/scala/com/wavesplatform/it/matcher/OrderGenerator.scala
+++ b/src/it/scala/com/wavesplatform/it/matcher/OrderGenerator.scala
@@ -15,7 +15,7 @@ trait OrderGenerator {
     val creationTime = System.currentTimeMillis()
     val timeToLiveTimestamp = creationTime + timeToLive.toMillis
 
-    val privateKey = PrivateKeyAccount(Base58.decode(node.accountSeed).get)
+    val privateKey = PrivateKeyAccount.fromSeed(node.accountSeed).right.get
     val matcherPublicKey = PublicKeyAccount(Base58.decode(matcherNode.publicKey).get)
 
     Order(privateKey, matcherPublicKey, pair, orderType, price, amount, creationTime, timeToLiveTimestamp, MatcherFee)

--- a/src/it/scala/com/wavesplatform/it/network/SimpleTransactionsSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/network/SimpleTransactionsSuite.scala
@@ -34,7 +34,7 @@ class SimpleTransactionsSuite extends FunSuite with BeforeAndAfterAll with Match
 
   test("valid tx send by network to node should be in blockchain") {
     val tx = TransferTransaction.create(None,
-      PrivateKeyAccount(Base58.decode(node.accountSeed).get),
+      PrivateKeyAccount.fromSeed(node.accountSeed).right.get,
       Address.fromString(node.address).right.get,
       1L,
       System.currentTimeMillis(),
@@ -56,7 +56,7 @@ class SimpleTransactionsSuite extends FunSuite with BeforeAndAfterAll with Match
 
   test("invalid tx send by network to node should be not in UTX or blockchain") {
     val tx = TransferTransaction.create(None,
-      PrivateKeyAccount(Base58.decode(node.accountSeed).get),
+      PrivateKeyAccount.fromSeed(node.accountSeed).right.get,
       Address.fromString(node.address).right.get,
       1L,
       System.currentTimeMillis() + (1 days).toMillis,

--- a/src/it/scala/com/wavesplatform/it/network/SimpleTransactionsSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/network/SimpleTransactionsSuite.scala
@@ -9,7 +9,6 @@ import com.wavesplatform.network.{RawBytes, TransactionSpec}
 import org.scalatest._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import scorex.account.{Address, PrivateKeyAccount}
-import scorex.crypto.encode.Base58
 import scorex.transaction.assets.TransferTransaction
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/it/scala/com/wavesplatform/it/transactions/AliasTransactionSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/AliasTransactionSuite.scala
@@ -62,7 +62,7 @@ class AliasTransactionSuite extends BaseTransactionSuite with TableDrivenPropert
       aliasTxId <- sender.createAlias(firstAddress, alias, aliasFee).map(_.id)
 
       _ <- waitForHeightAraiseAndTxPresent(aliasTxId, 1)
-      _ <- assertBadRequestAndMessage(sender.createAlias(secondAddress, alias, aliasFee), "Tx with such id already present")
+      _ <- assertBadRequestAndMessage(sender.createAlias(secondAddress, alias, aliasFee), "already in the state")
       _ <- assertBalances(firstAddress, balance - aliasFee, effectiveBalance - aliasFee)
     } yield succeed
 

--- a/src/it/scala/com/wavesplatform/it/transactions/BaseTransactionSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/BaseTransactionSuite.scala
@@ -18,6 +18,6 @@ abstract class BaseTransactionSuite extends FunSuite with IntegrationNodesInitia
       .build()
   )
 
-  override lazy val notMiner: Node = nodes.last
+  override def notMiner: Node = nodes.last
 
 }

--- a/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
@@ -1,20 +1,19 @@
 package com.wavesplatform.it.transactions
 
+import com.wavesplatform.it.TransferSending
 import com.wavesplatform.it.api._
 import com.wavesplatform.it.util._
 import org.scalatest.CancelAfterFailure
 import play.api.libs.json.{JsArray, JsValue}
 import scorex.account.{AddressOrAlias, PrivateKeyAccount}
 import scorex.api.http.Mistiming
-import scorex.api.http.assets.SignedTransferRequest
-import scorex.crypto.encode.Base58
 import scorex.transaction.assets.TransferTransaction
 
 import scala.concurrent.Await
 import scala.concurrent.Future.{sequence, traverse}
 import scala.concurrent.duration._
 
-class TransferTransactionSuite extends BaseTransactionSuite with CancelAfterFailure {
+class TransferTransactionSuite extends BaseTransactionSuite with TransferSending with CancelAfterFailure {
 
   private val waitCompletion = 2.minutes
   private val defaultQuantity = 100000
@@ -55,21 +54,6 @@ class TransferTransactionSuite extends BaseTransactionSuite with CancelAfterFail
   }
 
   test("invalid signed waves transfer should not be in UTX or blockchain") {
-    def createSignedTransferRequest(tx: TransferTransaction): SignedTransferRequest = {
-      import tx._
-      SignedTransferRequest(
-        Base58.encode(tx.sender.publicKey),
-        assetId.map(_.base58),
-        recipient.stringRepr,
-        amount,
-        fee,
-        feeAssetId.map(_.base58),
-        timestamp,
-        attachment.headOption.map(_ => Base58.encode(attachment)),
-        signature.base58
-      )
-    }
-
     val invalidByTsTx = TransferTransaction.create(None,
       PrivateKeyAccount.fromSeed(sender.accountSeed).right.get,
       AddressOrAlias.fromString(sender.address).right.get,
@@ -81,7 +65,6 @@ class TransferTransactionSuite extends BaseTransactionSuite with CancelAfterFail
     ).right.get
 
     val invalidTxId = invalidByTsTx.id()
-
     val invalidByTsSignedRequest = createSignedTransferRequest(invalidByTsTx)
 
     val f = for {

--- a/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
@@ -71,7 +71,7 @@ class TransferTransactionSuite extends BaseTransactionSuite with CancelAfterFail
     }
 
     val invalidByTsTx = TransferTransaction.create(None,
-      PrivateKeyAccount(Base58.decode(sender.accountSeed).get),
+      PrivateKeyAccount.fromSeed(sender.accountSeed).right.get,
       AddressOrAlias.fromString(sender.address).right.get,
       1,
       System.currentTimeMillis() + 1.day.toMillis,

--- a/src/it/scala/com/wavesplatform/it/util/GlobalTimer.scala
+++ b/src/it/scala/com/wavesplatform/it/util/GlobalTimer.scala
@@ -1,0 +1,12 @@
+package com.wavesplatform.it.util
+
+import io.netty.util.{HashedWheelTimer, Timer}
+
+object GlobalTimer {
+
+  val instance: Timer = new HashedWheelTimer()
+  sys.addShutdownHook {
+    instance.stop()
+  }
+
+}

--- a/src/main/scala/com/wavesplatform/UtxPool.scala
+++ b/src/main/scala/com/wavesplatform/UtxPool.scala
@@ -8,7 +8,6 @@ import com.wavesplatform.UtxPoolImpl.PessimisticPortfolios
 import com.wavesplatform.metrics.Instrumented
 import com.wavesplatform.settings.{FunctionalitySettings, UtxSettings}
 import com.wavesplatform.state2.diffs.TransactionDiffer
-import com.wavesplatform.state2.diffs.TransactionDiffer.TransactionValidationError
 import com.wavesplatform.state2.reader.CompositeStateReader.composite
 import com.wavesplatform.state2.{ByteStr, Diff, Portfolio, StateReader}
 import kamon.Kamon
@@ -113,14 +112,8 @@ class UtxPoolImpl(time: Time,
               true
           }
 
-          val r: Either[ValidationError, Boolean] = added match {
-            case Left(TransactionValidationError(_: ValidationError.AlreadyInTheState, _)) => Right(false)
-            case Left(e) => Left(e)
-            case Right(x) => Right(x)
-          }
-
-          knownTransactions.put(tx.id(), r)
-          r
+          knownTransactions.put(tx.id(), added)
+          added
       }
     })
   }

--- a/src/main/scala/com/wavesplatform/UtxPool.scala
+++ b/src/main/scala/com/wavesplatform/UtxPool.scala
@@ -8,6 +8,7 @@ import com.wavesplatform.UtxPoolImpl.PessimisticPortfolios
 import com.wavesplatform.metrics.Instrumented
 import com.wavesplatform.settings.{FunctionalitySettings, UtxSettings}
 import com.wavesplatform.state2.diffs.TransactionDiffer
+import com.wavesplatform.state2.diffs.TransactionDiffer.TransactionValidationError
 import com.wavesplatform.state2.reader.CompositeStateReader.composite
 import com.wavesplatform.state2.{ByteStr, Diff, Portfolio, StateReader}
 import kamon.Kamon
@@ -113,7 +114,7 @@ class UtxPoolImpl(time: Time,
           }
 
           val r: Either[ValidationError, Boolean] = added match {
-            case Left(_: ValidationError.AlreadyInTheState) => Right(false)
+            case Left(TransactionValidationError(_: ValidationError.AlreadyInTheState, _)) => Right(false)
             case Left(e) => Left(e)
             case Right(x) => Right(x)
           }

--- a/src/main/scala/com/wavesplatform/UtxPool.scala
+++ b/src/main/scala/com/wavesplatform/UtxPool.scala
@@ -111,7 +111,7 @@ class UtxPoolImpl(time: Time,
           }
 
           val r: Either[ValidationError, Boolean] = added match {
-            case Left(_: ValidationError.AlreadyInThePool) => Option(knownTransactions.getIfPresent(tx.id())).getOrElse(Right(true))
+            case Left(_: ValidationError.AlreadyInTheState) => Option(knownTransactions.getIfPresent(tx.id())).getOrElse(Right(true))
             case Left(e) => Left(e)
             case Right(x) => Right(x)
           }

--- a/src/main/scala/com/wavesplatform/UtxPool.scala
+++ b/src/main/scala/com/wavesplatform/UtxPool.scala
@@ -105,7 +105,7 @@ class UtxPoolImpl(time: Time,
           } yield {
             utxPoolSizeStats.increment()
             pessimisticPortfolios.add(tx.id(), diff)
-            transactions.put(tx.id(), tx)
+            transactions.putIfAbsent(tx.id(), tx)
             tx
           }
 

--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -224,7 +224,7 @@ class OrderBookActor(assetPair: AssetPair,
           _ <- utx.putIfNew(tx)
         } yield tx) match {
           case Right(tx) if tx.isInstanceOf[ExchangeTransaction] =>
-            allChannels.broadcast(RawBytes(TransactionSpec.messageCode, tx.bytes()))
+            allChannels.broadcastTx(tx)
             processEvent(event)
             context.system.eventStream.publish(ExchangeTransactionCreated(tx.asInstanceOf[ExchangeTransaction]))
             if (event.submittedRemaining > 0)

--- a/src/main/scala/com/wavesplatform/network/UtxPoolSynchronizer.scala
+++ b/src/main/scala/com/wavesplatform/network/UtxPoolSynchronizer.scala
@@ -21,7 +21,7 @@ class UtxPoolSynchronizer(utx: UtxPool, allChannels: ChannelGroup)
   override def channelRead(ctx: ChannelHandlerContext, msg: AnyRef): Unit = msg match {
     case t: Transaction => Task(utx.putIfNew(t) match {
       case Right(true) => // log.trace(s"${id(ctx)} Added transaction ${t.id} to UTX pool")
-        allChannels.broadcast(RawBytes(TransactionSpec.messageCode, t.bytes()), Some(ctx.channel()))
+        allChannels.broadcastTx(t, Some(ctx.channel()))
       case Left(TransactionValidationError(e, _)) => // log.trace(s"${id(ctx)} Error processing transaction ${t.id}: $e")
       case Left(e) => // log.trace(s"${id(ctx)} Error processing transaction ${t.id}: $e")
       case Right(false) => // log.trace(s"${id(ctx)} TX ${t.id} already known")

--- a/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.settings.FunctionalitySettings
 import com.wavesplatform.state2.reader.SnapshotStateReader
 import com.wavesplatform.state2.{Portfolio, _}
 import scorex.account.Address
-import scorex.transaction.ValidationError.{GenericError, Mistiming}
+import scorex.transaction.ValidationError.{AlreadyInThePool, GenericError, Mistiming}
 import scorex.transaction._
 import scorex.transaction.assets._
 import scorex.transaction.assets.exchange.ExchangeTransaction
@@ -59,7 +59,7 @@ object CommonValidation {
     case _ =>
       if (state.containsTransaction(tx.id())) {
         val txHeight = state.transactionInfo(tx.id()).map(_._1)
-        Left(GenericError(s"Txs cannot be duplicated. Target height is: $height, current height is: ${state.height}, existing tx height is: $txHeight Tx with such id already present"))
+        Left(AlreadyInThePool(tx.id(), s"Txs cannot be duplicated. Target height is: $height, current height is: ${state.height}, existing tx height is: $txHeight Tx with such id already present"))
       }
       else Right(tx)
   }

--- a/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.settings.FunctionalitySettings
 import com.wavesplatform.state2.reader.SnapshotStateReader
 import com.wavesplatform.state2.{Portfolio, _}
 import scorex.account.Address
-import scorex.transaction.ValidationError.{AlreadyInThePool, GenericError, Mistiming}
+import scorex.transaction.ValidationError.{AlreadyInTheState, GenericError, Mistiming}
 import scorex.transaction._
 import scorex.transaction.assets._
 import scorex.transaction.assets.exchange.ExchangeTransaction
@@ -59,7 +59,7 @@ object CommonValidation {
     case _ =>
       if (state.containsTransaction(tx.id())) {
         val txHeight = state.transactionInfo(tx.id()).map(_._1)
-        Left(AlreadyInThePool(tx.id(), s"Txs cannot be duplicated. Target height is: $height, current height is: ${state.height}, existing tx height is: $txHeight Tx with such id already present"))
+        Left(AlreadyInTheState(tx.id(), s"Txs cannot be duplicated. Target height is: $height, current height is: ${state.height}, existing tx height is: $txHeight Tx with such id already present"))
       }
       else Right(tx)
   }

--- a/src/main/scala/scorex/BroadcastRoute.scala
+++ b/src/main/scala/scorex/BroadcastRoute.scala
@@ -3,9 +3,7 @@ package scorex
 import com.wavesplatform.UtxPool
 import com.wavesplatform.network._
 import io.netty.channel.group.ChannelGroup
-import play.api.libs.json.JsObject
 import scorex.api.http.ApiError
-import scorex.api.http.assets.SignedTransferRequest
 import scorex.transaction.{Transaction, ValidationError}
 
 import scala.concurrent.Future
@@ -27,15 +25,6 @@ trait BroadcastRoute {
       }
       tx
     }).left.map(ApiError.fromValidationError)
-  }
 
-  protected def addToUtx(req: SignedTransferRequest): Either[ValidationError, (Transaction, Boolean)] = for {
-    tx <- req.toTx
-    added <- utx.putIfNew(tx)
-  } yield (tx, added)
-
-  protected def toResponse(x: Either[ValidationError, Transaction]): JsObject = x match {
-    case Left(e) => ApiError.fromValidationError(e).json
-    case Right(tx) => tx.json()
   }
 }

--- a/src/main/scala/scorex/BroadcastRoute.scala
+++ b/src/main/scala/scorex/BroadcastRoute.scala
@@ -29,14 +29,10 @@ trait BroadcastRoute {
     }).left.map(ApiError.fromValidationError)
   }
 
-  protected def addToUtx(req: SignedTransferRequest): Either[ApiError, (Transaction, Boolean)] = {
-    val r = for {
-      tx <- req.toTx
-      added <- utx.putIfNew(tx)
-    } yield (tx, added)
-
-    r.left.map(ApiError.fromValidationError)
-  }
+  protected def addToUtx(req: SignedTransferRequest): Either[ValidationError, (Transaction, Boolean)] = for {
+    tx <- req.toTx
+    added <- utx.putIfNew(tx)
+  } yield (tx, added)
 
   protected def toResponse(x: Either[ValidationError, Transaction]): JsObject = x match {
     case Left(e) => ApiError.fromValidationError(e).json

--- a/src/main/scala/scorex/account/PrivateKeyAccount.scala
+++ b/src/main/scala/scorex/account/PrivateKeyAccount.scala
@@ -20,7 +20,7 @@ object PrivateKeyAccount {
     PrivateKeyAccountImpl(seed, pair._1, pair._2)
   }
 
-  def fromBase58String(s: String): Either[GenericError, PrivateKeyAccount] =
+  def fromBase58Seed(s: String): Either[GenericError, PrivateKeyAccount] =
     (for {
       _ <- Either.cond(s.length <= TransactionParser.KeyStringLength, (), "Bad private key string length")
       bytes <- Base58.decode(s).toEither.left.map(ex => s"Unable to decode base58: ${ex.getMessage}")

--- a/src/main/scala/scorex/account/PrivateKeyAccount.scala
+++ b/src/main/scala/scorex/account/PrivateKeyAccount.scala
@@ -1,6 +1,9 @@
 package scorex.account
 
 import scorex.crypto.EllipticCurveImpl
+import scorex.crypto.encode.Base58
+import scorex.transaction.TransactionParser
+import scorex.transaction.ValidationError.GenericError
 
 sealed trait PrivateKeyAccount extends PublicKeyAccount {
   def seed: Array[Byte]
@@ -16,5 +19,11 @@ object PrivateKeyAccount {
     val pair = EllipticCurveImpl.createKeyPair(seed)
     PrivateKeyAccountImpl(seed, pair._1, pair._2)
   }
+
+  def fromBase58String(s: String): Either[GenericError, PrivateKeyAccount] =
+    (for {
+      _ <- Either.cond(s.length <= TransactionParser.KeyStringLength, (), "Bad private key string length")
+      bytes <- Base58.decode(s).toEither.left.map(ex => s"Unable to decode base58: ${ex.getMessage}")
+    } yield PrivateKeyAccount(bytes)).left.map(err => GenericError(s"Can't parse '$s' as private key: $err"))
 
 }

--- a/src/main/scala/scorex/account/PrivateKeyAccount.scala
+++ b/src/main/scala/scorex/account/PrivateKeyAccount.scala
@@ -2,7 +2,6 @@ package scorex.account
 
 import scorex.crypto.EllipticCurveImpl
 import scorex.crypto.encode.Base58
-import scorex.transaction.TransactionParser
 import scorex.transaction.ValidationError.GenericError
 
 sealed trait PrivateKeyAccount extends PublicKeyAccount {
@@ -20,10 +19,9 @@ object PrivateKeyAccount {
     PrivateKeyAccountImpl(seed, pair._1, pair._2)
   }
 
-  def fromBase58Seed(s: String): Either[GenericError, PrivateKeyAccount] =
-    (for {
-      _ <- Either.cond(s.length <= TransactionParser.KeyStringLength, (), "Bad private key string length")
-      bytes <- Base58.decode(s).toEither.left.map(ex => s"Unable to decode base58: ${ex.getMessage}")
-    } yield PrivateKeyAccount(bytes)).left.map(err => GenericError(s"Can't parse '$s' as private key: $err"))
+  def fromSeed(s: String): Either[GenericError, PrivateKeyAccount] = Base58.decode(s)
+    .toEither
+    .right.map(PrivateKeyAccount(_))
+    .left.map(ex => GenericError(s"Unable to get a private key from the seed '$s': ${ex.getMessage}"))
 
 }

--- a/src/main/scala/scorex/account/PrivateKeyAccount.scala
+++ b/src/main/scala/scorex/account/PrivateKeyAccount.scala
@@ -4,6 +4,8 @@ import scorex.crypto.EllipticCurveImpl
 import scorex.crypto.encode.Base58
 import scorex.transaction.ValidationError.GenericError
 
+import scala.util.{Failure, Success}
+
 sealed trait PrivateKeyAccount extends PublicKeyAccount {
   def seed: Array[Byte]
 
@@ -19,9 +21,9 @@ object PrivateKeyAccount {
     PrivateKeyAccountImpl(seed, pair._1, pair._2)
   }
 
-  def fromSeed(s: String): Either[GenericError, PrivateKeyAccount] = Base58.decode(s)
-    .toEither
-    .right.map(PrivateKeyAccount(_))
-    .left.map(ex => GenericError(s"Unable to get a private key from the seed '$s': ${ex.getMessage}"))
+  def fromSeed(s: String): Either[GenericError, PrivateKeyAccount] = Base58.decode(s) match {
+    case Success(x) => Right(PrivateKeyAccount(x))
+    case Failure(e) => Left(GenericError(s"Unable to get a private key from the seed '$s': ${e.getMessage}"))
+  }
 
 }

--- a/src/main/scala/scorex/api/http/ApiError.scala
+++ b/src/main/scala/scorex/api/http/ApiError.scala
@@ -34,7 +34,7 @@ object ApiError {
     case ValidationError.ToSelf => ToSelfError
     case ValidationError.MissingSenderPrivateKey => MissingSenderPrivateKey
     case ValidationError.GenericError(ge) => CustomValidationError(ge)
-    case ValidationError.AlreadyInThePool(tx) => CustomValidationError(s"Transaction $tx already in the pool")
+    case ValidationError.AlreadyInThePool(tx, _) => CustomValidationError(s"Transaction $tx already in the pool")
     case ValidationError.AccountBalanceError(errs) => CustomValidationError(errs.values.mkString(", "))
     case ValidationError.AliasNotExists(tx) => AliasNotExists(tx)
     case ValidationError.OrderValidationError(_, m) => CustomValidationError(m)

--- a/src/main/scala/scorex/api/http/ApiError.scala
+++ b/src/main/scala/scorex/api/http/ApiError.scala
@@ -34,7 +34,7 @@ object ApiError {
     case ValidationError.ToSelf => ToSelfError
     case ValidationError.MissingSenderPrivateKey => MissingSenderPrivateKey
     case ValidationError.GenericError(ge) => CustomValidationError(ge)
-    case ValidationError.AlreadyInThePool(tx, _) => CustomValidationError(s"Transaction $tx already in the pool")
+    case ValidationError.AlreadyInTheState(tx, _) => CustomValidationError(s"Transaction $tx is already in the state")
     case ValidationError.AccountBalanceError(errs) => CustomValidationError(errs.values.mkString(", "))
     case ValidationError.AliasNotExists(tx) => AliasNotExists(tx)
     case ValidationError.OrderValidationError(_, m) => CustomValidationError(m)

--- a/src/main/scala/scorex/api/http/ApiError.scala
+++ b/src/main/scala/scorex/api/http/ApiError.scala
@@ -34,7 +34,7 @@ object ApiError {
     case ValidationError.ToSelf => ToSelfError
     case ValidationError.MissingSenderPrivateKey => MissingSenderPrivateKey
     case ValidationError.GenericError(ge) => CustomValidationError(ge)
-    case ValidationError.AlreadyInTheState(tx, _) => CustomValidationError(s"Transaction $tx is already in the state")
+    case ValidationError.AlreadyInTheState(tx, txHeight) => CustomValidationError(s"Transaction $tx is already in the state on a height of $txHeight")
     case ValidationError.AccountBalanceError(errs) => CustomValidationError(errs.values.mkString(", "))
     case ValidationError.AliasNotExists(tx) => AliasNotExists(tx)
     case ValidationError.OrderValidationError(_, m) => CustomValidationError(m)

--- a/src/main/scala/scorex/api/http/assets/AssetsBroadcastApiRoute.scala
+++ b/src/main/scala/scorex/api/http/assets/AssetsBroadcastApiRoute.scala
@@ -113,10 +113,9 @@ case class AssetsBroadcastApiRoute(settings: RestAPISettings,
   ))
   def batchTransfer: Route = (path("batch-transfer") & post) {
     json[List[SignedTransferRequest]] { reqs =>
-      Future(processRequests(reqs)).map { xs =>
-        networkBroadcast(xs)
-        toResponse(xs)
-      }
+      val r = Future(processRequests(reqs))
+      r.foreach(networkBroadcast)
+      r.map(toResponse)
     }
   }
 

--- a/src/main/scala/scorex/transaction/ValidationError.scala
+++ b/src/main/scala/scorex/transaction/ValidationError.scala
@@ -30,7 +30,7 @@ object ValidationError {
   object GenericError {
     def apply(ex: Throwable): GenericError = new GenericError(Throwables.getStackTraceAsString(ex))
   }
-  case class AlreadyInTheState(txId: ByteStr, details: String = "") extends ValidationError
+  case class AlreadyInTheState(txId: ByteStr, txHeight: Int) extends ValidationError
   case class AccountBalanceError(errs: Map[Address, String]) extends ValidationError
   case class AliasNotExists(a: Alias) extends ValidationError
   case class OrderValidationError(order: Order, err: String) extends ValidationError

--- a/src/main/scala/scorex/transaction/ValidationError.scala
+++ b/src/main/scala/scorex/transaction/ValidationError.scala
@@ -30,7 +30,7 @@ object ValidationError {
   object GenericError {
     def apply(ex: Throwable): GenericError = new GenericError(Throwables.getStackTraceAsString(ex))
   }
-  case class AlreadyInThePool(txId: ByteStr) extends ValidationError
+  case class AlreadyInThePool(txId: ByteStr, details: String = "") extends ValidationError
   case class AccountBalanceError(errs: Map[Address, String]) extends ValidationError
   case class AliasNotExists(a: Alias) extends ValidationError
   case class OrderValidationError(order: Order, err: String) extends ValidationError

--- a/src/main/scala/scorex/transaction/ValidationError.scala
+++ b/src/main/scala/scorex/transaction/ValidationError.scala
@@ -30,7 +30,7 @@ object ValidationError {
   object GenericError {
     def apply(ex: Throwable): GenericError = new GenericError(Throwables.getStackTraceAsString(ex))
   }
-  case class AlreadyInThePool(txId: ByteStr, details: String = "") extends ValidationError
+  case class AlreadyInTheState(txId: ByteStr, details: String = "") extends ValidationError
   case class AccountBalanceError(errs: Map[Address, String]) extends ValidationError
   case class AliasNotExists(a: Alias) extends ValidationError
   case class OrderValidationError(order: Order, err: String) extends ValidationError

--- a/src/test/scala/com/wavesplatform/state2/diffs/CommonValidationTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/CommonValidationTest.scala
@@ -21,11 +21,11 @@ class CommonValidationTest extends PropSpec with PropertyChecks with Matchers wi
 
     forAll(preconditionsAndPayment) { case ((genesis, transfer)) =>
       assertDiffEi(Seq(TestBlock.create(Seq(genesis, transfer))), TestBlock.create(Seq(transfer))) { blockDiffEi =>
-        blockDiffEi should produce("Tx with such id already present")
+        blockDiffEi should produce("AlreadyInTheState")
       }
 
       assertDiffEi(Seq(TestBlock.create(Seq(genesis))), TestBlock.create(Seq(transfer, transfer))) { blockDiffEi =>
-        blockDiffEi should produce("Tx with such id already present")
+        blockDiffEi should produce("AlreadyInTheState")
       }
     }
   }

--- a/src/test/scala/com/wavesplatform/state2/diffs/CreateAliasTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/CreateAliasTransactionDiffTest.scala
@@ -48,11 +48,11 @@ class CreateAliasTransactionDiffTest extends PropSpec
   property("cannot recreate existing alias") {
     forAll(preconditionsAndAliasCreations) { case (gen, aliasTx, sameAliasTx, sameAliasOtherSenderTx, _) =>
       assertDiffEi(Seq(TestBlock.create(Seq(gen, aliasTx))), TestBlock.create(Seq(sameAliasTx))) { blockDiffEi =>
-        blockDiffEi should produce("Tx with such id already present")
+        blockDiffEi should produce("AlreadyInTheState")
       }
 
       assertDiffEi(Seq(TestBlock.create(Seq(gen, aliasTx))), TestBlock.create(Seq(sameAliasOtherSenderTx))) { blockDiffEi =>
-        blockDiffEi should produce("Tx with such id already present")
+        blockDiffEi should produce("AlreadyInTheState")
       }
     }
   }


### PR DESCRIPTION
`/assets/broadcast/batch-transfer`:
* Optimisations;
* Now returns a transaction without a error if it is in the blockchain;
* Can hold up to 10k transactions per request in tests.

Other:
* Improvements in UtxPool;
* Some optimisations for transactions validation;
* A fix for "You are creating too many HashedWheelTimer instances";