### PR TITLE
NODE-410 Response to blocks API call without lock

### DIFF
--- a/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
+++ b/src/main/scala/com/wavesplatform/history/HistoryWriterImpl.scala
@@ -111,17 +111,17 @@ class HistoryWriterImpl private(file: Option[File], val synchronizationToken: Re
       .reverse
   }
 
-  override def height(): Int = read { implicit lock => blockIdByHeight().size() }
+  override def height(): Int = lockfree { implicit lock => blockIdByHeight().size() }
 
   override def scoreOf(id: ByteStr): Option[BlockchainScore] = read { implicit lock =>
     heightOf(id).map(scoreByHeight().get(_))
   }
 
-  override def heightOf(blockSignature: ByteStr): Option[Int] = read { implicit lock =>
+  override def heightOf(blockSignature: ByteStr): Option[Int] = lockfree { implicit lock =>
     Option(heightByBlockId().get(blockSignature))
   }
 
-  override def blockBytes(height: Int): Option[Array[Byte]] = read { implicit lock =>
+  override def blockBytes(height: Int): Option[Array[Byte]] = lockfree { implicit lock =>
     Option(blockBodyByHeight().get(height))
   }
 

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -32,7 +32,7 @@ class StateWriterImpl(p: StateStorage, storeTransactions: Boolean, synchronizati
 
   import StateStorage._
 
-  override val status = read { implicit l =>
+  override val status = lockfree { implicit l =>
     BehaviorSubject(Status(sp().getHeight, System.currentTimeMillis))
   }
 

--- a/src/main/scala/scorex/utils/Synchronized.scala
+++ b/src/main/scala/scorex/utils/Synchronized.scala
@@ -71,6 +71,8 @@ trait Synchronized extends ScorexLogging {
     }
   }
 
+  def lockfree[T](body: ReadLock => T): T = body(instanceReadLock)
+
   def read[T](body: ReadLock => T): T =
     synchronizeOperation(instanceReadLock)(body)
 


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-410

A few HistoryWriterImpl methods call atomic operations on MVMaps under a read lock. This is not needed because MVMap is thread safe.

I'm introducing a new method, `Synchronized.lockfree`, that provides the implicit lock parameter but does not acquire the lock.