### PR TITLE
NODE-467 Stop exposing internal entities to NodeApiRoute

### DIFF
--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -20,7 +20,6 @@ import com.wavesplatform.metrics.Metrics
 import com.wavesplatform.mining.{Miner, MinerImpl}
 import com.wavesplatform.network._
 import com.wavesplatform.settings._
-import com.wavesplatform.state2.StateWriter
 import com.wavesplatform.state2.appender.{BlockAppender, CheckpointAppender, ExtensionAppender, MicroblockAppender}
 import com.wavesplatform.utils.{SystemInformationReporter, forceStopApplication}
 import io.netty.channel.Channel
@@ -55,20 +54,19 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
   // Start /node API right away
   private implicit val as: ActorSystem = actorSystem
   private implicit val materializer: ActorMaterializer = ActorMaterializer()
-
-  private val nodeApiLauncher = (bcu: BlockchainUpdater, state: StateWriter) =>
-    Option(settings.restAPISettings.enable).collect { case true =>
-      val tags = Seq(typeOf[NodeApiRoute])
-      val routes = Seq(NodeApiRoute(settings.restAPISettings, bcu, state, () => this.shutdown()))
-      val combinedRoute: Route = CompositeHttpService(actorSystem, tags, routes, settings.restAPISettings).compositeRoute
-      val httpFuture = Http().bindAndHandle(combinedRoute, settings.restAPISettings.bindAddress, settings.restAPISettings.port)
-      serverBinding = Await.result(httpFuture, 10.seconds)
-      log.info(s"Node REST API was bound on ${settings.restAPISettings.bindAddress}:${settings.restAPISettings.port}")
-      (tags, routes)
-    }
+  private val (storage, heights) = StorageFactory(settings).get
+  private val nodeApi = Option(settings.restAPISettings.enable).collect { case true =>
+    val tags = Seq(typeOf[NodeApiRoute])
+    val routes = Seq(NodeApiRoute(settings.restAPISettings, heights, () => this.shutdown()))
+    val combinedRoute: Route = CompositeHttpService(actorSystem, tags, routes, settings.restAPISettings).compositeRoute
+    val httpFuture = Http().bindAndHandle(combinedRoute, settings.restAPISettings.bindAddress, settings.restAPISettings.port)
+    serverBinding = Await.result(httpFuture, 10.seconds)
+    log.info(s"Node REST API was bound on ${settings.restAPISettings.bindAddress}:${settings.restAPISettings.port}")
+    (tags, routes)
+  }
 
   private val checkpointService = new CheckpointServiceImpl(settings.blockchainSettings.checkpointFile, settings.checkpointsSettings)
-  private val (history, featureProvider, stateWriter, stateReader, blockchainUpdater, blockchainDebugInfo, nodeApi) = StorageFactory(settings, nodeApiLauncher).get
+  private val (history, featureProvider, stateWriter, stateReader, blockchainUpdater, blockchainDebugInfo) = storage()
   private lazy val upnp = new UPnP(settings.networkSettings.uPnPSettings) // don't initialize unless enabled
   private val wallet: Wallet = Wallet(settings.walletSettings)
   private val peerDatabase = new PeerDatabaseImpl(settings.networkSettings)

