### PR TITLE
NODE-387 Fixed broadcast of burn and lease cancel requests

### DIFF
--- a/src/it/scala/com/wavesplatform/it/TransactionsApiSuite.scala
+++ b/src/it/scala/com/wavesplatform/it/TransactionsApiSuite.scala
@@ -87,7 +87,7 @@ class TransactionsApiSuite extends BaseTransactionSuite {
     Await.result(f, timeout)
   }
 
-  test("/transactions/sign should produce issue/reissue transactions that are good for /transactions/broadcast") {
+  test("/transactions/sign should produce issue/reissue/burn transactions that are good for /transactions/broadcast") {
     val issueId = signAndBroadcast(Json.obj(
       "type" -> 3,
       "name" -> "Gigacoin",
@@ -105,6 +105,13 @@ class TransactionsApiSuite extends BaseTransactionSuite {
       "sender" -> firstAddress,
       "reissuable" -> false,
       "fee" -> 1.waves))
+
+    signAndBroadcast(Json.obj(
+      "type" -> 6,
+      "quantity" -> 100.waves,
+      "assetId" -> issueId,
+      "sender" -> firstAddress,
+      "fee" -> 1.waves))
   }
 
   test("/transactions/sign should produce transfer transaction that is good for /transactions/broadcast") {
@@ -117,12 +124,18 @@ class TransactionsApiSuite extends BaseTransactionSuite {
       "attachment" -> Base58.encode("falafel".getBytes)))
   }
 
-  test("/transactions/sign should produce leasing transactions that are good for /transactions/broadcast") {
-    signAndBroadcast(Json.obj(
+  test("/transactions/sign should produce lease/cancel transactions that are good for /transactions/broadcast") {
+    val leaseId = signAndBroadcast(Json.obj(
       "type" -> 8,
       "sender" -> firstAddress,
       "amount" -> 1.waves,
       "recipient" -> secondAddress,
+      "fee" -> 100000))
+
+    signAndBroadcast(Json.obj(
+      "type" -> 9,
+      "sender" -> firstAddress,
+      "txId" -> leaseId,
       "fee" -> 100000))
   }
 

--- a/src/main/scala/scorex/api/http/assets/SignedBurnRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedBurnRequest.scala
@@ -1,15 +1,25 @@
 package scorex.api.http.assets
 
 import io.swagger.annotations.ApiModelProperty
-import play.api.libs.json.{Format, Json}
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
 import scorex.transaction.TransactionParser.SignatureStringLength
-import scorex.transaction.{AssetIdStringLength, ValidationError}
 import scorex.transaction.assets.BurnTransaction
+import scorex.transaction.{AssetIdStringLength, ValidationError}
 
 object SignedBurnRequest {
-  implicit val assetBurnRequestReads: Format[SignedBurnRequest] = Json.format
+  implicit val reads: Reads[SignedBurnRequest] = (
+      (JsPath \ "senderPublicKey").read[String] and
+      (JsPath \ "assetId").read[String] and
+      (JsPath \ "quantity").read[Long].orElse((JsPath \ "amount").read[Long]) and
+      (JsPath \ "fee").read[Long] and
+      (JsPath \ "timestamp").read[Long] and
+      (JsPath \ "signature").read[String]
+    )(SignedBurnRequest.apply _)
+
+  implicit val writes: Writes[SignedBurnRequest] = Json.writes[SignedBurnRequest]
 }
 
 case class SignedBurnRequest(@ApiModelProperty(value = "Base58 encoded Issuer public key", required = true)

--- a/src/main/scala/scorex/api/http/leasing/SignedLeaseCancelRequest.scala
+++ b/src/main/scala/scorex/api/http/leasing/SignedLeaseCancelRequest.scala
@@ -1,7 +1,8 @@
 package scorex.api.http.leasing
 
 import io.swagger.annotations.ApiModelProperty
-import play.api.libs.json.{Format, Json}
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
 import scorex.transaction.TransactionParser.SignatureStringLength
@@ -32,6 +33,14 @@ case class SignedLeaseCancelRequest(@ApiModelProperty(value = "Base58 encoded se
 }
 
 object SignedLeaseCancelRequest {
-  implicit val leaseCancelRequestFormat: Format[SignedLeaseCancelRequest] = Json.format
+  implicit val reads: Reads[SignedLeaseCancelRequest] = (
+      (JsPath \ "senderPublicKey").read[String] and
+      (JsPath \ "txId").read[String].orElse((JsPath \ "leaseId").read[String]) and
+      (JsPath \ "timestamp").read[Long] and
+      (JsPath \ "signature").read[String] and
+      (JsPath \ "fee").read[Long]
+    )(SignedLeaseCancelRequest.apply _)
+
+  implicit val writes: Writes[SignedLeaseCancelRequest] = Json.writes[SignedLeaseCancelRequest]
 }
 


### PR DESCRIPTION
Additional fix for https://wavesplatform.atlassian.net/browse/NODE-387

I'm working around differences in field naming:
"amount" in BurnTransaction but "quantity" in SignedBurnRequest
"leaseId" in LeaseCancelTransaction but "txId" in SignedLeaseCancelRequest

The solution proposed is to provide custom JSON deserializers for SignedRequest classes so that they accept both variants