### PR TITLE
NODE-387 leftover: accept both "feeAsset" and "feeAssetId" in SignedTransferRequest

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/TransactionsApiSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/TransactionsApiSuite.scala
@@ -87,7 +87,7 @@ class TransactionsApiSuite extends BaseTransactionSuite {
     Await.result(f, timeout)
   }
 
-  test("/transactions/sign should produce issue/reissue/burn transactions that are good for /transactions/broadcast") {
+  test("/transactions/sign should produce issue/reissue/burn/transfer transactions that are good for /transactions/broadcast") {
     val issueId = signAndBroadcast(Json.obj(
       "type" -> 3,
       "name" -> "Gigacoin",
@@ -112,6 +112,15 @@ class TransactionsApiSuite extends BaseTransactionSuite {
       "assetId" -> issueId,
       "sender" -> firstAddress,
       "fee" -> 1.waves))
+
+    signAndBroadcast(Json.obj(
+      "type" -> 4,
+      "sender" -> firstAddress,
+      "recipient" -> secondAddress,
+      "fee" -> 100000,
+      "assetId" -> issueId,
+      "amount" -> 1.waves,
+      "attachment" -> Base58.encode("asset transfer".getBytes)))
   }
 
   test("/transactions/sign should produce transfer transaction that is good for /transactions/broadcast") {

--- a/src/main/scala/scorex/api/http/assets/SignedTransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedTransferRequest.scala
@@ -1,7 +1,8 @@
 package scorex.api.http.assets
 
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
-import play.api.libs.json.{Format, Json}
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 import scorex.account.{AddressOrAlias, PublicKeyAccount}
 import scorex.api.http.BroadcastRequest
 import scorex.transaction.TransactionParser.SignatureStringLength
@@ -9,7 +10,19 @@ import scorex.transaction.assets.TransferTransaction
 import scorex.transaction.{AssetIdStringLength, ValidationError}
 
 object SignedTransferRequest {
-  implicit val assetTransferRequestFormat: Format[SignedTransferRequest] = Json.format
+  implicit val reads: Reads[SignedTransferRequest] = (
+      (JsPath \ "senderPublicKey").read[String] and
+      (JsPath \ "assetId").readNullable[String] and
+      (JsPath \ "recipient").read[String] and
+      (JsPath \ "amount").read[Long] and
+      (JsPath \ "fee").read[Long] and
+      (JsPath \ "feeAssetId").read[String].map(Option.apply).orElse((JsPath \ "feeAsset").readNullable[String]) and
+      (JsPath \ "timestamp").read[Long] and
+      (JsPath \ "attachment").readNullable[String] and
+      (JsPath \ "signature").read[String]
+    )(SignedTransferRequest.apply _)
+
+  implicit val writes: Writes[SignedTransferRequest] = Json.writes[SignedTransferRequest]
 }
 
 @ApiModel(value = "Signed Asset transfer transaction")


### PR DESCRIPTION
...so that JSON returned from /transactions/sign can be fed right into /transactions/broadcast