### PR TITLE
Node 494 mass transfer api

### DIFF
--- a/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
@@ -19,7 +19,7 @@ object Gen {
     val feeGen = Iterator.continually(minFee + random.nextLong(maxFee - minFee))
     transfers(senderGen, recipientGen, feeGen)
       .zip(massTransfers(senderGen, recipientGen, feeGen))
-      .flatMap { case (tx1, tx2) => Iterator(tx1, tx2) }
+      .flatMap { case (tx1, tx2) => Iterator(tx2, tx1) }
   }
 
   def transfers(senderGen: Iterator[PrivateKeyAccount],

--- a/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
@@ -39,7 +39,8 @@ object Gen {
     val transferCountGen = Iterator.continually(random.nextInt(MassTransferTransaction.MaxTransferCount + 1))
     senderGen.zip(transferCountGen).map { case (sender, count) =>
       val transfers = List.tabulate(count)(_ => ParsedTransfer(recipientGen.next(), amountGen.next()))
-      MassTransferTransaction.create(None, sender, transfers, System.currentTimeMillis, amountGen.next(), Array.emptyByteArray)
+      val fee = 100000 + count * 50000
+      MassTransferTransaction.create(None, sender, transfers, System.currentTimeMillis, fee, Array.emptyByteArray)
     }.collect { case Right(tx) => tx }
   }
 

--- a/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
@@ -19,7 +19,7 @@ object Gen {
     val feeGen = Iterator.continually(minFee + random.nextLong(maxFee - minFee))
     transfers(senderGen, recipientGen, feeGen)
       .zip(massTransfers(senderGen, recipientGen, feeGen))
-      .flatMap { case (tx1, tx2) => Iterator(tx2, tx1) }
+      .flatMap { case (tt, mtt) => Iterator(mtt, tt) }
   }
 
   def transfers(senderGen: Iterator[PrivateKeyAccount],

--- a/src/main/scala/com/wavesplatform/network/BasicMessagesRepo.scala
+++ b/src/main/scala/com/wavesplatform/network/BasicMessagesRepo.scala
@@ -193,8 +193,8 @@ object CheckpointSpec extends MessageSpec[Checkpoint] {
 object TransactionSpec extends MessageSpec[Transaction] {
   override val messageCode: MessageCode = 25: Byte
 
-  // IssueTransaction is the biggest https://github.com/wavesplatform/Waves/wiki/Data-Structures#issue-transaction
-  override val maxLength: Int = 120 + 16 + 1000 + 8
+  // Modeled after MassTransferTransaction https://wavesplatform.atlassian.net/wiki/spaces/MAIN/pages/386171054/Mass+Transfer+Transaction
+  override val maxLength: Int = 5000
 
   override def deserializeData(bytes: Array[Byte]): Try[Transaction] =
     TransactionParser.parseBytes(bytes)


### PR DESCRIPTION
Fixed propagation of MassTransfer transactions:
- Increased `TransactionSpec.maxLength`
- Created a test
- Made sure Generator specifies sufficient fee