### PR TITLE
NODE-387 Create API two methods to sign and broadcast transactions

### DIFF
--- a/src/it/scala/com/wavesplatform/it/TransactionsApiSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/TransactionsApiSuite.scala
@@ -1,0 +1,151 @@
+package com.wavesplatform.it
+
+import com.wavesplatform.it.api._
+import com.wavesplatform.it.transactions.BaseTransactionSuite
+import com.wavesplatform.it.util._
+import org.asynchttpclient.util.HttpConstants
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
+import scorex.crypto.encode.Base58
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class TransactionsApiSuite extends BaseTransactionSuite {
+
+  private val timeout = 2.minutes
+
+  test("height should always be reported for transactions") {
+    val f = for {
+      txId <- sender.transfer(firstAddress, secondAddress, 1.waves, fee = 1.waves).map(_.id)
+      _ <- waitForHeightAraiseAndTxPresent(txId, 1)
+
+      jsv1 <- sender.get(s"/transactions/info/$txId").as[JsValue]
+      hasPositiveHeight1 = (jsv1 \ "height").asOpt[Int].map(_ > 0)
+      _ = assert(hasPositiveHeight1.getOrElse(false))
+
+      jsv2 <- sender.get(s"/transactions/address/$firstAddress/limit/1").as[JsArray]
+      hasPositiveHeight2 = (jsv2(0)(0) \ "height").asOpt[Int].map(_ > 0)
+      _ = assert(hasPositiveHeight2.getOrElse(false))
+    } yield succeed
+
+    Await.result(f, timeout)
+  }
+
+  test("/transactions/sign should handle erroneous input") {
+    def assertSignBadJson(json: JsObject) =
+      assertBadRequestAndMessage(sender.postJsonWithApiKey("/transactions/sign", json), "failed to parse json message")
+    val json = Json.obj(
+      "type" -> 10,
+      "sender" -> firstAddress,
+      "alias" -> "alias",
+      "fee" -> 100000)
+    val f = for {
+      _ <- assertSignBadJson(json - "type")
+      _ <- assertSignBadJson(json + ("type" -> Json.toJson(-100)))
+      _ <- assertSignBadJson(json - "alias")
+    } yield succeed
+
+    Await.result(f, timeout)
+  }
+
+  test("/transactions/sign should respect timestamp if specified") {
+    val timestamp = 1500000000000L
+    val json = Json.obj(
+      "type" -> 10,
+      "sender" -> firstAddress,
+      "alias" -> "alias",
+      "fee" -> 100000,
+      "timestamp" -> timestamp)
+    val f = for {
+      r <- sender.postJsonWithApiKey("/transactions/sign", json)
+      _ = assert(r.getStatusCode == HttpConstants.ResponseStatusCodes.OK_200)
+      _ = assert((Json.parse(r.getResponseBody) \ "timestamp").as[Long] == timestamp)
+    } yield succeed
+
+    Await.result(f, timeout)
+  }
+
+  test("/transactions/broadcast should handle erroneous input") {
+    def assertBroadcastBadJson(json: JsObject, expectedMessage: String) =
+      assertBadRequestAndMessage(sender.postJson("/transactions/broadcast", json), expectedMessage)
+    val timestamp = System.currentTimeMillis
+    val json = Json.obj(
+      "type" -> 10,
+      "senderPublicKey" -> "8LbAU5BSrGkpk5wbjLMNjrbc9VzN9KBBYv9X8wGpmAJT",
+      "alias" -> "alias",
+      "fee" -> 100000,
+      "timestamp" -> timestamp,
+      "signature" -> "A" * 64)
+    val f = for {
+      _ <- assertBroadcastBadJson(json - "type", "failed to parse json message")
+      _ <- assertBroadcastBadJson(json - "type" + ("type" -> Json.toJson(88)), "failed to parse json message")
+      _ <- assertBroadcastBadJson(json - "alias", "failed to parse json message")
+      _ <- assertBroadcastBadJson(json, "invalid signature")
+    } yield succeed
+
+    Await.result(f, timeout)
+  }
+
+  test("/transactions/sign should produce issue/reissue transactions that are good for /transactions/broadcast") {
+    val issueId = signAndBroadcast(Json.obj(
+      "type" -> 3,
+      "name" -> "Gigacoin",
+      "quantity" -> 100.waves,
+      "description" -> "Gigacoin",
+      "sender" -> firstAddress,
+      "decimals" -> 8,
+      "reissuable" -> true,
+      "fee" -> 1.waves))
+
+    signAndBroadcast(Json.obj(
+      "type" -> 5,
+      "quantity" -> 200.waves,
+      "assetId" -> issueId,
+      "sender" -> firstAddress,
+      "reissuable" -> false,
+      "fee" -> 1.waves))
+  }
+
+  test("/transactions/sign should produce transfer transaction that is good for /transactions/broadcast") {
+    signAndBroadcast(Json.obj(
+      "type" -> 4,
+      "sender" -> firstAddress,
+      "recipient" -> secondAddress,
+      "fee" -> 100000,
+      "amount" -> 1.waves,
+      "attachment" -> Base58.encode("falafel".getBytes)))
+  }
+
+  test("/transactions/sign should produce leasing transactions that are good for /transactions/broadcast") {
+    signAndBroadcast(Json.obj(
+      "type" -> 8,
+      "sender" -> firstAddress,
+      "amount" -> 1.waves,
+      "recipient" -> secondAddress,
+      "fee" -> 100000))
+  }
+
+  test("/transactions/sign should produce alias transaction that is good for /transactions/broadcast") {
+    signAndBroadcast(Json.obj(
+      "type" -> 10,
+      "sender" -> firstAddress,
+      "alias" -> "myalias",
+      "fee" -> 100000))
+  }
+
+  private def signAndBroadcast(json: JsObject): String = {
+    val f = for {
+      rs <- sender.postJsonWithApiKey("/transactions/sign", json)
+      _ = assert(rs.getStatusCode == HttpConstants.ResponseStatusCodes.OK_200)
+      body = Json.parse(rs.getResponseBody)
+      _ = assert((body \ "signature").as[String].nonEmpty)
+      rb <- sender.postJson("/transactions/broadcast", body)
+      _ = assert(rb.getStatusCode == HttpConstants.ResponseStatusCodes.OK_200)
+      id = (Json.parse(rb.getResponseBody) \ "id").as[String]
+      _ = assert(id.nonEmpty)
+      _ <- waitForHeightAraiseAndTxPresent(id, 1)
+    } yield id
+
+    Await.result(f, timeout)
+  }
+}

