### PR TITLE
NODE-430 Expose stateful application comoponents details via /node/st…

### DIFF
--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -106,12 +106,13 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
       allChannels.broadcast(LocalScoreChanged(x))
     }(scheduler)
 
-    val network = NetworkServer(settings, lastBlockInfo, history, utxStorage, peerDatabase, allChannels, establishedConnections)
+    val historyReplier = new HistoryReplier(history, settings.synchronizationSettings)
+    val network = NetworkServer(settings, lastBlockInfo, history, historyReplier, utxStorage, peerDatabase, allChannels, establishedConnections)
     val (signatures, blocks, blockchainScores, checkpoints, microblockInvs, microblockResponses, transactions) = network.messages
 
-    val syncWithChannelClosed = RxScoreObserver(settings.synchronizationSettings.scoreTTL, history.score(), lastScore, blockchainScores, network.closedChannels)
-    val microblockDatas = MicroBlockSynchronizer(settings.synchronizationSettings.microBlockSynchronizer, peerDatabase, lastBlockInfo.map(_.id), microblockInvs, microblockResponses)
-    val newBlocks = RxExtensionLoader(settings.synchronizationSettings.maxRollback, settings.synchronizationSettings.synchronizationTimeout,
+    val (syncWithChannelClosed, scoreStatsReporter) = RxScoreObserver(settings.synchronizationSettings.scoreTTL, history.score(), lastScore, blockchainScores, network.closedChannels)
+    val (microblockDatas, mbSyncCacheSizes) = MicroBlockSynchronizer(settings.synchronizationSettings.microBlockSynchronizer, peerDatabase, lastBlockInfo.map(_.id), microblockInvs, microblockResponses)
+    val (newBlocks, extLoaderState) = RxExtensionLoader(settings.synchronizationSettings.maxRollback, settings.synchronizationSettings.synchronizationTimeout,
       history, peerDatabase, knownInvalidBlocks, blocks, signatures, syncWithChannelClosed) { case ((c, b)) => processFork(c, b.blocks) }
 
     val utxSink = UtxPoolSynchronizer(utxStorage, settings.synchronizationSettings.utxSynchronizerSettings, allChannels, transactions)
@@ -137,7 +138,8 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
         UtilsApiRoute(settings.restAPISettings),
         PeersApiRoute(settings.restAPISettings, network.connect, peerDatabase, establishedConnections),
         AddressApiRoute(settings.restAPISettings, wallet, stateReader, settings.blockchainSettings.functionalitySettings),
-        DebugApiRoute(settings.restAPISettings, wallet, stateReader, history, peerDatabase, establishedConnections, blockchainUpdater, allChannels, utxStorage, blockchainDebugInfo, miner, configRoot),
+        DebugApiRoute(settings.restAPISettings, wallet, stateReader, history, peerDatabase, establishedConnections, blockchainUpdater, allChannels,
+          utxStorage, blockchainDebugInfo, miner, historyReplier, extLoaderState, mbSyncCacheSizes, scoreStatsReporter, configRoot),
         WavesApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, time),
         AssetsApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, stateReader, time),
         ActivationApiRoute(settings.restAPISettings, settings.blockchainSettings.functionalitySettings, settings.featuresSettings, history, featureProvider),

--- a/src/main/scala/com/wavesplatform/network/HistoryReplier.scala
+++ b/src/main/scala/com/wavesplatform/network/HistoryReplier.scala
@@ -11,6 +11,7 @@ import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 import scorex.transaction.NgHistory
 import scorex.utils.ScorexLogging
+import HistoryReplier._
 
 @Sharable
 class HistoryReplier(history: NgHistory, settings: SynchronizationSettings) extends ChannelInboundHandlerAdapter with ScorexLogging {
@@ -65,4 +66,10 @@ class HistoryReplier(history: NgHistory, settings: SynchronizationSettings) exte
 
     case _ => super.channelRead(ctx, msg)
   }
+
+  def cacheSizes: CacheSizes = CacheSizes(knownBlocks.size(), knownMicroBlocks.size())
+}
+
+object HistoryReplier {
+  case class CacheSizes(blocks: Long, microBlocks: Long)
 }

