### PR TITLE
NODE-619 LeaseStatusTestSuite consistently fails

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/LeaseStatusTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/LeaseStatusTestSuite.scala
@@ -24,8 +24,8 @@ class LeaseStatusTestSuite extends BaseTransactionSuite with CancelAfterFailure 
     val status = getStatus(createdLeaseTxId)
     status shouldBe Active
 
-    val cancelLesingTxId = sender.cancelLease(firstAddress, createdLeaseTxId, fee = transferFee).id
-    notMiner.waitForTransaction(cancelLesingTxId)
+    val cancelLeaseTxId = sender.cancelLease(firstAddress, createdLeaseTxId, fee = transferFee).id
+    notMiner.waitForTransaction(cancelLeaseTxId)
     val status1 = getStatus(createdLeaseTxId)
     status1 shouldBe Canceled
     val sizeActiveLeases = sender.activeLeases(firstAddress).size


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-619

In CompositeStateReader:
```
override def allActiveLeases = diff.leaseState
    .collect { case (id, true) => diff.transactions(id)._2 }
    .collect { case lt: LeaseTransaction => lt }
    .toSet ++ inner.allActiveLeases
```
Problem is, if a lease is canceled in `diff.leaseState` but not in `inner.allActiveLeases`, it will be returned as active. We need to filter such just recently canceled leases from `inner.allActiveLeases`