--- a/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
+++ b/src/it/scala/com/wavesplatform/it/api/NodeApi.scala
@@ -75,13 +75,13 @@ trait NodeApi {
   def get(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] =
     retrying(f(_get(s"http://$restAddress:$nodeRestPort$path")).build())
 
-  def getWihApiKey(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] = retrying {
+  def getWithApiKey(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] = retrying {
     _get(s"http://$restAddress:$nodeRestPort$path")
       .setHeader("api_key", "integration-test-rest-api")
       .build()
   }
 
-  def postJsonWihApiKey[A: Writes](path: String, body: A): Future[Response] = retrying {
+  def postJsonWithApiKey[A: Writes](path: String, body: A): Future[Response] = retrying {
     _post(s"http://$restAddress:$nodeRestPort$path")
       .setHeader("api_key", "integration-test-rest-api")
       .setHeader("Content-type", "application/json").setBody(stringify(toJson(body)))
@@ -103,7 +103,7 @@ trait NodeApi {
   def blacklist(networkIpAddress: String, hostNetworkPort: Int): Future[Unit] =
     post("/debug/blacklist", s"$networkIpAddress:$hostNetworkPort").map(_ => ())
 
-  def printDebugMessage(db: DebugMessage): Future[Response] = postJsonWihApiKey("/debug/print", db)
+  def printDebugMessage(db: DebugMessage): Future[Response] = postJsonWithApiKey("/debug/print", db)
 
   def connectedPeers: Future[Seq[Peer]] = get("/peers/connected").map { r =>
     (Json.parse(r.getResponseBody) \ "peers").as[Seq[Peer]]
@@ -357,7 +357,7 @@ trait NodeApi {
   def debugStateAt(height: Long): Future[Map[String, Long]] = get(s"/debug/stateWaves/$height").as[Map[String, Long]]
 
   def debugPortfoliosFor(address: String, considerUnspent: Boolean) = {
-    getWihApiKey(s"/debug/portfolios/$address?considerUnspent=$considerUnspent")
+    getWithApiKey(s"/debug/portfolios/$address?considerUnspent=$considerUnspent")
   }.as[Portfolio]
 
 }

--- a/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/transactions/TransferTransactionSuite.scala
@@ -1,10 +1,8 @@
 package com.wavesplatform.it.transactions
 
 import com.wavesplatform.it.TransferSending
-import com.wavesplatform.it.api._
 import com.wavesplatform.it.util._
 import org.scalatest.CancelAfterFailure
-import play.api.libs.json.{JsArray, JsValue}
 import scorex.account.{AddressOrAlias, PrivateKeyAccount}
 import scorex.api.http.Mistiming
 import scorex.transaction.assets.TransferTransaction
@@ -190,23 +188,5 @@ class TransferTransactionSuite extends BaseTransactionSuite with TransferSending
     } yield succeed
 
     Await.result(f, waitCompletion)
-  }
-
-  // probably should be moved elsewhere, just don't see any suite that fits the purpose right now
-  test("height should be reported for transactions") {
-    val f = for {
-      txId <- sender.transfer(firstAddress, secondAddress, 1.waves, fee = 1.waves).map(_.id)
-      _ <- waitForHeightAraiseAndTxPresent(txId, 1)
-
-      jsv1 <- sender.get(s"/transactions/info/$txId").as[JsValue]
-      hasPositiveHeight1 = (jsv1 \ "height").asOpt[Int].map(_ > 0)
-      _ = assert(hasPositiveHeight1.getOrElse(false))
-
-      jsv2 <- sender.get(s"/transactions/address/$firstAddress/limit/1").as[JsArray]
-      hasPositiveHeight2 = (jsv2(0)(0) \ "height").asOpt[Int].map(_ > 0)
-      _ = assert(hasPositiveHeight2.getOrElse(false))
-    } yield succeed
-
-    Await.result(f, 2.minutes)
   }
 }

--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -129,7 +129,7 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
     nodeApi.foreach { case (tags, routes) =>
       val apiRoutes = routes ++ Seq(
         BlocksApiRoute(settings.restAPISettings, history, blockchainUpdater, allChannels, c => processCheckpoint(None, c)),
-        TransactionsApiRoute(settings.restAPISettings, stateReader, history, utxStorage),
+        TransactionsApiRoute(settings.restAPISettings, wallet, stateReader, history, utxStorage, allChannels, time),
         NxtConsensusApiRoute(settings.restAPISettings, stateReader, history, settings.blockchainSettings.functionalitySettings),
         WalletApiRoute(settings.restAPISettings, wallet),
         PaymentApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, time),

--- a/src/main/scala/scorex/api/http/alias/CreateAliasRequest.scala
+++ b/src/main/scala/scorex/api/http/alias/CreateAliasRequest.scala
@@ -8,7 +8,8 @@ case class CreateAliasRequest(@ApiModelProperty(value = "Base58 encoded sender p
                               @ApiModelProperty(value = "Alias", required = true)
                               alias: String,
                               @ApiModelProperty(required = true)
-                              fee: Long)
+                              fee: Long,
+                              timestamp: Option[Long] = None)
 
 object CreateAliasRequest {
   implicit val aliasRequestFormat: Format[CreateAliasRequest] = Json.format

--- a/src/main/scala/scorex/api/http/assets/BurnRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/BurnRequest.scala
@@ -3,7 +3,7 @@ package scorex.api.http.assets
 import play.api.libs.json._
 
 
-case class BurnRequest(sender: String, assetId: String, quantity: Long, fee: Long)
+case class BurnRequest(sender: String, assetId: String, quantity: Long, fee: Long, timestamp: Option[Long] = None)
 
 object BurnRequest {
   implicit val burnFormat: Format[BurnRequest] = Json.format

--- a/src/main/scala/scorex/api/http/assets/IssueRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/IssueRequest.scala
@@ -11,7 +11,8 @@ case class IssueRequest(sender: String,
   @ApiModelProperty(allowableValues = "range[0,8]", example = "8", dataType = "integer", required = true)
   decimals: Byte,
   reissuable: Boolean,
-  fee: Long)
+  fee: Long,
+  timestamp: Option[Long] = None)
 
 object IssueRequest {
   implicit val issueFormat: Format[IssueRequest] = Json.format

--- a/src/main/scala/scorex/api/http/assets/ReissueRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/ReissueRequest.scala
@@ -2,7 +2,7 @@ package scorex.api.http.assets
 
 import play.api.libs.json.{Format, Json}
 
-case class ReissueRequest(sender: String, assetId: String, quantity: Long, reissuable: Boolean, fee: Long)
+case class ReissueRequest(sender: String, assetId: String, quantity: Long, reissuable: Boolean, fee: Long, timestamp: Option[Long] = None)
 
 object ReissueRequest {
   implicit val reissueFormat: Format[ReissueRequest] = Json.format

--- a/src/main/scala/scorex/api/http/assets/TransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/TransferRequest.scala
@@ -8,7 +8,8 @@ case class TransferRequest(assetId: Option[String],
                            fee: Long,
                            sender: String,
                            attachment: Option[String],
-                           recipient: String)
+                           recipient: String,
+                           timestamp: Option[Long] = None)
 
 object TransferRequest {
   implicit val transferFormat: Format[TransferRequest] = Json.format

--- a/src/main/scala/scorex/api/http/leasing/LeaseCancelRequest.scala
+++ b/src/main/scala/scorex/api/http/leasing/LeaseCancelRequest.scala
@@ -8,7 +8,8 @@ case class LeaseCancelRequest(@ApiModelProperty(value = "Base58 encoded sender p
                               @ApiModelProperty(value = "Base58 encoded lease transaction id", required = true)
                               txId: String,
                               @ApiModelProperty(required = true)
-                              fee: Long)
+                              fee: Long,
+                              timestamp: Option[Long] = None)
 
 object LeaseCancelRequest {
   implicit val leaseCancelRequestFormat: Format[LeaseCancelRequest] = Json.format

--- a/src/main/scala/scorex/api/http/leasing/LeaseRequest.scala
+++ b/src/main/scala/scorex/api/http/leasing/LeaseRequest.scala
@@ -10,7 +10,8 @@ case class LeaseRequest(@ApiModelProperty(value = "Base58 encoded sender public 
                         @ApiModelProperty(required = true)
                         fee: Long,
                         @ApiModelProperty(value = "Recipient address", required = true)
-                        recipient: String)
+                        recipient: String,
+                        timestamp: Option[Long] = None)
 
 object LeaseRequest {
   implicit val leaseCancelRequestFormat: Format[LeaseRequest] = Json.format

--- a/src/test/scala/com/wavesplatform/http/TransactionsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/TransactionsRouteSpec.scala
@@ -2,8 +2,10 @@ package com.wavesplatform.http
 
 import akka.http.scaladsl.model.StatusCodes
 import com.wavesplatform.http.ApiMarshallers._
+import com.wavesplatform.settings.WalletSettings
 import com.wavesplatform.state2.reader.SnapshotStateReader
-import com.wavesplatform.{BlockGen, NoShrink, TransactionGen, UtxPool}
+import com.wavesplatform.{BlockGen, NoShrink, TestTime, TransactionGen, UtxPool}
+import io.netty.channel.group.ChannelGroup
 import monix.eval.Coeval
 import org.scalacheck.Gen._
 import org.scalamock.scalatest.MockFactory
@@ -14,6 +16,7 @@ import scorex.account.Address
 import scorex.api.http.{InvalidAddress, InvalidSignature, TooBigArrayAllocation, TransactionsApiRoute}
 import scorex.crypto.encode.Base58
 import scorex.transaction._
+import scorex.wallet.Wallet
 
 class TransactionsRouteSpec extends RouteSpec("/transactions")
   with RestAPISettingsHelper
@@ -28,10 +31,12 @@ class TransactionsRouteSpec extends RouteSpec("/transactions")
 
   private val transactionsCount = 10
 
+  private val wallet = Wallet(WalletSettings(None, "qwerty", None))
   private val history = mock[History]
   private val state = mock[SnapshotStateReader]
   private val utx = mock[UtxPool]
-  private val route = TransactionsApiRoute(restAPISettings, Coeval.now(state), history, utx).route
+  private val allChannels = mock[ChannelGroup]
+  private val route = TransactionsApiRoute(restAPISettings, wallet, Coeval.now(state), history, utx, allChannels, new TestTime).route
 
 
   routePath("/address/{address}/limit/{limit}") - {


### PR DESCRIPTION
https://wavesplatform.atlassian.net/browse/NODE-387

Changes:
- Added /transactions/sign endpoint for signing transactions of all types. This endpoint is protected with API key and supports an optional timestamp parameter. If no timestamp is specified, server time is used.
- Added another endpoint, /transactions/broadcast, for publishing signed transactions.