--- a/src/main/scala/com/wavesplatform/network/NetworkServer.scala
+++ b/src/main/scala/com/wavesplatform/network/NetworkServer.scala
@@ -39,6 +39,7 @@ object NetworkServer extends ScorexLogging {
   def apply(settings: WavesSettings,
             lastBlockInfos: Observable[LastBlockInfo],
             history: NgHistory,
+            historyReplier: HistoryReplier,
             utxPool: UtxPool,
             peerDatabase: PeerDatabase,
             allChannels: ChannelGroup,
@@ -78,7 +79,6 @@ object NetworkServer extends ScorexLogging {
     val writeErrorHandler = new WriteErrorHandler
     val fatalErrorHandler = new FatalErrorHandler
 
-    val historyReplier = new HistoryReplier(history, settings.synchronizationSettings)
     val inboundConnectionFilter: PipelineInitializer.HandlerWrapper = new InboundConnectionFilter(peerDatabase,
       settings.networkSettings.maxInboundConnections,
       settings.networkSettings.maxConnectionsPerHost)

--- a/src/main/scala/com/wavesplatform/network/RxExtensionLoader.scala
+++ b/src/main/scala/com/wavesplatform/network/RxExtensionLoader.scala
@@ -28,7 +28,7 @@ object RxExtensionLoader extends ScorexLogging {
             signatures: Observable[(Channel, Signatures)],
             syncWithChannelClosed: Observable[ChannelClosedAndSyncWith]
            )(extensionApplier: (Channel, ExtensionBlocks) => Task[Either[ValidationError, Option[BlockchainScore]]])
-    : (Observable[(Channel, Block)], () => State) = {
+    : (Observable[(Channel, Block)], Coeval[State]) = {
 
     implicit val scheduler: SchedulerService = Scheduler.singleThread("rx-extension-loader")
 
@@ -203,7 +203,7 @@ object RxExtensionLoader extends ScorexLogging {
       .logErr
       .subscribe()(scheduler)
 
-    (simpleBlocks, () => s)
+    (simpleBlocks, Coeval.eval(s))
   }
 
   sealed trait LoaderState

--- a/src/test/scala/com/wavesplatform/http/DebugApiRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/DebugApiRouteSpec.scala
@@ -9,7 +9,8 @@ class DebugApiRouteSpec extends RouteSpec("/debug") with RestAPISettingsHelper w
   private val sampleConfig = com.typesafe.config.ConfigFactory.load()
   private val wavesSettings = WavesSettings.fromConfig(sampleConfig)
   private val configObject = sampleConfig.root()
-  private val route = DebugApiRoute(wavesSettings.restAPISettings, null, null, null, null, null, null, null, null, null, null, configObject).route
+  private val route = DebugApiRoute(wavesSettings.restAPISettings,
+    null, null, null, null, null, null, null, null, null, null, null, null, null, null, configObject).route
 
   routePath("/configInfo") - {
     "requires api_key header" in {

--- a/src/test/scala/com/wavesplatform/network/MicroBlockSynchronizerSpec.scala
+++ b/src/test/scala/com/wavesplatform/network/MicroBlockSynchronizerSpec.scala
@@ -20,7 +20,7 @@ class MicroBlockSynchronizerSpec extends FreeSpec with Matchers with Transaction
     val lastBlockIds = PublishSubject[ByteStr]
     val microInvs = PublishSubject[(Channel, MicroBlockInv)]
     val microResponses = PublishSubject[(Channel, MicroBlockResponse)]
-    val r = MicroBlockSynchronizer(ms, peers, lastBlockIds, microInvs, microResponses)
+    val (r, _) = MicroBlockSynchronizer(ms, peers, lastBlockIds, microInvs, microResponses)
     (lastBlockIds, microInvs, microResponses, r)
   }
 

--- a/src/test/scala/com/wavesplatform/network/RxExtensionLoaderSpec.scala
+++ b/src/test/scala/com/wavesplatform/network/RxExtensionLoaderSpec.scala
@@ -32,7 +32,7 @@ class RxExtensionLoaderSpec extends FreeSpec with Matchers with TransactionGen w
     val history = new TestHistory
     val op = PeerDatabase.NoOp
     val invBlockStorage = new InMemoryInvalidBlockStorage
-    val singleBlocks = RxExtensionLoader(MaxRollback, timeOut, history, op, invBlockStorage, blocks, sigs, ccsw)(applier)
+    val (singleBlocks, _) = RxExtensionLoader(MaxRollback, timeOut, history, op, invBlockStorage, blocks, sigs, ccsw)(applier)
 
     (history, invBlockStorage, blocks, sigs, ccsw, singleBlocks)
   }

--- a/src/test/scala/com/wavesplatform/network/RxScoreObserverSpec.scala
+++ b/src/test/scala/com/wavesplatform/network/RxScoreObserverSpec.scala
@@ -16,7 +16,7 @@ class RxScoreObserverSpec extends FreeSpec with Matchers with TransactionGen wit
     val localScores = PublishSubject[BlockchainScore]
     val remoteScores = PublishSubject[(Channel, BlockchainScore)]
     val channelClosed = PublishSubject[Channel]
-    val syncWith = RxScoreObserver(1.minute, 0, localScores, remoteScores, channelClosed)
+    val (syncWith, _) = RxScoreObserver(1.minute, 0, localScores, remoteScores, channelClosed)
 
     (newItems(syncWith.map(_.syncWith)), localScores, remoteScores, channelClosed)
   }


### PR DESCRIPTION
…atus

JIRA: https://wavesplatform.atlassian.net/browse/NODE-430

Implemented all things requested, just moved them under /debug/info because /node/status starts right at node startup, when most of the data is not yet available.

Sample output (taken from a single devnet node, so all the caches are empty):
```
{
  "stateHeight" : 755,
  "stateHash" : 950345314,
  "blockchainDebugInfo" : {
    "persisted" : {
      "height" : 649,
      "hash" : 950345314
    },
    "inMemory" : [ {
      "height" : 105,
      "hash" : 0
    } ],
    "microBaseHash" : 0
  },
  "extensionLoaderState" : "State(Idle,Idle)",
  "historyReplierCacheSizes" : {
    "blocks" : 0,
    "microBlocks" : 0
  },
  "microBlockSynchronizerCacheSizes" : {
    "microBlockOwners" : 0,
    "nextInvs" : 0,
    "awaiting" : 0,
    "successfullyReceived" : 0
  },
  "scoreObserverStats" : {
    "localScore" : 16410511314917908277,
    "currentBestChannel" : "None",
    "scoresCacheSize" : 0
  },
  "minerState" : "mining microblocks"
}
```