--- a/src/main/scala/com/wavesplatform/Importer.scala
+++ b/src/main/scala/com/wavesplatform/Importer.scala
@@ -33,7 +33,8 @@ object Importer extends ScorexLogging {
           case Success(inputStream) =>
             deleteFile(settings.blockchainSettings.blockchainFile)
             deleteFile(settings.blockchainSettings.stateFile)
-            val (history, _, stateWriter, _, blockchainUpdater, _, _) = StorageFactory(settings).get
+            val (storage, _) = StorageFactory(settings).get
+            val (history, _, stateWriter, _, blockchainUpdater, _) = storage()
             checkGenesis(history, settings, blockchainUpdater)
             val bis = new BufferedInputStream(inputStream)
             var quit = false

--- a/src/main/scala/com/wavesplatform/history/StorageFactory.scala
+++ b/src/main/scala/com/wavesplatform/history/StorageFactory.scala
@@ -6,37 +6,39 @@ import java.util.concurrent.locks.{ReentrantReadWriteLock => RWL}
 import com.wavesplatform.features.FeatureProvider
 import com.wavesplatform.settings.WavesSettings
 import com.wavesplatform.state2._
+import com.wavesplatform.utils.HeightInfo
+import monix.eval.Coeval
 import scorex.transaction._
-import scorex.utils.NTP
+import scorex.utils.{NTP, Time}
 
 import scala.util.{Success, Try}
 
 object StorageFactory {
 
-  private def createStateStorage(history: History with FeatureProvider, stateFile: Option[File], pageSplitSize: Int): Try[StateStorage] =
-    StateStorage(stateFile, dropExisting = false).flatMap { ss =>
+  type Storage = Coeval[(NgHistory with DebugNgHistory with AutoCloseable, FeatureProvider, AutoCloseable, StateReader, BlockchainUpdater, BlockchainDebugInfo)]
+  type HeightInfos = Coeval[(HeightInfo, HeightInfo)]
+
+  private def createStateStorage(history: History with FeatureProvider, stateFile: Option[File], pageSplitSize: Int, time: Time): Try[StateStorage] =
+    StateStorage(stateFile, dropExisting = false, time).flatMap { ss =>
       if (ss.getHeight <= history.height()) Success(ss) else {
         ss.close()
-        StateStorage(stateFile, dropExisting = true)
+        StateStorage(stateFile, dropExisting = true, time)
       }
     }
 
-  def apply[T](settings: WavesSettings,
-               beforeStateUpdate: (BlockchainUpdater, StateWriter) => T = (_: BlockchainUpdater, _: StateWriter) => (),
-               time: scorex.utils.Time = NTP):
-    Try[(NgHistory with DebugNgHistory with AutoCloseable, FeatureProvider, AutoCloseable, StateReader, BlockchainUpdater, BlockchainDebugInfo, T)] =
-  {
+  def apply[T](settings: WavesSettings, time: Time = NTP): Try[(Storage, HeightInfos)] = {
     val lock = new RWL(true)
     for {
-      historyWriter <- HistoryWriterImpl(settings.blockchainSettings.blockchainFile, lock, settings.blockchainSettings.functionalitySettings, settings.featuresSettings)
-      ss <- createStateStorage(historyWriter, settings.blockchainSettings.stateFile, settings.mvstorePageSplitSize)
-      stateWriter = new StateWriterImpl(ss, settings.blockchainSettings.storeTransactionsInState, lock)
-      bcu = BlockchainUpdaterImpl(stateWriter, historyWriter, settings, time, lock)
-      callbackResult = beforeStateUpdate(bcu, stateWriter)
-    } yield {
-      bcu.syncPersistedAndInMemory()
-      val history: NgHistory with DebugNgHistory with FeatureProvider = bcu.historyReader
-      (history, history, stateWriter, bcu.bestLiquidState, bcu, bcu, callbackResult)
-    }
+      historyWriter <- HistoryWriterImpl(settings.blockchainSettings.blockchainFile, lock, settings.blockchainSettings.functionalitySettings, settings.featuresSettings, time)
+      ss <- createStateStorage(historyWriter, settings.blockchainSettings.stateFile, settings.mvstorePageSplitSize, time)
+    } yield (
+      Coeval {
+        val stateWriter = new StateWriterImpl(ss, settings.blockchainSettings.storeTransactionsInState, lock)
+        val bcu = BlockchainUpdaterImpl(stateWriter, historyWriter, settings, time, lock)
+        val history: NgHistory with DebugNgHistory with FeatureProvider = bcu.historyReader
+        (history, history, stateWriter, bcu.bestLiquidState, bcu, bcu)
+      },
+      Coeval { (historyWriter.debugInfo, ss.debugInfo) }
+    )
   }
 }

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -5,36 +5,22 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import cats.Monoid
 import cats.implicits._
 import com.wavesplatform.metrics.Instrumented
-import com.wavesplatform.state2.StateWriter.Status
 import com.wavesplatform.state2.reader.StateReaderImpl
-import monix.reactive.Observable
-import monix.reactive.subjects.BehaviorSubject
 import scorex.transaction.PaymentTransaction
 import scorex.transaction.assets.TransferTransaction
 import scorex.transaction.assets.exchange.ExchangeTransaction
 import scorex.utils.ScorexLogging
-import scorex.utils.Synchronized.ReadLock
 
 trait StateWriter {
   def applyBlockDiff(blockDiff: BlockDiff): Unit
 
   def clear(): Unit
-
-  def status: Observable[Status]
-}
-
-object StateWriter {
-  case class Status(height: Int, lastUpdated: Long)
 }
 
 class StateWriterImpl(p: StateStorage, storeTransactions: Boolean, synchronizationToken: ReentrantReadWriteLock)
   extends StateReaderImpl(p, synchronizationToken) with StateWriter with AutoCloseable with ScorexLogging with Instrumented {
 
   import StateStorage._
-
-  override val status = read { implicit l =>
-    BehaviorSubject(Status(sp().getHeight, System.currentTimeMillis))
-  }
 
   override def close(): Unit = p.close()
 
@@ -120,7 +106,7 @@ class StateWriterImpl(p: StateStorage, storeTransactions: Boolean, synchronizati
     measureSizeLog("lease info")(blockDiff.txsDiff.leaseState)(
       _.foreach { case (id, isActive) => sp().leaseState.put(id, isActive) })
 
-    setHeight(newHeight)
+    sp().setHeight(newHeight)
 
     val nextChunkOfBlocks = !sameQuotient(newHeight, oldHeight, 1000)
     sp().commit(nextChunkOfBlocks)
@@ -140,12 +126,7 @@ class StateWriterImpl(p: StateStorage, storeTransactions: Boolean, synchronizati
     sp().aliasToAddress.clear()
     sp().leaseState.clear()
     sp().lastBalanceSnapshotHeight.clear()
-    setHeight(0)
+    sp().setHeight(0)
     sp().commit(compact = true)
-  }
-
-  private def setHeight(newHeight: Int)(implicit lock: ReadLock) = {
-    sp().setHeight(newHeight)
-    status.onNext(Status(newHeight, System.currentTimeMillis))
   }
 }

--- a/src/main/scala/com/wavesplatform/utils/package.scala
+++ b/src/main/scala/com/wavesplatform/utils/package.scala
@@ -13,6 +13,8 @@ import scala.util.Try
 
 package object utils extends ScorexLogging {
 
+  type HeightInfo = (Int, Long)
+
   private val DefaultPageSplitSize = 4 * 1024
 
   def base58Length(byteArrayLength: Int): Int = math.ceil(math.log(256) / math.log(58) * byteArrayLength).toInt

--- a/src/main/scala/scorex/transaction/BlockchainUpdater.scala
+++ b/src/main/scala/scorex/transaction/BlockchainUpdater.scala
@@ -25,7 +25,7 @@ trait BlockchainDebugInfo {
 
 }
 
-case class LastBlockInfo(id: BlockId, height: Int, score: BlockchainScore, ready: Boolean, lastUpdated: Long)
+case class LastBlockInfo(id: BlockId, height: Int, score: BlockchainScore, ready: Boolean)
 
 case class HashInfo(height: Int, hash: Int)
 

--- a/src/main/scala/scorex/transaction/History.scala
+++ b/src/main/scala/scorex/transaction/History.scala
@@ -2,6 +2,7 @@ package scorex.transaction
 
 import com.wavesplatform.network.{BlockCheckpoint, Checkpoint}
 import com.wavesplatform.state2.ByteStr
+import com.wavesplatform.utils.HeightInfo
 import scorex.block.Block.BlockId
 import scorex.block.{Block, BlockHeader, MicroBlock}
 import scorex.consensus.nxt.NxtLikeConsensusBlockData
@@ -29,6 +30,8 @@ trait History extends Synchronized with AutoCloseable {
   def lastBlockTimestamp(): Option[Long]
 
   def lastBlockId(): Option[ByteStr]
+
+  def debugInfo: HeightInfo
 }
 
 trait NgHistory extends History {

--- a/src/main/scala/scorex/transaction/NgHistoryReader.scala
+++ b/src/main/scala/scorex/transaction/NgHistoryReader.scala
@@ -9,6 +9,7 @@ import scorex.block.Block.BlockId
 import scorex.block.{Block, BlockHeader, MicroBlock}
 import scorex.transaction.History.{BlockMinerInfo, BlockchainScore}
 import cats.implicits._
+import com.wavesplatform.utils.HeightInfo
 
 class NgHistoryReader(ngState: () => Option[NgState], inner: History with FeatureProvider, settings: FunctionalitySettings) extends History with NgHistory with DebugNgHistory with FeatureProvider {
 
@@ -102,4 +103,6 @@ class NgHistoryReader(ngState: () => Option[NgState], inner: History with Featur
     else
       inner.blockHeaderAndSizeAt(height)
   }
+
+  override def debugInfo: HeightInfo = inner.debugInfo
 }

--- a/src/test/scala/com/wavesplatform/UtxPoolSpecification.scala
+++ b/src/test/scala/com/wavesplatform/UtxPoolSpecification.scala
@@ -40,7 +40,8 @@ class UtxPoolSpecification extends FreeSpec
     val genesisSettings = TestHelpers.genesisSettings(Map(senderAccount -> senderBalance))
     val settings = WavesSettings.fromConfig(config).copy(blockchainSettings = BlockchainSettings(None, None, false, None, 'T', 5, 5, FunctionalitySettings.TESTNET, genesisSettings))
 
-    val (history, _, _, state, bcu, _, _) = StorageFactory(settings).get
+    val (storage, _) = StorageFactory(settings).get
+    val (history, _, _, state, bcu, _) = storage()
 
     bcu.processBlock(Block.genesis(genesisSettings).right.get)
 

--- a/src/test/scala/com/wavesplatform/history/package.scala
+++ b/src/test/scala/com/wavesplatform/history/package.scala
@@ -38,7 +38,8 @@ package object history {
   val DefaultWavesSettings: WavesSettings = settings.copy(blockchainSettings = DefaultBlockchainSettings)
 
   def domain(settings: WavesSettings): Domain = {
-    val (history, _, _, stateReader, blockchainUpdater, _, _) = StorageFactory(settings).get
+    val (storage, _) = StorageFactory(settings).get
+    val (history, _, _, stateReader, blockchainUpdater, _) = storage()
     Domain(history, stateReader, blockchainUpdater)
   }
 

--- a/src/test/scala/com/wavesplatform/network/TestHistory.scala
+++ b/src/test/scala/com/wavesplatform/network/TestHistory.scala
@@ -3,6 +3,7 @@ package com.wavesplatform.network
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import com.wavesplatform.state2.ByteStr
+import com.wavesplatform.utils.HeightInfo
 import scorex.block.Block.BlockId
 import scorex.block.{Block, BlockHeader, MicroBlock}
 import scorex.transaction.History.BlockchainScore
@@ -40,4 +41,6 @@ class TestHistory extends NgHistory {
   override def synchronizationToken: ReentrantReadWriteLock = ???
 
   override def close(): Unit = ???
+
+  override def debugInfo: HeightInfo = ???
 }

--- a/src/test/scala/scorex/transaction/BlockchainUpdaterTest.scala
+++ b/src/test/scala/scorex/transaction/BlockchainUpdaterTest.scala
@@ -28,10 +28,13 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
     featuresSettings = DefaultWavesSettings.featuresSettings.copy(autoShutdownOnUnsupportedFeature = true)
   )
 
-  private def storageFactory() = StorageFactory(WavesSettings).get
+  private def storageFactory() = {
+    val (storage, _) = StorageFactory(WavesSettings).get
+    storage()
+  }
 
   ignore ("concurrent access to lastBlock doesn't throw any exception") {
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -57,7 +60,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
 
   test("features approved and accepted as height grows") {
 
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -94,7 +97,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("features rollback with block rollback") {
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -149,7 +152,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("feature activation height is not overrided with further periods") {
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -171,7 +174,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("feature activated only by 90% of blocks") {
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -194,7 +197,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("features votes resets when voting window changes") {
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
 
     bu.processBlock(genesisBlock)
 
@@ -234,7 +237,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
     })
 
 
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
     bu.processBlock(genesisBlock)
 
     (1 to ApprovalPeriod * 2).foreach { i =>
@@ -249,7 +252,7 @@ class BlockchainUpdaterTest extends FunSuite with Matchers with HistoryTest with
   }
 
   test("sunny day test when known feature activated") {
-    val (h, fp, _, _, bu, _, _) = storageFactory()
+    val (h, fp, _, _, bu, _) = storageFactory()
     bu.processBlock(genesisBlock)
 
     (1 until ApprovalPeriod * 2 - 1).foreach { i =>


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-467

- In NodeApiRoute, replaced StateWriter and BlockchainUpdater references with Coevals
- Got rid of nodeApiLauncher callback