### PR TITLE
NODE-483 api_key is deprecated, X-API-Key is preferred

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -327,7 +327,7 @@ waves {
     # Enable/disable CORS support
     cors = yes
 
-    # Enable/disable api_key from different host
+    # Enable/disable X-API-Key from different host
     api-key-different-host = no
   }
 

--- a/src/main/resources/swagger-ui/index.html
+++ b/src/main/resources/swagger-ui/index.html
@@ -84,9 +84,9 @@
       $('#input_apiKey').change(function() {
         var key = $('#input_apiKey')[0].value;
         if(key && key.trim() != "") {
-          swaggerUi.api.clientAuthorizations.add("api_key", new SwaggerClient.ApiKeyAuthorization("api_key", key, "header"));
+          swaggerUi.api.clientAuthorizations.add("X-API-Key", new SwaggerClient.ApiKeyAuthorization("X-API-Key", key, "header"));
         }
-      })
+      });
 
       // -------------------------------------------------------------------------------------
 

--- a/src/main/scala/com/wavesplatform/http/api_key.scala
+++ b/src/main/scala/com/wavesplatform/http/api_key.scala
@@ -5,14 +5,23 @@ import akka.http.scaladsl.model.headers._
 import scala.util.Try
 
 object api_key extends ModeledCustomHeaderCompanion[api_key] {
-  override val name = "api_key"
+  override val name = "X-API-Key"
   override def parse(value: String) = Try(new api_key(value))
 }
 
-final class api_key(val key: String) extends ModeledCustomHeader[api_key] {
+final class api_key(override val value: String) extends ModeledCustomHeader[api_key] {
   override def companion = api_key
-  override def value = key
   override def renderInRequests = true
   override def renderInResponses = false
 }
 
+object deprecated_api_key extends ModeledCustomHeaderCompanion[deprecated_api_key] {
+  override val name = "api_key"
+  override def parse(value: String) = Try(new deprecated_api_key(value))
+}
+
+final class deprecated_api_key(override val value: String) extends ModeledCustomHeader[deprecated_api_key] {
+  override def companion = deprecated_api_key
+  override def renderInRequests = true
+  override def renderInResponses = false
+}

--- a/src/main/scala/scorex/api/http/CompositeHttpService.scala
+++ b/src/main/scala/scorex/api/http/CompositeHttpService.scala
@@ -24,7 +24,7 @@ case class CompositeHttpService(system: ActorSystem, apiTypes: Seq[Type], routes
     respondWithHeader(`Access-Control-Allow-Origin`.*) else pass
 
   private val headers: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("Authorization", "Content-Type", "X-Requested-With", "Timestamp", "Signature") ++
-    (if (settings.apiKeyDifferentHost) Seq("api_key") else Seq.empty[String])
+    (if (settings.apiKeyDifferentHost) Seq("api_key", "X-API-Key") else Seq.empty[String])
 
   val compositeRoute: Route =
     withCors(routes.map(_.route).reduce(_ ~ _)) ~

--- a/src/test/scala/com/wavesplatform/http/DebugApiRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/DebugApiRouteSpec.scala
@@ -13,7 +13,7 @@ class DebugApiRouteSpec extends RouteSpec("/debug") with RestAPISettingsHelper w
     null, null, null, null, null, null, null, null, null, null, null, null, null, null, configObject).route
 
   routePath("/configInfo") - {
-    "requires api_key header" in {
+    "requires api-key header" in {
       Get(routePath("/configInfo?full=true")) ~> route should produce(ApiKeyNotValid)
       Get(routePath("/configInfo?full=false")) ~> route should produce(ApiKeyNotValid)
     }

--- a/src/test/scala/com/wavesplatform/http/WalletRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/WalletRouteSpec.scala
@@ -10,11 +10,11 @@ class WalletRouteSpec extends RouteSpec("/wallet") with RestAPISettingsHelper wi
   private val route = WalletApiRoute(restAPISettings, testWallet).route
 
   routePath("/seed") - {
-    "requires api_key header" in {
+    "requires api-key header" in {
       Get(routePath("/seed")) ~> route should produce(ApiKeyNotValid)
     }
 
-    "returns seed when api_key header is present" in {
+    "returns seed when api-key header is present" in {
       Get(routePath("/seed")) ~> api_key(apiKey) ~> route ~> check {
         (responseAs[JsObject] \ "seed").as[String] shouldEqual Base58.encode(testWallet.seed)
       }


### PR DESCRIPTION
- [x] **api_key** works
- [x] **X-API-Key** works