### PR TITLE
NODE-520 API method to return all active leasing transaction

### DIFF
--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -148,7 +148,7 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
         AssetsApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, stateReader, time),
         ActivationApiRoute(settings.restAPISettings, settings.blockchainSettings.functionalitySettings, settings.featuresSettings, history, featureProvider),
         AssetsBroadcastApiRoute(settings.restAPISettings, utxStorage, allChannels),
-        LeaseApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, time),
+        LeaseApiRoute(settings.restAPISettings, wallet, stateReader, utxStorage, allChannels, time),
         LeaseBroadcastApiRoute(settings.restAPISettings, utxStorage, allChannels),
         AliasApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, time, stateReader),
         AliasBroadcastApiRoute(settings.restAPISettings, utxStorage, allChannels)

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -60,7 +60,9 @@ class CompositeStateReader private(inner: SnapshotStateReader, blockDiff: BlockD
     blockDiff.txsDiff.leaseState.getOrElse(leaseTx.id(), inner.isLeaseActive(leaseTx))
 
   override def activeLeases(): Seq[ByteStr] = {
-    blockDiff.txsDiff.leaseState.collect { case (id, isActive) if isActive => id }.toSeq ++ inner.activeLeases()
+    val leaseState = blockDiff.txsDiff.leaseState
+    leaseState.collect { case (id, isActive) if isActive => id }.toSeq ++
+      inner.activeLeases().filter(leaseState.getOrElse(_, true))
   }
 
   override def lastUpdateHeight(acc: Address): Option[Int] = blockDiff.snapshots.get(acc).map(_.lastKey).orElse(inner.lastUpdateHeight(acc))

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -60,9 +60,9 @@ class CompositeStateReader private(inner: SnapshotStateReader, blockDiff: BlockD
     blockDiff.txsDiff.leaseState.getOrElse(leaseTx.id(), inner.isLeaseActive(leaseTx))
 
   override def activeLeases(): Seq[ByteStr] = {
-    val leaseState = blockDiff.txsDiff.leaseState
-    leaseState.collect { case (id, isActive) if isActive => id }.toSeq ++
-      inner.activeLeases().filter(leaseState.getOrElse(_, true))
+    val newestLeaseState = blockDiff.txsDiff.leaseState
+    newestLeaseState.collect { case (id, true) => id }.toSeq ++
+      inner.activeLeases().filter(newestLeaseState.getOrElse(_, true))
   }
 
   override def lastUpdateHeight(acc: Address): Option[Int] = blockDiff.snapshots.get(acc).map(_.lastKey).orElse(inner.lastUpdateHeight(acc))

--- a/src/main/scala/scorex/api/http/leasing/LeaseApiRoute.scala
+++ b/src/main/scala/scorex/api/http/leasing/LeaseApiRoute.scala
@@ -74,8 +74,7 @@ case class LeaseApiRoute(settings: RestAPISettings, wallet: Wallet, state: State
         case Right(a) =>
           state().activeLeases()
             .flatMap(state().transactionInfo)
-            .flatMap(_._2)
-            .filter(_.asInstanceOf[LeaseTransaction].sender.address == address)
+            .collect { case (_, Some(lt: LeaseTransaction)) if lt.sender.address == address => lt }
       })
     }
   }


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-520

A new API endpoint was introduced: GET /leasing/active/{address} . It returns list of all active outgoing leases from that address.

I've also fixed a bug in CompositeStateReader.activeLeases(): when `blockDiff.txsDiff.leaseState` and the inner state report different states for a lease, the former should win