### PR TITLE
NODE-416 API returs error 500 if timestamp in json is too large

### DIFF
--- a/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
@@ -80,7 +80,7 @@ object CommonValidation {
 
   def disallowTxFromFuture[T <: Transaction](settings: FunctionalitySettings, time: Long, tx: T): Either[ValidationError, T] = {
     val allowTransactionsFromFutureByTimestamp = tx.timestamp < settings.allowTransactionsFromFutureUntil
-    if (!allowTransactionsFromFutureByTimestamp && (tx.timestamp - time).millis > MaxTimeTransactionOverBlockDiff)
+    if (!allowTransactionsFromFutureByTimestamp && tx.timestamp - time > MaxTimeTransactionOverBlockDiff.toMillis)
       Left(Mistiming(s"Transaction ts ${tx.timestamp} is from far future. BlockTime: $time"))
     else Right(tx)
   }


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-416

The fix is to compare Long values instead of Durations