### PR TITLE
NODE-615 Versioning transactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - secure: NYdeuFBQVVjN5gon2KQEDfNfyp9Bk6AZJ7V1tfLJW54y5Dd/4PHdWGWeOyhCMIqwX3UaUmWExY1KcKXpbDMLwTmahNLjiDc3e3rCqxghL5cDgqs6OHcwNGw+CwNiw3tufo5PZ9mhK/ZJh0qgOHWyETs/ifq4VyacvgYH9IZzK4YdKYdwf+T9c3Q7VO3KmzOXiHkvPvLfkc8I8cSZlT1kJFCGawRdE/0nygPd8HYfCxiEFuXOKpRz0hlm8njjZdlZpMcou8TLeH5fFSvHtELIHFvSTEj/QilSTmCXgFRVUd8sd53n3uTouwtVbdCHsXNm4Nphf0lUJnN7fTzbD2xpOZN9zS+SO/YTkIxZpSgQLwsJsWzIHI+6IOlcjeNwZHbYBfsAdv1c4GMkgFfxsWWtb4r7+ooXDTbyy1qeZgVU4caGBMwoNE+l0Y60JdGYT4hrTfJ5c+GpcPzIV3CYVOUkHmoCYXRCtxnfDFXCR0mDVfYAA14osLi3v+EKdTxHDfqP6fICIW9y7oZd//38iEQrDy+k9iCyNmvOsqvDxXZithmSP0WzeGCXQDI+s3FxB5ywt8yDvzFbF5JYY74o1tnNFG7TlSF5v8EHSHxzXBeBtnE9V1g2wxYnvW2HYk5kW6WZJgYE9LCc6ubpQ2W387PRfCJjoLNjHqNlNGkEYlkPuaw=
   - secure: rvBDWIiECsp1rI5wUjtw0098Gb2qE4r1uj33w+OtEnszftoZ+XgvvyyyfeykkcAAWob56pOFLox6CO1t/t3YyIyi8sXCPrf1eLBaFt4p6K5czNkWyWY6rlgd/cEXrJeE63UZhx9trN+jiZVjZ7oPpVNSNVAqXhf7dCHWOsKKu7i2gclzGYG1JeBL4eES/WJNVlgcsOdXbWG/udz9A/3+26afgN8Y5N/UMc0PJEmWUKcX7xWfLIcg4UIIvyPp5P55CT698N1jz57GHESDyYrMxMpZOO+0Q26Rjm+7A0U2+mm9XFE7cXT1JNFrJbUs/mvOpjTe0pScT34hRpH1pJcU3vppG/ffJ3IXB9/L2UfWcSemx4pNpdHuvt8Q2otdIlHxZrZpvHAOi6m/HkNBQlNYdRu9hjMVEmJUxiPtLl7npeMfbranEZ+gUtZoFV64aNBV6SUAmsi2supmj9xKmt3R0XOoMCR5zRglm/2EQY2fGhhp+OPrIWgSbGSTXXcUc5hEVM7sdTHo3taIbZsWya6NfjVJ/cxpBjc9hGpuSITU+r0WfSgTLqvEI3cgXQki/ggqVnDM80ft32KIUKIUaoaZSI7r5REps4A1F7HAP9+6VEJRk1p70Ls2IonzDifLij2LQDds1q8LbA9qOQtdj9beAGPvgKPJnBbH4rjNG5k+Iyw=
 script:
-  - sbt -S-Xfatal-warnings clean coverage lang/test test coverageReport
+  - sbt -S-Xfatal-warnings clean coverage lang/test test generator/compile coverageReport
 after_success:
   - "[[ $TRAVIS_REPO_SLUG == \"wavesplatform/Scorex\" ]] && [[ $TRAVIS_BRANCH == \"master\" ]] && { sbt publish; };"
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - secure: NYdeuFBQVVjN5gon2KQEDfNfyp9Bk6AZJ7V1tfLJW54y5Dd/4PHdWGWeOyhCMIqwX3UaUmWExY1KcKXpbDMLwTmahNLjiDc3e3rCqxghL5cDgqs6OHcwNGw+CwNiw3tufo5PZ9mhK/ZJh0qgOHWyETs/ifq4VyacvgYH9IZzK4YdKYdwf+T9c3Q7VO3KmzOXiHkvPvLfkc8I8cSZlT1kJFCGawRdE/0nygPd8HYfCxiEFuXOKpRz0hlm8njjZdlZpMcou8TLeH5fFSvHtELIHFvSTEj/QilSTmCXgFRVUd8sd53n3uTouwtVbdCHsXNm4Nphf0lUJnN7fTzbD2xpOZN9zS+SO/YTkIxZpSgQLwsJsWzIHI+6IOlcjeNwZHbYBfsAdv1c4GMkgFfxsWWtb4r7+ooXDTbyy1qeZgVU4caGBMwoNE+l0Y60JdGYT4hrTfJ5c+GpcPzIV3CYVOUkHmoCYXRCtxnfDFXCR0mDVfYAA14osLi3v+EKdTxHDfqP6fICIW9y7oZd//38iEQrDy+k9iCyNmvOsqvDxXZithmSP0WzeGCXQDI+s3FxB5ywt8yDvzFbF5JYY74o1tnNFG7TlSF5v8EHSHxzXBeBtnE9V1g2wxYnvW2HYk5kW6WZJgYE9LCc6ubpQ2W387PRfCJjoLNjHqNlNGkEYlkPuaw=
   - secure: rvBDWIiECsp1rI5wUjtw0098Gb2qE4r1uj33w+OtEnszftoZ+XgvvyyyfeykkcAAWob56pOFLox6CO1t/t3YyIyi8sXCPrf1eLBaFt4p6K5czNkWyWY6rlgd/cEXrJeE63UZhx9trN+jiZVjZ7oPpVNSNVAqXhf7dCHWOsKKu7i2gclzGYG1JeBL4eES/WJNVlgcsOdXbWG/udz9A/3+26afgN8Y5N/UMc0PJEmWUKcX7xWfLIcg4UIIvyPp5P55CT698N1jz57GHESDyYrMxMpZOO+0Q26Rjm+7A0U2+mm9XFE7cXT1JNFrJbUs/mvOpjTe0pScT34hRpH1pJcU3vppG/ffJ3IXB9/L2UfWcSemx4pNpdHuvt8Q2otdIlHxZrZpvHAOi6m/HkNBQlNYdRu9hjMVEmJUxiPtLl7npeMfbranEZ+gUtZoFV64aNBV6SUAmsi2supmj9xKmt3R0XOoMCR5zRglm/2EQY2fGhhp+OPrIWgSbGSTXXcUc5hEVM7sdTHo3taIbZsWya6NfjVJ/cxpBjc9hGpuSITU+r0WfSgTLqvEI3cgXQki/ggqVnDM80ft32KIUKIUaoaZSI7r5REps4A1F7HAP9+6VEJRk1p70Ls2IonzDifLij2LQDds1q8LbA9qOQtdj9beAGPvgKPJnBbH4rjNG5k+Iyw=
 script:
-  - sbt -S-Xfatal-warnings clean coverage test lang/test coverageReport
+  - sbt -S-Xfatal-warnings clean coverage lang/test test coverageReport
 after_success:
   - "[[ $TRAVIS_REPO_SLUG == \"wavesplatform/Scorex\" ]] && [[ $TRAVIS_BRANCH == \"master\" ]] && { sbt publish; };"
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -194,7 +194,6 @@ lazy val node = project.in(file("."))
       Dependencies.commons_net ++
       Dependencies.monix.value
   )
-  .aggregate(langJVM)
   .dependsOn(langJVM)
 
 lazy val discovery = project

--- a/build.sbt
+++ b/build.sbt
@@ -189,6 +189,7 @@ lazy val node = project.in(file("."))
       Dependencies.matcher ++
       Dependencies.metrics ++
       Dependencies.fp ++
+      Dependencies.meta ++
       Dependencies.ficus ++
       Dependencies.scorex ++
       Dependencies.commons_net ++

--- a/generator/src/main/scala/com.wavesplatform.generator/GeneratorSettings.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/GeneratorSettings.scala
@@ -5,7 +5,6 @@ import java.net.InetSocketAddress
 import cats.Show
 import cats.implicits.showInterpolator
 import scorex.account.PrivateKeyAccount
-import scorex.crypto.encode.Base58
 
 case class GeneratorSettings(chainId: String,
                              accounts: Seq[String],

--- a/generator/src/main/scala/com.wavesplatform.generator/NarrowTransactionGenerator.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/NarrowTransactionGenerator.scala
@@ -6,12 +6,11 @@ import cats.Show
 import com.wavesplatform.generator.NarrowTransactionGenerator.Settings
 import org.slf4j.LoggerFactory
 import scorex.account.{Alias, PrivateKeyAccount}
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.assets.MassTransferTransaction.ParsedTransfer
 import scorex.transaction.assets._
 import scorex.transaction.assets.exchange.{AssetPair, ExchangeTransaction, Order}
 import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
-import scorex.transaction.{CreateAliasTransaction, Proofs, Transaction, ValidationError}
+import scorex.transaction._
 import scorex.utils.LoggerFacade
 
 import scala.concurrent.duration._
@@ -60,12 +59,9 @@ class NarrowTransactionGenerator(settings: Settings,
       case ((allTxsWithValid, validIssueTxs, reissuableIssueTxs, activeLeaseTransactions, aliases), _) =>
         def moreThatStandartFee = 100000L + r.nextInt(100000)
 
-        val txType = typeGen.getRandom
-
         def ts = System.currentTimeMillis()
-
-        val tx = txType match {
-          case TransactionType.IssueTransaction =>
+        val tx = typeGen.getRandom match {
+          case IssueTransaction =>
             val sender = randomFrom(accounts).get
             val name = new Array[Byte](10)
             val description = new Array[Byte](10)
@@ -74,7 +70,7 @@ class NarrowTransactionGenerator(settings: Settings,
             val reissuable = r.nextBoolean()
             val amount = 100000000L + Random.nextInt(Int.MaxValue)
             logOption(IssueTransaction.create(sender, name, description, amount, Random.nextInt(9).toByte, reissuable, 100000000L + r.nextInt(100000000), ts))
-          case TransactionType.TransferTransaction =>
+          case TransferTransaction =>
             val useAlias = r.nextBoolean()
             val recipient = if (useAlias && aliases.nonEmpty) randomFrom(aliases).map(_.alias).get else randomFrom(accounts).get.toAddress
             val sendAsset = r.nextBoolean()
@@ -89,18 +85,18 @@ class NarrowTransactionGenerator(settings: Settings,
               logOption(TransferTransaction.create(asset, sender, recipient, r.nextInt(500000), ts, None, moreThatStandartFee,
                 Array.fill(r.nextInt(100))(r.nextInt().toByte)))
             }
-          case TransactionType.ReissueTransaction =>
+          case ReissueTransaction =>
             val reissuable = r.nextBoolean()
             randomFrom(reissuableIssueTxs).flatMap(assetTx => {
               val sender = accounts.find(_.address == assetTx.sender.address).get
               logOption(ReissueTransaction.create(sender, assetTx.id(), Random.nextInt(Int.MaxValue), reissuable, moreThatStandartFee, ts))
             })
-          case TransactionType.BurnTransaction =>
+          case BurnTransaction =>
             randomFrom(validIssueTxs).flatMap(assetTx => {
               val sender = accounts.find(_.address == assetTx.sender.address).get
               logOption(BurnTransaction.create(sender, assetTx.id(), Random.nextInt(1000), moreThatStandartFee, ts))
             })
-          case TransactionType.ExchangeTransaction =>
+          case ExchangeTransaction =>
             val matcher = randomFrom(accounts).get
             val seller = randomFrom(accounts).get
             val pair = AssetPair(None, Some(tradeAssetIssue.id()))
@@ -108,22 +104,22 @@ class NarrowTransactionGenerator(settings: Settings,
             val buyer = randomFrom(accounts).get
             val buyOrder = Order.buy(buyer, matcher, pair, 100000000, 1, ts, ts + 1.day.toMillis, moreThatStandartFee * 3)
             logOption(ExchangeTransaction.create(matcher, buyOrder, sellOrder, 100000000, 1, 300000, 300000, moreThatStandartFee * 3, ts))
-          case TransactionType.LeaseTransaction =>
+          case LeaseTransaction =>
             val sender = randomFrom(accounts).get
             val useAlias = r.nextBoolean()
             val recipientOpt = if (useAlias && aliases.nonEmpty) randomFrom(aliases.filter(_.sender != sender)).map(_.alias) else randomFrom(accounts.filter(_ != sender).map(_.toAddress))
             recipientOpt.flatMap(recipient =>
               logOption(LeaseTransaction.create(sender, 1, moreThatStandartFee * 3, ts, recipient)))
-          case TransactionType.LeaseCancelTransaction =>
+          case LeaseCancelTransaction =>
             randomFrom(activeLeaseTransactions).flatMap(lease => {
               val sender = accounts.find(_.address == lease.sender.address).get
               logOption(LeaseCancelTransaction.create(sender, lease.id(), moreThatStandartFee * 3, ts))
             })
-          case TransactionType.CreateAliasTransaction =>
+          case CreateAliasTransaction =>
             val sender = randomFrom(accounts).get
             val aliasString = NarrowTransactionGenerator.generateAlias()
             logOption(CreateAliasTransaction.create(sender, Alias.buildWithCurrentNetworkByte(aliasString).right.get, 100000, ts))
-          case TransactionType.MassTransferTransaction =>
+          case MassTransferTransaction =>
             val transferCount = r.nextInt(MassTransferTransaction.MaxTransferCount)
             val transfers = for (i <- 0 to transferCount) yield {
               val useAlias = r.nextBoolean()
@@ -140,7 +136,7 @@ class NarrowTransactionGenerator(settings: Settings,
               })
             } else Some(randomFrom(accounts).get, None)
             senderAndAssetOpt.flatMap { case (sender, asset) =>
-              logOption(MassTransferTransaction.selfSigned(Proofs.Version, asset, sender, transfers.toList, ts, moreThatStandartFee,
+              logOption(MassTransferTransaction.selfSigned(asset, sender, transfers.toList, ts, moreThatStandartFee,
                 Array.fill(r.nextInt(100))(r.nextInt().toByte)))
             }
         }
@@ -172,7 +168,7 @@ class NarrowTransactionGenerator(settings: Settings,
 
 object NarrowTransactionGenerator {
 
-  case class Settings(transactions: Int, probabilities: Map[TransactionType.Value, Double])
+  case class Settings(transactions: Int, probabilities: Map[TransactionParser, Double])
 
   private val minAliasLength = 4
   private val maxAliasLength = 30

--- a/generator/src/main/scala/com.wavesplatform.generator/NarrowTransactionGenerator.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/NarrowTransactionGenerator.scala
@@ -80,7 +80,7 @@ class NarrowTransactionGenerator(settings: Settings,
                 val pk = accounts.find(_ == issue.sender).get
                 (pk, Some(issue.id()))
               })
-            } else Some(randomFrom(accounts).get, None)
+            } else Some((randomFrom(accounts).get, None))
             senderAndAssetOpt.flatMap { case (sender, asset) =>
               logOption(TransferTransaction.create(asset, sender, recipient, r.nextInt(500000), ts, None, moreThatStandartFee,
                 Array.fill(r.nextInt(100))(r.nextInt().toByte)))
@@ -134,9 +134,9 @@ class NarrowTransactionGenerator(settings: Settings,
                 val pk = accounts.find(_ == issue.sender).get
                 (pk, Some(issue.id()))
               })
-            } else Some(randomFrom(accounts).get, None)
+            } else Some((randomFrom(accounts).get, None))
             senderAndAssetOpt.flatMap { case (sender, asset) =>
-              logOption(MassTransferTransaction.selfSigned(asset, sender, transfers.toList, ts, moreThatStandartFee,
+              logOption(MassTransferTransaction.selfSigned(MassTransferTransaction.version, asset, sender, transfers.toList, ts, moreThatStandartFee,
                 Array.fill(r.nextInt(100))(r.nextInt().toByte)))
             }
         }

--- a/generator/src/main/scala/com.wavesplatform.generator/Worker.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/Worker.scala
@@ -55,7 +55,7 @@ class Worker(settings: Settings,
   private def sendTransactions(startStep: Int, channel: Channel): Result[Unit] = {
     def loop(step: Int): Result[Unit] = {
       log.info(s"[$node] Iteration $step")
-      val messages: Seq[RawBytes] = generator.next.map(tx => RawBytes(25.toByte, tx.bytes())).toSeq
+      val messages: Seq[RawBytes] = generator.next.map(RawBytes.from).toSeq
 
       def trySend: Result[Unit] = EitherT {
         sender

--- a/generator/src/main/scala/com.wavesplatform.generator/config/FicusImplicits.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/config/FicusImplicits.scala
@@ -18,7 +18,7 @@ trait FicusImplicits {
 
   implicit val distributionsReader: ValueReader[Map[TransactionParser, Double]] = {
     val converter = CaseFormat.LOWER_HYPHEN.converterTo(CaseFormat.UPPER_CAMEL)
-    def toTxType(key: String): TransactionParser = TransactionParsers.builderBy(s"${converter.convert(key)}Transaction").get
+    def toTxType(key: String): TransactionParser = TransactionParsers.by(s"${converter.convert(key)}Transaction").get
 
     CollectionReaders.mapValueReader[Double].map { xs =>
       xs.map { case (k, v) => toTxType(k) -> v }

--- a/generator/src/main/scala/com.wavesplatform.generator/config/FicusImplicits.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/config/FicusImplicits.scala
@@ -6,7 +6,7 @@ import com.google.common.base.CaseFormat
 import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.{CollectionReaders, ValueReader}
-import scorex.transaction.TransactionParser.TransactionType
+import scorex.transaction.{TransactionParser, TransactionParsers}
 
 trait FicusImplicits {
   implicit val inetSocketAddressReader: ValueReader[InetSocketAddress] = { (config: Config, path: String) =>
@@ -16,9 +16,9 @@ trait FicusImplicits {
     )
   }
 
-  implicit val distributionsReader: ValueReader[Map[TransactionType.Value, Double]] = {
+  implicit val distributionsReader: ValueReader[Map[TransactionParser, Double]] = {
     val converter = CaseFormat.LOWER_HYPHEN.converterTo(CaseFormat.UPPER_CAMEL)
-    def toTxType(key: String): TransactionType.Value = TransactionType.withName(s"${converter.convert(key)}Transaction")
+    def toTxType(key: String): TransactionParser = TransactionParsers.builderBy(s"${converter.convert(key)}Transaction").get
 
     CollectionReaders.mapValueReader[Double].map { xs =>
       xs.map { case (k, v) => toTxType(k) -> v }

--- a/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/utils/Gen.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.generator.utils.Implicits._
 import scorex.account.{Address, PrivateKeyAccount}
 import scorex.transaction.assets.MassTransferTransaction.ParsedTransfer
 import scorex.transaction.assets.{MassTransferTransaction, TransferTransaction}
-import scorex.transaction.{Proofs, Transaction, TransactionParser}
+import scorex.transaction.{Proofs, Transaction, TransactionParsers}
 
 object Gen {
   private def random = ThreadLocalRandom.current
@@ -45,7 +45,7 @@ object Gen {
   }
 
   val address: Iterator[Address] = Iterator.continually {
-    val pk = Array.fill[Byte](TransactionParser.KeyLength)(random.nextInt(Byte.MaxValue).toByte)
+    val pk = Array.fill[Byte](TransactionParsers.KeyLength)(random.nextInt(Byte.MaxValue).toByte)
     Address.fromPublicKey(pk)
   }
 

--- a/it/build.sbt
+++ b/it/build.sbt
@@ -38,13 +38,6 @@ inTask(docker)(Seq(
 
 libraryDependencies ++= Dependencies.testKit ++ Dependencies.itKit
 
-concurrentRestrictions in Global := Seq(
-  Tags.limit(Tags.CPU, 5),
-  Tags.limit(Tags.Network, 5),
-  Tags.limit(Tags.Test, 5),
-  Tags.limitAll(5)
-)
-
 val logDirectory = Def.task {
   val runId = Option(System.getenv("RUN_ID")).getOrElse {
     val formatter = DateTimeFormatter.ofPattern("MM-dd--HH_mm_ss")

--- a/it/src/main/scala/com/wavesplatform/it/IntegrationSuiteWithThreeAddresses.scala
+++ b/it/src/main/scala/com/wavesplatform/it/IntegrationSuiteWithThreeAddresses.scala
@@ -55,7 +55,7 @@ trait IntegrationSuiteWithThreeAddresses extends BeforeAndAfterAll with Matchers
     }
 
     def makeTransfers(accounts: Seq[String]): Future[Seq[String]] = traverse(accounts) { acc =>
-      sender.transfer(sender.address, acc, defaultBalance, sender.fee(TransferTransaction.version)).map(_.id)
+      sender.transfer(sender.address, acc, defaultBalance, sender.fee(TransferTransaction.typeId)).map(_.id)
     }
 
     val correctStartBalancesFuture = for {

--- a/it/src/main/scala/com/wavesplatform/it/IntegrationSuiteWithThreeAddresses.scala
+++ b/it/src/main/scala/com/wavesplatform/it/IntegrationSuiteWithThreeAddresses.scala
@@ -4,7 +4,7 @@ import com.wavesplatform.it.api.AsyncHttpApi._
 import com.wavesplatform.it.util._
 import org.scalatest._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import scorex.transaction.TransactionParser.TransactionType
+import scorex.transaction.assets.TransferTransaction
 import scorex.utils.ScorexLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -55,7 +55,7 @@ trait IntegrationSuiteWithThreeAddresses extends BeforeAndAfterAll with Matchers
     }
 
     def makeTransfers(accounts: Seq[String]): Future[Seq[String]] = traverse(accounts) { acc =>
-      sender.transfer(sender.address, acc, defaultBalance, sender.fee(TransactionType.TransferTransaction)).map(_.id)
+      sender.transfer(sender.address, acc, defaultBalance, sender.fee(TransferTransaction.version)).map(_.id)
     }
 
     val correctStartBalancesFuture = for {

--- a/it/src/main/scala/com/wavesplatform/it/Node.scala
+++ b/it/src/main/scala/com/wavesplatform/it/Node.scala
@@ -10,7 +10,6 @@ import org.asynchttpclient._
 import org.slf4j.LoggerFactory
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
 import scorex.crypto.encode.Base58
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.utils.LoggerFacade
 
 import scala.concurrent.duration.FiniteDuration
@@ -43,8 +42,8 @@ object Node {
 
     def publicKeyStr = Base58.encode(n.publicKey.publicKey)
 
-    def fee(txValue: TransactionType.Value, asset: String = "WAVES"): Long
-     = n.settings.feesSettings.fees(txValue.id).find(_.asset == asset).get.fee
+    def fee(txTypeId: Byte, asset: String = "WAVES"): Long
+     = n.settings.feesSettings.fees(txTypeId).find(_.asset == asset).get.fee
 
     def blockDelay: FiniteDuration = n.settings.blockchainSettings.genesisSettings.averageBlockDelay
   }

--- a/it/src/main/scala/com/wavesplatform/it/Node.scala
+++ b/it/src/main/scala/com/wavesplatform/it/Node.scala
@@ -19,12 +19,14 @@ abstract class Node(config: Config) extends AutoCloseable {
     LoggerFacade(LoggerFactory.getLogger(s"${getClass.getCanonicalName}.${this.name}"))
 
   val settings: WavesSettings = WavesSettings.fromConfig(config)
-  val client: AsyncHttpClient = asyncHttpClient(clientConfig()
-      .setKeepAlive(false).setNettyTimer(GlobalTimer.instance))
+  val client: AsyncHttpClient = asyncHttpClient(
+    clientConfig()
+      .setKeepAlive(false)
+      .setNettyTimer(GlobalTimer.instance))
 
   val privateKey: PrivateKeyAccount = PrivateKeyAccount.fromSeed(config.getString("account-seed")).right.get
-  val publicKey: PublicKeyAccount = PublicKeyAccount.fromBase58String(config.getString("public-key")).right.get
-  val address: String = config.getString("address")
+  val publicKey: PublicKeyAccount   = PublicKeyAccount.fromBase58String(config.getString("public-key")).right.get
+  val address: String               = config.getString("address")
 
   def nodeApiEndpoint: URL
   def matcherApiEndpoint: URL
@@ -42,8 +44,7 @@ object Node {
 
     def publicKeyStr = Base58.encode(n.publicKey.publicKey)
 
-    def fee(txTypeId: Byte, asset: String = "WAVES"): Long
-     = n.settings.feesSettings.fees(txTypeId).find(_.asset == asset).get.fee
+    def fee(txTypeId: Byte, asset: String = "WAVES"): Long = n.settings.feesSettings.fees(txTypeId).find(_.asset == asset).get.fee
 
     def blockDelay: FiniteDuration = n.settings.blockchainSettings.genesisSettings.averageBlockDelay
   }

--- a/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
@@ -251,7 +251,7 @@ object AsyncHttpApi extends Assertions {
     def massTransfer(sourceAddress: String, transfers: List[Transfer], fee: Long, assetId: Option[String] = None): Future[Transaction] = {
       implicit val w = Json.writes[MassTransferRequest]
       postJson("/assets/masstransfer",
-        MassTransferRequest(MassTransferTransaction.Version, assetId, sourceAddress, transfers, fee, None)).as[Transaction]
+        MassTransferRequest(MassTransferTransaction.version, assetId, sourceAddress, transfers, fee, None)).as[Transaction]
     }
 
     def putData(sourceAddress: String, data: List[DataEntry[_]], fee: Long): Future[Transaction] = {
@@ -304,7 +304,7 @@ object AsyncHttpApi extends Assertions {
     }
 
     def createAlias(targetAddress: String, alias: String, fee: Long): Future[Transaction] =
-      postJson("/alias/create", CreateAliasRequest(targetAddress, alias, fee)).as[Transaction]
+      postJson("/alias/create", CreateAliasRequest(None, targetAddress, alias, fee)).as[Transaction]
 
     def aliasByAddress(targetAddress: String): Future[Seq[String]] =
       get(s"/alias/by-address/$targetAddress").as[Seq[String]]

--- a/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
@@ -304,7 +304,7 @@ object AsyncHttpApi extends Assertions {
     }
 
     def createAlias(targetAddress: String, alias: String, fee: Long): Future[Transaction] =
-      postJson("/alias/create", CreateAliasRequest(None, targetAddress, alias, fee)).as[Transaction]
+      postJson("/alias/create", CreateAliasRequest(targetAddress, alias, fee)).as[Transaction]
 
     def aliasByAddress(targetAddress: String): Future[Seq[String]] =
       get(s"/alias/by-address/$targetAddress").as[Seq[String]]

--- a/it/src/test/scala/com/wavesplatform/it/async/network/SimpleTransactionsSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/async/network/SimpleTransactionsSuite.scala
@@ -37,7 +37,7 @@ class SimpleTransactionsSuite extends BaseTransactionSuite with Matchers with Sc
       .right
       .get
     val f = for {
-      _  <- node.sendByNetwork(RawBytes(TransactionSpec.messageCode, tx.bytes()))
+      _ <- node.sendByNetwork(RawBytes.from(tx))
       tx <- node.waitForTransaction(tx.id().base58)
     } yield {
       tx shouldBe Transaction(tx.`type`, tx.id, tx.fee, tx.timestamp)
@@ -58,7 +58,7 @@ class SimpleTransactionsSuite extends BaseTransactionSuite with Matchers with Sc
       .right
       .get
     val f = for {
-      _         <- node.sendByNetwork(RawBytes(TransactionSpec.messageCode, tx.bytes()))
+      _ <- node.sendByNetwork(RawBytes.from(tx))
       maxHeight <- traverse(nodes)(_.height).map(_.max)
       _         <- traverse(nodes)(_.waitForHeight(maxHeight + 1))
       _         <- traverse(nodes)(_.ensureTxDoesntExist(tx.id().base58))

--- a/it/src/test/scala/com/wavesplatform/it/sync/DataTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/DataTransactionSuite.scala
@@ -275,7 +275,6 @@ class DataTransactionSuite extends BaseTransactionSuite {
     val extraSizedData = List.tabulate(MaxEntryCount + 1)(n => BinaryDataEntry(extraKey, ByteStr(Array.fill(MaxValueSize)(n.toByte))))
     assertBadRequestAndResponse(sender.putData(firstAddress, extraSizedData, calcDataFee(extraSizedData)), message)
     nodes.waitForHeightAraise()
-
   }
 
   private def calcDataFee(data: List[DataEntry[_]]): Long = {

--- a/it/src/test/scala/com/wavesplatform/it/sync/MassTransferTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/MassTransferTransactionSuite.scala
@@ -107,7 +107,7 @@ class MassTransferTransactionSuite extends BaseTransactionSuite with CancelAfter
   test("invalid transfer should not be in UTX or blockchain") {
     import scorex.transaction.assets.TransferTransaction.MaxAttachmentSize
 
-    def request(version: Byte = MassTransferTransaction.Version,
+    def request(version: Byte = MassTransferTransaction.version,
                 transfers: List[Transfer] = List(Transfer(secondAddress, transferAmount)),
                 fee: Long = calcFee(1),
                 timestamp: Long = System.currentTimeMillis,

--- a/it/src/test/scala/com/wavesplatform/it/sync/MassTransferTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/MassTransferTransactionSuite.scala
@@ -7,9 +7,8 @@ import org.scalatest.CancelAfterFailure
 import play.api.libs.json.{JsNumber, JsObject, Json}
 import scorex.api.http.assets.SignedMassTransferRequest
 import scorex.crypto.encode.Base58
-import scorex.transaction.TransactionParser.TransactionType
-import scorex.transaction.assets.MassTransferTransaction
 import scorex.transaction.assets.MassTransferTransaction.{MaxTransferCount, Transfer}
+import scorex.transaction.assets.{MassTransferTransaction, TransferTransaction}
 
 import scala.concurrent.duration._
 import scala.util.Random
@@ -20,9 +19,9 @@ class MassTransferTransactionSuite extends BaseTransactionSuite with CancelAfter
   private val transferAmount             = 5.waves
   private val leasingAmount              = 5.waves
   private val leasingFee                 = 0.003.waves
-  private val transferFee                = notMiner.settings.feesSettings.fees(TransactionType.TransferTransaction.id)(0).fee
+  private val transferFee                = notMiner.settings.feesSettings.fees(TransferTransaction.typeId)(0).fee
   private val issueFee                   = 1.waves
-  private val massTransferFeePerTransfer = notMiner.settings.feesSettings.fees(TransactionType.MassTransferTransaction.id)(0).fee
+  private val massTransferFeePerTransfer = notMiner.settings.feesSettings.fees(MassTransferTransaction.typeId)(0).fee
 
   private def calcFee(numberOfRecipients: Int): Long = {
     transferFee + numberOfRecipients * massTransferFeePerTransfer
@@ -132,7 +131,7 @@ class MassTransferTransactionSuite extends BaseTransactionSuite with CancelAfter
     }
 
     implicit val w =
-      Json.writes[SignedMassTransferRequest].transform((jsobj: JsObject) => jsobj + ("type" -> JsNumber(TransactionType.MassTransferTransaction.id)))
+      Json.writes[SignedMassTransferRequest].transform((jsobj: JsObject) => jsobj + ("type" -> JsNumber(MassTransferTransaction.typeId.toInt)))
 
     val (balance1, eff1) = notMiner.accountBalances(firstAddress)
     val invalidTransfers = Seq(
@@ -175,11 +174,11 @@ class MassTransferTransactionSuite extends BaseTransactionSuite with CancelAfter
     val transfers = Seq(Transfer(secondAddress, transferAmount), Transfer(thirdAddress, transferAmount))
     val signedMassTransfer: JsObject = {
       val rs = sender.postJsonWithApiKey("/transactions/sign", Json.obj(
-        "type" -> TransactionType.MassTransferTransaction.id,
-        "version" -> MassTransferTransaction.Version,
-        "sender" -> firstAddress,
+        "type"      -> MassTransferTransaction.typeId,
+        "version"   -> MassTransferTransaction.version,
+        "sender"    -> firstAddress,
         "transfers" -> transfers,
-        "fee" -> fee))
+        "fee"       -> fee))
       Json.parse(rs.getResponseBody).as[JsObject]
     }
     def id(obj: JsObject) = obj.value("id").as[String]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,7 @@ object Dependencies {
     "org.typelevel" %% "cats-core" % "1.0.1",
     "io.github.amrhassan" %% "scalacheck-cats" % "0.4.0" % Test
   )
+  lazy val meta = Seq("com.chuusai" %% "shapeless" % "2.3.3")
   lazy val monix = Def.setting(Seq("io.monix" %%% "monix" % "3.0.0-M3"))
   lazy val scodec = Def.setting(Seq("org.scodec" %%% "scodec-core" % "1.10.3"))
   lazy val fastparse = Def.setting(Seq("com.lihaoyi" %%% "fastparse" % "1.0.0"))

--- a/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
+++ b/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
@@ -259,7 +259,7 @@ object LevelDBWriter {
       Key(byteKeyWithH(17, height, orderId.arr), readVolumeAndFee, writeVolumeAndFee)
 
     private def readTransactionInfo(data: Array[Byte]) =
-      (Ints.fromByteArray(data), TransactionParser.parseBytes(data.drop(4)).get)
+      (Ints.fromByteArray(data), TransactionParsers.parseBytes(data.drop(4)).get)
 
     private def writeTransactionInfo(txInfo: (Int, Transaction)) = {
       val (h, tx) = txInfo
@@ -563,7 +563,7 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings) extends Caches {
     val accountTransactions = (for {
       (id, (tx, addresses)) <- transactions.toSeq
       addressId             <- addresses
-    } yield (addressId, (tx.transactionType.id, id))).groupBy(_._1).mapValues(_.map(_._2))
+    } yield (addressId, (tx.builder.typeId.toInt, id))).groupBy(_._1).mapValues(_.map(_._2))
 
     for ((addressId, txs) <- accountTransactions) {
       rw.put(k.addressTransactionIds(height, addressId), txs)
@@ -628,46 +628,38 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings) extends Caches {
           val ktxId         = k.transactionInfo(txId)
           val Some((_, tx)) = rw.get(ktxId)
 
-          import scorex.transaction.TransactionParser.{TransactionType => T}
-
           rw.delete(ktxId)
-          tx.transactionType match {
-            case T.GenesisTransaction                                                                                      => // genesis transaction can not be rolled back
-            case T.PaymentTransaction | T.TransferTransaction | T.VersionedTransferTransaction | T.MassTransferTransaction => // balances already restored
-            case T.IssueTransaction =>
-              rollbackAssetInfo(rw, tx.id(), currentHeight)
-            case T.ReissueTransaction =>
-              rollbackAssetInfo(rw, tx.asInstanceOf[ReissueTransaction].assetId, currentHeight)
-            case T.BurnTransaction =>
-              rollbackAssetInfo(rw, tx.asInstanceOf[BurnTransaction].assetId, currentHeight)
-            case T.LeaseTransaction =>
-              rw.delete(k.leaseStatus(currentHeight, tx.id()))
-            case T.LeaseCancelTransaction =>
-              rw.delete(k.leaseStatus(currentHeight, tx.asInstanceOf[LeaseCancelTransaction].leaseId))
-            case T.SetScriptTransaction =>
-              val address = tx.asInstanceOf[SetScriptTransaction].sender.toAddress
+          tx match {
+            case _: GenesisTransaction => // genesis transaction can not be rolled back
+            case _: PaymentTransaction | _: TransferTransaction | _: VersionedTransferTransaction | _: MassTransferTransaction => // balances already restored
+            case _: IssueTransaction         => rollbackAssetInfo(rw, tx.id(), currentHeight)
+            case tx: ReissueTransaction      => rollbackAssetInfo(rw, tx.assetId, currentHeight)
+            case tx: BurnTransaction         => rollbackAssetInfo(rw, tx.assetId, currentHeight)
+            case _: LeaseTransaction         => rw.delete(k.leaseStatus(currentHeight, tx.id()))
+            case tx: LeaseCancelTransaction  => rw.delete(k.leaseStatus(currentHeight, tx.leaseId))
+
+            case tx: SetScriptTransaction =>
+              val address = tx.sender.toAddress
               scriptCache.invalidate(address)
               addressIdCache.get(address).foreach { addressId =>
                 rw.delete(k.addressScript(currentHeight, addressId))
                 val kash = k.addressScriptHistory(addressId)
                 rw.put(kash, rw.get(kash).filter(_ != currentHeight))
               }
-            case T.DataTransaction =>
-              val dtx     = tx.asInstanceOf[DataTransaction]
-              val address = dtx.sender.toAddress
+            case tx: DataTransaction =>
+              val address = tx.sender.toAddress
               addressIdCache.get(address).foreach { addressId =>
-                dtx.data.foreach { e =>
+                tx.data.foreach { e =>
                   rw.delete(k.data(currentHeight, addressId, e.key))
                   val kdh = k.dataHistory(addressId, e.key)
                   rw.put(kdh, rw.get(kdh).filter(_ != currentHeight))
                 }
               }
-            case T.CreateAliasTransaction =>
-              rw.delete(k.addressIdOfAlias(tx.asInstanceOf[CreateAliasTransaction].alias))
-            case T.ExchangeTransaction =>
-              val et = tx.asInstanceOf[ExchangeTransaction]
-              rollbackOrderFill(rw, ByteStr(et.buyOrder.id()), currentHeight)
-              rollbackOrderFill(rw, ByteStr(et.sellOrder.id()), currentHeight)
+
+            case tx: CreateAliasTransaction => rw.delete(k.addressIdOfAlias(tx.alias))
+            case tx: ExchangeTransaction =>
+              rollbackOrderFill(rw, ByteStr(tx.buyOrder.id()), currentHeight)
+              rollbackOrderFill(rw, ByteStr(tx.sellOrder.id()), currentHeight)
           }
         }
 
@@ -693,16 +685,12 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings) extends Caches {
 
   override def transactionInfo(id: ByteStr): Option[(Int, Transaction)] = readOnly(db => db.get(k.transactionInfo(id)))
 
-  override def addressTransactions(address: Address,
-                                   types: Set[TransactionParser.TransactionType.Value],
-                                   from: Int,
-                                   count: Int): Seq[(Int, Transaction)] = readOnly { db =>
-    val filter = types.map(_.id)
+  override def addressTransactions(address: Address, from: Int, count: Int, filter: Set[Transaction.Type]): Seq[(Int, Transaction)] = readOnly { db =>
     db.get(k.addressId(address)).fold(Seq.empty[(Int, Transaction)]) { addressId =>
       val txs = for {
         h              <- (db.get(k.height) to 1 by -1).view
         (txType, txId) <- db.get(k.addressTransactionIds(h, addressId))
-        if filter.isEmpty || filter(txType)
+        if filter.isEmpty || filter.contains(txType.toByte)
         (_, tx) <- db.get(k.transactionInfo(txId))
       } yield (h, tx)
 

--- a/src/main/scala/com/wavesplatform/db/LevelDBFactory.scala
+++ b/src/main/scala/com/wavesplatform/db/LevelDBFactory.scala
@@ -19,7 +19,7 @@ object LevelDBFactory extends ScorexLogging {
 
     val f = pairs.flatMap { case (name, loader) =>
       try {
-        val c = loader.loadClass(name).newInstance().asInstanceOf[DBFactory]
+        val c = loader.loadClass(name).getConstructor().newInstance().asInstanceOf[DBFactory]
         log.trace(s"Loaded ${c.getClass.getName} with $loader")
         Some(c)
       } catch {

--- a/src/main/scala/com/wavesplatform/network/BasicMessagesRepo.scala
+++ b/src/main/scala/com/wavesplatform/network/BasicMessagesRepo.scala
@@ -10,8 +10,8 @@ import scorex.account.PublicKeyAccount
 import scorex.block.{Block, MicroBlock}
 import scorex.network.message.Message._
 import scorex.network.message._
-import scorex.transaction.TransactionParser._
-import scorex.transaction.{History, Transaction, TransactionParser}
+import scorex.transaction.TransactionParsers._
+import scorex.transaction.{History, Transaction, TransactionParsers}
 
 import scala.util.Try
 
@@ -71,7 +71,7 @@ object PeersSpec extends MessageSpec[KnownPeers] {
 
 trait SignaturesSeqSpec[A <: AnyRef] extends MessageSpec[A] {
 
-  import scorex.transaction.TransactionParser.SignatureLength
+  import scorex.transaction.TransactionParsers.SignatureLength
 
   private val DataLength = 4
 
@@ -122,7 +122,7 @@ object SignaturesSpec extends SignaturesSeqSpec[Signatures] {
 object GetBlockSpec extends MessageSpec[GetBlock] {
   override val messageCode: MessageCode = 22: Byte
 
-  override val maxLength: Int = TransactionParser.SignatureLength
+  override val maxLength: Int = TransactionParsers.SignatureLength
 
   override def serializeData(signature: GetBlock): Array[Byte] = signature.signature.arr
 
@@ -196,7 +196,7 @@ object TransactionSpec extends MessageSpec[Transaction] {
   override val maxLength: Int = 150000
 
   override def deserializeData(bytes: Array[Byte]): Try[Transaction] =
-    TransactionParser.parseBytes(bytes)
+    TransactionParsers.parseBytes(bytes)
 
   override def serializeData(tx: Transaction): Array[Byte] = tx.bytes()
 }

--- a/src/main/scala/com/wavesplatform/network/Checkpoint.scala
+++ b/src/main/scala/com/wavesplatform/network/Checkpoint.scala
@@ -35,7 +35,7 @@ object Checkpoint {
   implicit val byteArrayReads = new Reads[Array[Byte]] {
     def reads(json: JsValue) = json match {
       case JsString(s) => Base58.decode(s) match {
-        case Success(bytes) if bytes.length == scorex.transaction.TransactionParser.SignatureLength => JsSuccess(bytes)
+        case Success(bytes) if bytes.length == scorex.transaction.TransactionParsers.SignatureLength => JsSuccess(bytes)
         case Success(bytes) => JsError(JsonValidationError("error.incorrect.signatureLength", bytes.length.toString))
         case Failure(t) => JsError(JsonValidationError(Seq("error.incorrect.base58", t.getLocalizedMessage), s))
       }

--- a/src/main/scala/com/wavesplatform/network/UtxPoolSynchronizer.scala
+++ b/src/main/scala/com/wavesplatform/network/UtxPoolSynchronizer.scala
@@ -42,7 +42,7 @@ object UtxPoolSynchronizer {
                   val channelMatcher: ChannelMatcher = { (_: Channel) != sender }
                   xs.foreach { case (_, tx) =>
                     ops.putIfNew(tx) match {
-                      case Right((true, _)) => allChannels.write(RawBytes(TransactionSpec.messageCode, tx.bytes()), channelMatcher)
+                      case Right((true, _)) => allChannels.write(RawBytes.from(tx), channelMatcher)
                       case _ =>
                     }
                   }

--- a/src/main/scala/com/wavesplatform/network/messages.scala
+++ b/src/main/scala/com/wavesplatform/network/messages.scala
@@ -7,7 +7,7 @@ import com.wavesplatform.state2.ByteStr
 import monix.eval.Coeval
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
 import scorex.block.{Block, MicroBlock}
-import scorex.transaction.{History, Signed}
+import scorex.transaction.{History, Signed, Transaction}
 
 sealed trait Message
 
@@ -28,6 +28,10 @@ case class GetBlock(signature: ByteStr) extends Message
 case class LocalScoreChanged(newLocalScore: History.BlockchainScore) extends Message
 
 case class RawBytes(code: Byte, data: Array[Byte]) extends Message
+
+object RawBytes {
+  def from(tx: Transaction): RawBytes = RawBytes(TransactionSpec.messageCode, tx.bytes())
+}
 
 case class BlockForged(block: Block) extends Message
 

--- a/src/main/scala/com/wavesplatform/network/package.scala
+++ b/src/main/scala/com/wavesplatform/network/package.scala
@@ -81,11 +81,9 @@ package object network extends ScorexLogging {
       allChannels.flush(channelMatcher)
     }
 
-    def broadcastTx(tx: Transaction, except: Option[Channel] = None): Unit =
-      allChannels.broadcast(RawBytes(TransactionSpec.messageCode, tx.bytes()), except)
+    def broadcastTx(tx: Transaction, except: Option[Channel] = None): Unit = allChannels.broadcast(RawBytes.from(tx), except)
 
-    def broadcastTx(txs: Seq[Transaction]): Unit =
-      allChannels.broadcastMany(txs.map(tx => RawBytes(TransactionSpec.messageCode, tx.bytes())))
+    def broadcastTx(txs: Seq[Transaction]): Unit = allChannels.broadcastMany(txs.map(RawBytes.from))
 
     private def logBroadcast(message: AnyRef, except: Set[Channel]): Unit = message match {
       case RawBytes(TransactionSpec.messageCode, _) =>

--- a/src/main/scala/com/wavesplatform/settings/FeesSettings.scala
+++ b/src/main/scala/com/wavesplatform/settings/FeesSettings.scala
@@ -22,6 +22,6 @@ object FeesSettings {
 
   private def toTxType(key: String): Int = {
     val name = s"${converter.convert(key)}Transaction"
-    TransactionParsers.builderBy(name).getOrElse(throw new NoSuchElementException(s"Can't find '$name' transaction")).typeId
+    TransactionParsers.by(name).getOrElse(throw new NoSuchElementException(s"Can't find '$name' transaction")).typeId
   }
 }

--- a/src/main/scala/com/wavesplatform/settings/FeesSettings.scala
+++ b/src/main/scala/com/wavesplatform/settings/FeesSettings.scala
@@ -3,7 +3,7 @@ package com.wavesplatform.settings
 import com.google.common.base.CaseFormat
 import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
-import scorex.transaction.TransactionParser.TransactionType
+import scorex.transaction.TransactionParsers
 
 case class FeeSettings(asset: String, fee: Long)
 
@@ -20,6 +20,8 @@ object FeesSettings {
       fees = fs.map { case (asset, fee) => FeeSettings(asset, fee) }.toSeq
     } yield toTxType(txTypeName) -> fees)
 
-  private def toTxType(key: String): Int =
-    TransactionType.withName(s"${converter.convert(key)}Transaction").id
+  private def toTxType(key: String): Int = {
+    val name = s"${converter.convert(key)}Transaction"
+    TransactionParsers.builderBy(name).getOrElse(throw new NoSuchElementException(s"Can't find '$name' transaction")).typeId
+  }
 }

--- a/src/main/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiff.scala
@@ -66,7 +66,7 @@ object AssetTransactionsDiff {
   private def validateAsset(tx: SignedTransaction, state: SnapshotStateReader, assetId: AssetId): Either[ValidationError, Unit] = {
     state.transactionInfo(assetId) match {
       case Some((_, itx: IssueTransaction)) if !(itx.sender equals tx.sender) => Left(GenericError("Asset was issued by other address"))
-      case Some((_, sitx @ SmartIssueTransaction(_, _, _, _, _, _, _, _, None, _, _, _))) if !(sitx.sender equals tx.sender) =>
+      case Some((_, sitx: SmartIssueTransaction)) if sitx.script.isEmpty && !sitx.sender.equals(tx.sender) =>
         Left(GenericError("Asset was issued by other address"))
       case None    => Left(GenericError("Referenced assetId not found"))
       case Some(_) => Right({})

--- a/src/main/scala/com/wavesplatform/state2/patch/CancelLeaseOverflow.scala
+++ b/src/main/scala/com/wavesplatform/state2/patch/CancelLeaseOverflow.scala
@@ -2,7 +2,6 @@ package com.wavesplatform.state2.patch
 
 import com.wavesplatform.state2.reader.SnapshotStateReader
 import com.wavesplatform.state2.{Diff, LeaseBalance, Portfolio}
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.lease.LeaseTransaction
 import scorex.utils.ScorexLogging
 
@@ -12,7 +11,7 @@ object CancelLeaseOverflow extends ScorexLogging {
 
     val addressesWithLeaseOverflow = s.collectPortfolios { p => p.balance < p.lease.out }
     val leasesToCancel = addressesWithLeaseOverflow.keys.flatMap { a =>
-      s.addressTransactions(a, Set(TransactionType.LeaseTransaction), 0, Int.MaxValue).collect {
+      s.addressTransactions(a, 0, Int.MaxValue, Set(LeaseTransaction.typeId)).collect {
         case (_, lt: LeaseTransaction) if lt.sender.toAddress == a => lt.id()
       }
     }

--- a/src/main/scala/com/wavesplatform/state2/patch/CancelLeaseOverflow.scala
+++ b/src/main/scala/com/wavesplatform/state2/patch/CancelLeaseOverflow.scala
@@ -11,7 +11,7 @@ object CancelLeaseOverflow extends ScorexLogging {
 
     val addressesWithLeaseOverflow = s.collectPortfolios { p => p.balance < p.lease.out }
     val leasesToCancel = addressesWithLeaseOverflow.keys.flatMap { a =>
-      s.addressTransactions(a, 0, Int.MaxValue, Set(LeaseTransaction.typeId)).collect {
+      s.addressTransactions(a, Set(LeaseTransaction.typeId), Int.MaxValue, 0).collect {
         case (_, lt: LeaseTransaction) if lt.sender.toAddress == a => lt.id()
       }
     }

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -3,10 +3,10 @@ package com.wavesplatform.state2.reader
 import cats.implicits._
 import com.wavesplatform.state2._
 import scorex.account.{Address, Alias}
+import scorex.transaction.Transaction
 import scorex.transaction.assets.{IssueTransaction, SmartIssueTransaction}
 import scorex.transaction.lease.LeaseTransaction
 import scorex.transaction.smart.Script
-import scorex.transaction.{Transaction, TransactionParser}
 
 class CompositeStateReader(inner: SnapshotStateReader, maybeDiff: => Option[Diff]) extends SnapshotStateReader {
 
@@ -40,19 +40,18 @@ class CompositeStateReader(inner: SnapshotStateReader, maybeDiff: => Option[Diff
 
   override def height: Int = inner.height + (if (maybeDiff.isDefined) 1 else 0)
 
-  override def addressTransactions(address: Address, types: Set[TransactionParser.TransactionType.Value], from: Int, count: Int) = {
-    val transactionsFromDiff = diff.transactions.values.view
-      .collect {
-        case (height, tx, addresses) if addresses(address) && (types(tx.transactionType) || types.isEmpty) => (height, tx)
-      }
-      .slice(from, from + count)
-      .toSeq
+  override def addressTransactions(address: Address,
+                                   from: Int,
+                                   count: Int,
+                                   filter: Set[Transaction.Type]): Seq[(Int, Transaction)] = {
+    val transactionsFromDiff = diff.transactions.values.view.collect {
+      case (height, tx, addresses) if addresses(address) && (filter.isEmpty || filter.contains(tx.builder.typeId)) => (height, tx)
+    }.slice(from, from + count).toSeq
 
     val actualTxCount = transactionsFromDiff.length
 
-    if (actualTxCount == count) transactionsFromDiff
-    else {
-      transactionsFromDiff ++ inner.addressTransactions(address, types, 0, count - actualTxCount)
+    if (actualTxCount == count) transactionsFromDiff else {
+      transactionsFromDiff ++ inner.addressTransactions(address, 0, count - actualTxCount, filter)
     }
   }
 

--- a/src/main/scala/com/wavesplatform/state2/reader/SnapshotStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/SnapshotStateReader.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.state2.reader
 
 import com.wavesplatform.state2._
 import scorex.account.{Address, AddressOrAlias, Alias}
+import scorex.transaction.Transaction.Type
 import scorex.transaction.ValidationError.AliasNotExists
 import scorex.transaction._
 import scorex.transaction.lease.LeaseTransaction
@@ -18,7 +19,7 @@ trait SnapshotStateReader {
 
   def transactionInfo(id: ByteStr): Option[(Int, Transaction)]
 
-  def addressTransactions(address: Address, from: Int, count: Int, filter: Set[Transaction.Type]): Seq[(Int, Transaction)]
+  def addressTransactions(address: Address, types: Set[Type], count: Int, from: Int): Seq[(Int, Transaction)]
 
   def containsTransaction(id: ByteStr): Boolean
 
@@ -70,11 +71,11 @@ object SnapshotStateReader {
     }
 
     def aliasesOfAddress(address: Address): Seq[Alias] =
-      s.addressTransactions(address, 0, Int.MaxValue, Set(CreateAliasTransaction.typeId))
+      s.addressTransactions(address, Set(CreateAliasTransaction.typeId), Int.MaxValue, 0)
         .collect { case (_, a: CreateAliasTransaction) => a.alias }
 
     def activeLeases(address: Address): Seq[LeaseTransaction] =
-      s.addressTransactions(address, 0, Int.MaxValue, Set(LeaseTransaction.typeId))
+      s.addressTransactions(address, Set(LeaseTransaction.typeId), Int.MaxValue, 0)
         .collect { case (_, l: LeaseTransaction) if s.leaseDetails(l.id()).exists(_.isActive) => l }
   }
 

--- a/src/main/scala/com/wavesplatform/state2/reader/SnapshotStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/SnapshotStateReader.scala
@@ -2,7 +2,6 @@ package com.wavesplatform.state2.reader
 
 import com.wavesplatform.state2._
 import scorex.account.{Address, AddressOrAlias, Alias}
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.ValidationError.AliasNotExists
 import scorex.transaction._
 import scorex.transaction.lease.LeaseTransaction
@@ -19,11 +18,7 @@ trait SnapshotStateReader {
 
   def transactionInfo(id: ByteStr): Option[(Int, Transaction)]
 
-  def addressTransactions(
-      address: Address,
-      types: Set[TransactionType.Value],
-      from: Int,
-      count: Int): Seq[(Int, Transaction)]
+  def addressTransactions(address: Address, from: Int, count: Int, filter: Set[Transaction.Type]): Seq[(Int, Transaction)]
 
   def containsTransaction(id: ByteStr): Boolean
 
@@ -59,7 +54,7 @@ object SnapshotStateReader {
     def resolveAliasEi[T <: Transaction](aoa: AddressOrAlias): Either[ValidationError, Address] =
       aoa match {
         case a: Address => Right(a)
-        case a: Alias => s.resolveAlias(a).toRight(AliasNotExists(a))
+        case a: Alias   => s.resolveAlias(a).toRight(AliasNotExists(a))
       }
 
     def effectiveBalance(address: Address, atHeight: Int, confirmations: Int): Long = {
@@ -70,16 +65,17 @@ object SnapshotStateReader {
 
     def balance(address: Address, atHeight: Int, confirmations: Int): Long = {
       val bottomLimit = (atHeight - confirmations + 1).max(1).min(atHeight)
-      val balances = s.balanceSnapshots(address, bottomLimit, atHeight)
+      val balances    = s.balanceSnapshots(address, bottomLimit, atHeight)
       if (balances.isEmpty) 0L else balances.view.map(_.regularBalance).min
     }
 
     def aliasesOfAddress(address: Address): Seq[Alias] =
-      s.addressTransactions(address, Set(TransactionType.CreateAliasTransaction), 0, Int.MaxValue)
-      .collect { case (_, a: CreateAliasTransaction) => a.alias }
+      s.addressTransactions(address, 0, Int.MaxValue, Set(CreateAliasTransaction.typeId))
+        .collect { case (_, a: CreateAliasTransaction) => a.alias }
 
     def activeLeases(address: Address): Seq[LeaseTransaction] =
-      s.addressTransactions(address, Set(TransactionType.LeaseTransaction), 0, Int.MaxValue)
-      .collect { case (_, l: LeaseTransaction) if s.leaseDetails(l.id()).exists(_.isActive) => l }
+      s.addressTransactions(address, 0, Int.MaxValue, Set(LeaseTransaction.typeId))
+        .collect { case (_, l: LeaseTransaction) if s.leaseDetails(l.id()).exists(_.isActive) => l }
   }
+
 }

--- a/src/main/scala/scorex/account/AddressScheme.scala
+++ b/src/main/scala/scorex/account/AddressScheme.scala
@@ -2,6 +2,7 @@ package scorex.account
 
 abstract class AddressScheme {
   val chainId: Byte
+  override def toString: String = s"AddressScheme($chainId)"
 }
 
 object AddressScheme {

--- a/src/main/scala/scorex/account/PublicKeyAccount.scala
+++ b/src/main/scala/scorex/account/PublicKeyAccount.scala
@@ -1,7 +1,7 @@
 package scorex.account
 
 import scorex.crypto.encode.Base58
-import scorex.transaction.TransactionParser
+import scorex.transaction.TransactionParsers
 import scorex.transaction.ValidationError.InvalidAddress
 
 trait PublicKeyAccount {
@@ -31,7 +31,7 @@ object PublicKeyAccount {
 
   def fromBase58String(s: String): Either[InvalidAddress, PublicKeyAccount] =
     (for {
-      _ <- Either.cond(s.length <= TransactionParser.KeyStringLength, (), "Bad public key string length")
+      _ <- Either.cond(s.length <= TransactionParsers.KeyStringLength, (), "Bad public key string length")
       bytes <- Base58.decode(s).toEither.left.map(ex => s"Unable to decode base58: ${ex.getMessage}")
     } yield PublicKeyAccount(bytes)).left.map(err => InvalidAddress(s"Invalid sender: $err"))
 }

--- a/src/main/scala/scorex/api/http/BlocksApiRoute.scala
+++ b/src/main/scala/scorex/api/http/BlocksApiRoute.scala
@@ -98,7 +98,7 @@ case class BlocksApiRoute(settings: RestAPISettings,
     new ApiImplicitParam(name = "signature", value = "Base58-encoded signature", required = true, dataType = "string", paramType = "path")
   ))
   def heightEncoded: Route = (path("height" / Segment) & get) { encodedSignature =>
-    if (encodedSignature.length > TransactionParser.SignatureStringLength)
+    if (encodedSignature.length > TransactionParsers.SignatureStringLength)
       complete(InvalidSignature)
     else {
       ByteStr.decodeBase58(encodedSignature).toOption.toRight(InvalidSignature)
@@ -207,7 +207,7 @@ case class BlocksApiRoute(settings: RestAPISettings,
     new ApiImplicitParam(name = "signature", value = "Base58-encoded signature", required = true, dataType = "string", paramType = "path")
   ))
   def signature: Route = (path("signature" / Segment) & get) { encodedSignature =>
-    if (encodedSignature.length > TransactionParser.SignatureStringLength) complete(InvalidSignature) else {
+    if (encodedSignature.length > TransactionParsers.SignatureStringLength) complete(InvalidSignature) else {
       ByteStr.decodeBase58(encodedSignature).toOption.toRight(InvalidSignature)
         .flatMap(s => history.blockById(s).toRight(BlockDoesNotExist)) match {
         case Right(block) => complete(block.json() + ("height" -> history.heightOf(block.uniqueId).map(Json.toJson(_)).getOrElse(JsNull)))

--- a/src/main/scala/scorex/api/http/CommonApiFunctions.scala
+++ b/src/main/scala/scorex/api/http/CommonApiFunctions.scala
@@ -3,12 +3,12 @@ package scorex.api.http
 import akka.http.scaladsl.server.Directive1
 import com.wavesplatform.state2.ByteStr
 import scorex.block.Block
-import scorex.transaction.{History, TransactionParser}
+import scorex.transaction.{History, TransactionParsers}
 
 
 trait CommonApiFunctions { this: ApiRoute =>
   protected[api] def withBlock(history: History, encodedSignature: String): Directive1[Block] =
-  if (encodedSignature.length > TransactionParser.SignatureStringLength) complete(InvalidSignature) else {
+  if (encodedSignature.length > TransactionParsers.SignatureStringLength) complete(InvalidSignature) else {
     ByteStr.decodeBase58(encodedSignature).toOption.toRight(InvalidSignature)
         .flatMap(s => history.blockById(s).toRight(BlockDoesNotExist)) match {
       case Right(b) => provide(b)

--- a/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -18,9 +18,11 @@ import scorex.api.http.DataRequest._
 import scorex.api.http.alias.{CreateAliasRequest, SignedCreateAliasRequest}
 import scorex.api.http.assets._
 import scorex.api.http.leasing.{LeaseCancelRequest, LeaseRequest, SignedLeaseCancelRequest, SignedLeaseRequest}
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.ValidationError.GenericError
-import scorex.transaction.{History, Transaction, TransactionFactory}
+import scorex.transaction.assets._
+import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
+import scorex.transaction._
+import scorex.transaction.smart.SetScriptTransaction
 import scorex.utils.Time
 import scorex.wallet.Wallet
 
@@ -73,8 +75,8 @@ case class TransactionsApiRoute(settings: RestAPISettings,
               path(Segment) { limitStr =>
                 Exception.allCatch.opt(limitStr.toInt) match {
                   case Some(limit) if limit > 0 && limit <= MaxTransactionsPerRequest =>
-                    complete(Json.arr(JsArray(state.addressTransactions(a, Set.empty, 0, limit).map {
-                      case (h, tx) =>
+                    complete(Json.arr(JsArray(
+                      state.addressTransactions(a, 0, limit, Set.empty).map { case (h, tx) =>
                         txToCompactJson(a, tx) + ("height" -> JsNumber(h))
                     })))
                   case Some(limit) if limit > MaxTransactionsPerRequest =>
@@ -161,22 +163,26 @@ case class TransactionsApiRoute(settings: RestAPISettings,
   def sign: Route = (pathPrefix("sign") & post & withAuth) {
     handleExceptions(jsonExceptionHandler) {
       json[JsObject] { jsv =>
-        import TransactionType._
-        val txEi = TransactionType((jsv \ "type").as[Int]) match {
-          case IssueTransaction             => TransactionFactory.issueAsset(jsv.as[IssueRequest], wallet, time)
-          case TransferTransaction          => TransactionFactory.transferAsset(jsv.as[TransferRequest], wallet, time)
-          case MassTransferTransaction      => TransactionFactory.massTransferAsset(jsv.as[MassTransferRequest], wallet, time)
-          case ReissueTransaction           => TransactionFactory.reissueAsset(jsv.as[ReissueRequest], wallet, time)
-          case BurnTransaction              => TransactionFactory.burnAsset(jsv.as[BurnRequest], wallet, time)
-          case LeaseTransaction             => TransactionFactory.lease(jsv.as[LeaseRequest], wallet, time)
-          case LeaseCancelTransaction       => TransactionFactory.leaseCancel(jsv.as[LeaseCancelRequest], wallet, time)
-          case CreateAliasTransaction       => TransactionFactory.alias(jsv.as[CreateAliasRequest], wallet, time)
-          case DataTransaction              => TransactionFactory.data(jsv.as[DataRequest], wallet, time)
-          case SetScriptTransaction         => TransactionFactory.setScript(jsv.as[SetScriptRequest], wallet, time)
-          case VersionedTransferTransaction => TransactionFactory.versionedTransfer(jsv.as[VersionedTransferRequest], wallet, time)
-          case t                            => Left(GenericError(s"Bad transaction type: $t"))
+        val typeId = (jsv \ "type").as[Byte]
+        val version = (jsv \ "version").asOpt[Byte].getOrElse(1.toByte)
+
+        val r = TransactionParsers.builderBy(typeId, version) match {
+          case None => Left(GenericError(s"Bad transaction type ($typeId) and version ($version)"))
+          case Some(x) => x match {
+            case IssueTransaction => TransactionFactory.issueAsset(jsv.as[IssueRequest], wallet, time)
+            case TransferTransaction => TransactionFactory.transferAsset(jsv.as[TransferRequest], wallet, time)
+            case VersionedTransferTransaction => TransactionFactory.versionedTransfer(jsv.as[VersionedTransferRequest], wallet, time)
+            case MassTransferTransaction => TransactionFactory.massTransferAsset(jsv.as[MassTransferRequest], wallet, time)
+            case ReissueTransaction => TransactionFactory.reissueAsset(jsv.as[ReissueRequest], wallet, time)
+            case BurnTransaction => TransactionFactory.burnAsset(jsv.as[BurnRequest], wallet, time)
+            case LeaseTransaction => TransactionFactory.lease(jsv.as[LeaseRequest], wallet, time)
+            case LeaseCancelTransaction => TransactionFactory.leaseCancel(jsv.as[LeaseCancelRequest], wallet, time)
+            case CreateAliasTransaction => TransactionFactory.alias(jsv.as[CreateAliasRequest], wallet, time)
+            case DataTransaction => TransactionFactory.data(jsv.as[DataRequest], wallet, time)
+            case SetScriptTransaction => TransactionFactory.setScript(jsv.as[SetScriptRequest], wallet, time)
+          }
         }
-        txEi match {
+        r match {
           case Right(tx) => tx.json()
           case Left(err) => ApiError.fromValidationError(err)
         }
@@ -197,22 +203,26 @@ case class TransactionsApiRoute(settings: RestAPISettings,
   def broadcast: Route = (pathPrefix("broadcast") & post) {
     handleExceptions(jsonExceptionHandler) {
       json[JsObject] { jsv =>
-        import TransactionType._
-        val req = TransactionType((jsv \ "type").as[Int]) match {
-          case IssueTransaction             => jsv.as[SignedIssueRequest].toTx
-          case TransferTransaction          => jsv.as[SignedTransferRequest].toTx
-          case MassTransferTransaction      => jsv.as[SignedMassTransferRequest].toTx
-          case ReissueTransaction           => jsv.as[SignedReissueRequest].toTx
-          case BurnTransaction              => jsv.as[SignedBurnRequest].toTx
-          case LeaseTransaction             => jsv.as[SignedLeaseRequest].toTx
-          case LeaseCancelTransaction       => jsv.as[SignedLeaseCancelRequest].toTx
-          case CreateAliasTransaction       => jsv.as[SignedCreateAliasRequest].toTx
-          case DataTransaction              => jsv.as[SignedDataRequest].toTx
-          case SetScriptTransaction         => jsv.as[SignedSetScriptRequest].toTx
-          case VersionedTransferTransaction => jsv.as[SignedVersionedTransferRequest].toTx
-          case t                            => Left(GenericError(s"Bad transaction type: $t"))
+        val typeId = (jsv \ "type").as[Byte]
+        val version = (jsv \ "version").asOpt[Byte].getOrElse(1.toByte)
+
+        val r = TransactionParsers.builderBy(typeId, version) match {
+          case None => Left(GenericError(s"Bad transaction type ($typeId) and version ($version)"))
+          case Some(x) => x match {
+            case IssueTransaction => jsv.as[SignedIssueRequest].toTx
+            case TransferTransaction => jsv.as[SignedTransferRequest].toTx
+            case VersionedTransferTransaction => jsv.as[SignedVersionedTransferRequest].toTx
+            case MassTransferTransaction => jsv.as[SignedMassTransferRequest].toTx
+            case ReissueTransaction => jsv.as[SignedReissueRequest].toTx
+            case BurnTransaction => jsv.as[SignedBurnRequest].toTx
+            case LeaseTransaction => jsv.as[SignedLeaseRequest].toTx
+            case LeaseCancelTransaction => jsv.as[SignedLeaseCancelRequest].toTx
+            case CreateAliasTransaction => jsv.as[SignedCreateAliasRequest].toTx
+            case DataTransaction => jsv.as[SignedDataRequest].toTx
+            case SetScriptTransaction => jsv.as[SignedSetScriptRequest].toTx
+          }
         }
-        doBroadcast(req)
+        doBroadcast(r)
       }
     }
   }

--- a/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -76,7 +76,7 @@ case class TransactionsApiRoute(settings: RestAPISettings,
                 Exception.allCatch.opt(limitStr.toInt) match {
                   case Some(limit) if limit > 0 && limit <= MaxTransactionsPerRequest =>
                     complete(Json.arr(JsArray(
-                      state.addressTransactions(a, 0, limit, Set.empty).map { case (h, tx) =>
+                      state.addressTransactions(a, Set.empty, limit, 0).map { case (h, tx) =>
                         txToCompactJson(a, tx) + ("height" -> JsNumber(h))
                     })))
                   case Some(limit) if limit > MaxTransactionsPerRequest =>
@@ -166,7 +166,7 @@ case class TransactionsApiRoute(settings: RestAPISettings,
         val typeId = (jsv \ "type").as[Byte]
         val version = (jsv \ "version").asOpt[Byte].getOrElse(1.toByte)
 
-        val r = TransactionParsers.builderBy(typeId, version) match {
+        val r = TransactionParsers.by(typeId, version) match {
           case None => Left(GenericError(s"Bad transaction type ($typeId) and version ($version)"))
           case Some(x) => x match {
             case IssueTransaction => TransactionFactory.issueAsset(jsv.as[IssueRequest], wallet, time)
@@ -206,7 +206,7 @@ case class TransactionsApiRoute(settings: RestAPISettings,
         val typeId = (jsv \ "type").as[Byte]
         val version = (jsv \ "version").asOpt[Byte].getOrElse(1.toByte)
 
-        val r = TransactionParsers.builderBy(typeId, version) match {
+        val r = TransactionParsers.by(typeId, version) match {
           case None => Left(GenericError(s"Bad transaction type ($typeId) and version ($version)"))
           case Some(x) => x match {
             case IssueTransaction => jsv.as[SignedIssueRequest].toTx

--- a/src/main/scala/scorex/api/http/alias/CreateAliasRequest.scala
+++ b/src/main/scala/scorex/api/http/alias/CreateAliasRequest.scala
@@ -3,9 +3,7 @@ package scorex.api.http.alias
 import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{Format, Json}
 
-case class CreateAliasRequest(@ApiModelProperty(value = "Version")
-                              version: Option[Byte],
-                              @ApiModelProperty(value = "Base58 encoded sender public key", required = true)
+case class CreateAliasRequest(@ApiModelProperty(value = "Base58 encoded sender public key", required = true)
                               sender: String,
                               @ApiModelProperty(value = "Alias", required = true)
                               alias: String,

--- a/src/main/scala/scorex/api/http/alias/CreateAliasRequest.scala
+++ b/src/main/scala/scorex/api/http/alias/CreateAliasRequest.scala
@@ -3,7 +3,9 @@ package scorex.api.http.alias
 import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{Format, Json}
 
-case class CreateAliasRequest(@ApiModelProperty(value = "Base58 encoded sender public key", required = true)
+case class CreateAliasRequest(@ApiModelProperty(value = "Version")
+                              version: Option[Byte],
+                              @ApiModelProperty(value = "Base58 encoded sender public key", required = true)
                               sender: String,
                               @ApiModelProperty(value = "Alias", required = true)
                               alias: String,

--- a/src/main/scala/scorex/api/http/alias/SignedCreateAliasRequest.scala
+++ b/src/main/scala/scorex/api/http/alias/SignedCreateAliasRequest.scala
@@ -4,7 +4,7 @@ import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{Format, Json}
 import scorex.account.{Alias, PublicKeyAccount}
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.{CreateAliasTransaction, ValidationError}
 
 case class SignedCreateAliasRequest(@ApiModelProperty(value = "Base58 encoded sender public key", required = true)

--- a/src/main/scala/scorex/api/http/assets/AssetsBroadcastApiRoute.scala
+++ b/src/main/scala/scorex/api/http/assets/AssetsBroadcastApiRoute.scala
@@ -170,8 +170,16 @@ case class AssetsBroadcastApiRoute(settings: RestAPISettings,
     new ApiResponse(code = 200, message = "Json with signed Asset transfer transaction"),
     new ApiResponse(code = 400, message = "Json with error description", response = classOf[ApiErrorResponse])))
   def transfer: Route = (path("transfer") & post) {
-    json[SignedTransferRequest] { transferReq =>
-      doBroadcast(transferReq.toTx)
+    json[SignedTransferRequests] { transferReq =>
+      doBroadcast(
+        transferReq.eliminate(
+          _.toTx,
+          _.eliminate(
+            _.toTx,
+            _ => Left(ValidationError.UnsupportedTransactionType)
+          )
+        )
+      )
     }
   }
 

--- a/src/main/scala/scorex/api/http/assets/BurnRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/BurnRequest.scala
@@ -2,8 +2,11 @@ package scorex.api.http.assets
 
 import play.api.libs.json._
 
-
-case class BurnRequest(sender: String, assetId: String, quantity: Long, fee: Long, timestamp: Option[Long] = None)
+case class BurnRequest(sender: String,
+                       assetId: String,
+                       quantity: Long,
+                       fee: Long,
+                       timestamp: Option[Long] = None)
 
 object BurnRequest {
   implicit val burnFormat: Format[BurnRequest] = Json.format

--- a/src/main/scala/scorex/api/http/assets/IssueRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/IssueRequest.scala
@@ -3,16 +3,15 @@ package scorex.api.http.assets
 import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{Format, Json}
 
-
 case class IssueRequest(sender: String,
-  name: String,
-  description: String,
-  quantity: Long,
-  @ApiModelProperty(allowableValues = "range[0,8]", example = "8", dataType = "integer", required = true)
-  decimals: Byte,
-  reissuable: Boolean,
-  fee: Long,
-  timestamp: Option[Long] = None)
+                        name: String,
+                        description: String,
+                        quantity: Long,
+                        @ApiModelProperty(allowableValues = "range[0,8]", example = "8", dataType = "integer", required = true)
+                        decimals: Byte,
+                        reissuable: Boolean,
+                        fee: Long,
+                        timestamp: Option[Long] = None)
 
 object IssueRequest {
   implicit val issueFormat: Format[IssueRequest] = Json.format

--- a/src/main/scala/scorex/api/http/assets/ReissueRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/ReissueRequest.scala
@@ -2,7 +2,12 @@ package scorex.api.http.assets
 
 import play.api.libs.json.{Format, Json}
 
-case class ReissueRequest(sender: String, assetId: String, quantity: Long, reissuable: Boolean, fee: Long, timestamp: Option[Long] = None)
+case class ReissueRequest(sender: String,
+                          assetId: String,
+                          quantity: Long,
+                          reissuable: Boolean,
+                          fee: Long,
+                          timestamp: Option[Long] = None)
 
 object ReissueRequest {
   implicit val reissueFormat: Format[ReissueRequest] = Json.format

--- a/src/main/scala/scorex/api/http/assets/SetScriptRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SetScriptRequest.scala
@@ -2,7 +2,8 @@ package scorex.api.http.assets
 
 import play.api.libs.json.{Format, Json}
 
-case class SetScriptRequest(sender: String,
+case class SetScriptRequest(version: Byte,
+                            sender: String,
                             script: Option[String],
                             fee: Long,
                             timestamp: Option[Long] = None)

--- a/src/main/scala/scorex/api/http/assets/SignedBurnRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedBurnRequest.scala
@@ -5,40 +5,42 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.assets.BurnTransaction
 import scorex.transaction.{AssetIdStringLength, ValidationError}
 
 object SignedBurnRequest {
   implicit val reads: Reads[SignedBurnRequest] = (
-      (JsPath \ "senderPublicKey").read[String] and
+    (JsPath \ "senderPublicKey").read[String] and
       (JsPath \ "assetId").read[String] and
       (JsPath \ "quantity").read[Long].orElse((JsPath \ "amount").read[Long]) and
       (JsPath \ "fee").read[Long] and
       (JsPath \ "timestamp").read[Long] and
       (JsPath \ "signature").read[String]
-    )(SignedBurnRequest.apply _)
+  )(SignedBurnRequest.apply _)
 
   implicit val writes: Writes[SignedBurnRequest] = Json.writes[SignedBurnRequest]
 }
 
 case class SignedBurnRequest(@ApiModelProperty(value = "Base58 encoded Issuer public key", required = true)
-                            senderPublicKey: String,
+                             senderPublicKey: String,
                              @ApiModelProperty(value = "Base58 encoded Asset ID", required = true)
-                            assetId: String,
+                             assetId: String,
                              @ApiModelProperty(required = true, example = "1000000")
-                            quantity: Long,
+                             quantity: Long,
                              @ApiModelProperty(required = true)
-                            fee: Long,
+                             fee: Long,
                              @ApiModelProperty(required = true)
-                            timestamp: Long,
+                             timestamp: Long,
                              @ApiModelProperty(required = true)
-                            signature: String) extends BroadcastRequest {
+                             signature: String)
+    extends BroadcastRequest {
 
-  def toTx: Either[ValidationError, BurnTransaction] = for {
-    _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
-    _assetId <- parseBase58(assetId, "invalid.assetId", AssetIdStringLength)
-    _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
-    _t <- BurnTransaction.create(_sender, _assetId, quantity, fee, timestamp, _signature)
-  } yield _t
+  def toTx: Either[ValidationError, BurnTransaction] =
+    for {
+      _sender    <- PublicKeyAccount.fromBase58String(senderPublicKey)
+      _assetId   <- parseBase58(assetId, "invalid.assetId", AssetIdStringLength)
+      _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
+      _t         <- BurnTransaction.create(_sender, _assetId, quantity, fee, timestamp, _signature)
+    } yield _t
 }

--- a/src/main/scala/scorex/api/http/assets/SignedExchangeRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedExchangeRequest.scala
@@ -4,12 +4,12 @@ import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{Format, Json}
 import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.ValidationError
 import scorex.transaction.assets.exchange.{ExchangeTransaction, Order}
-import scorex.transaction.assets.exchange.OrderJson.orderFormat
 
 object SignedExchangeRequest {
+  implicit val orderFormat: Format[Order] = scorex.transaction.assets.exchange.OrderJson.orderFormat
   implicit val signedExchangeRequestFormat: Format[SignedExchangeRequest] = Json.format
 }
 
@@ -37,6 +37,6 @@ case class SignedExchangeRequest(@ApiModelProperty(value = "Base58 encoded sende
     _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
     _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
     _t <- ExchangeTransaction.create(order1, order2, price, amount, buyMatcherFee, sellMatcherFee, fee, timestamp,
-        _signature)
+      _signature)
   } yield _t
 }

--- a/src/main/scala/scorex/api/http/assets/SignedIssueRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedIssueRequest.scala
@@ -5,10 +5,9 @@ import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import play.api.libs.json.{Format, Json}
 import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.ValidationError
 import scorex.transaction.assets.IssueTransaction
-
 
 object SignedIssueRequest {
   implicit val assetIssueRequestReads: Format[SignedIssueRequest] = Json.format
@@ -16,23 +15,23 @@ object SignedIssueRequest {
 
 @ApiModel(value = "Signed Asset issue transaction")
 case class SignedIssueRequest(@ApiModelProperty(value = "Base58 encoded Issuer public key", required = true)
-                             senderPublicKey: String,
+                              senderPublicKey: String,
                               @ApiModelProperty(value = "Base58 encoded name of Asset", required = true)
-                             name: String,
+                              name: String,
                               @ApiModelProperty(value = "Base58 encoded description of Asset", required = true)
-                             description: String,
+                              description: String,
                               @ApiModelProperty(required = true, example = "1000000")
-                             quantity: Long,
+                              quantity: Long,
                               @ApiModelProperty(allowableValues = "range[0,8]", example = "8", dataType = "integer", required = true)
-                             decimals: Byte,
+                              decimals: Byte,
                               @ApiModelProperty(required = true)
-                             reissuable: Boolean,
+                              reissuable: Boolean,
                               @ApiModelProperty(required = true)
-                             fee: Long,
+                              fee: Long,
                               @ApiModelProperty(required = true)
-                             timestamp: Long,
+                              timestamp: Long,
                               @ApiModelProperty(required = true)
-                             signature: String) extends BroadcastRequest {
+                              signature: String) extends BroadcastRequest {
   def toTx: Either[ValidationError, IssueTransaction] = for {
     _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
     _signature <- parseBase58(signature, "invalid signature", SignatureStringLength)

--- a/src/main/scala/scorex/api/http/assets/SignedMassTransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedMassTransferRequest.scala
@@ -37,6 +37,6 @@ case class SignedMassTransferRequest(@ApiModelProperty(required = true)
     _proofs <- Proofs.create(_proofBytes)
     _attachment <- parseBase58(attachment.filter(_.length > 0), "invalid.attachment", TransferTransaction.MaxAttachmentStringSize)
     _transfers <- MassTransferTransaction.parseTransfersList(transfers)
-    t <- MassTransferTransaction.create(MassTransferTransaction.Version, _assetId, _sender, _transfers, timestamp, fee, _attachment.arr, _proofs)
+    t <- MassTransferTransaction.create(version, _assetId, _sender, _transfers, timestamp, fee, _attachment.arr, _proofs)
   } yield t
 }

--- a/src/main/scala/scorex/api/http/assets/SignedReissueRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedReissueRequest.scala
@@ -4,28 +4,28 @@ import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{Format, Json}
 import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
-import scorex.transaction.{AssetIdStringLength, ValidationError}
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.assets.ReissueTransaction
+import scorex.transaction.{AssetIdStringLength, ValidationError}
 
 object SignedReissueRequest {
   implicit val assetReissueRequestReads: Format[SignedReissueRequest] = Json.format
 }
 
 case class SignedReissueRequest(@ApiModelProperty(value = "Base58 encoded Issuer public key", required = true)
-                               senderPublicKey: String,
+                                senderPublicKey: String,
                                 @ApiModelProperty(value = "Base58 encoded Asset ID", required = true)
-                               assetId: String,
+                                assetId: String,
                                 @ApiModelProperty(required = true, example = "1000000")
-                               quantity: Long,
+                                quantity: Long,
                                 @ApiModelProperty(required = true)
-                               reissuable: Boolean,
+                                reissuable: Boolean,
                                 @ApiModelProperty(required = true)
-                               fee: Long,
+                                fee: Long,
                                 @ApiModelProperty(required = true)
-                               timestamp: Long,
+                                timestamp: Long,
                                 @ApiModelProperty(required = true)
-                               signature: String) extends BroadcastRequest {
+                                signature: String) extends BroadcastRequest {
   def toTx: Either[ValidationError, ReissueTransaction] = for {
     _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
     _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)

--- a/src/main/scala/scorex/api/http/assets/SignedSetScriptRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedSetScriptRequest.scala
@@ -13,7 +13,9 @@ object SignedSetScriptRequest {
 }
 
 @ApiModel(value = "Proven SetScript transaction")
-case class SignedSetScriptRequest(@ApiModelProperty(value = "Base58 encoded sender public key", required = true)
+case class SignedSetScriptRequest(@ApiModelProperty(required = true)
+                                  version: Byte,
+                                  @ApiModelProperty(value = "Base58 encoded sender public key", required = true)
                                   senderPublicKey: String,
                                   @ApiModelProperty(value = "Base58 encoded script(including version and checksum)", required = true)
                                   script: Option[String],
@@ -35,6 +37,6 @@ case class SignedSetScriptRequest(@ApiModelProperty(value = "Base58 encoded send
       }
       _proofBytes <- proofs.traverse(s => parseBase58(s, "invalid proof", Proofs.MaxProofStringSize))
       _proofs     <- Proofs.create(_proofBytes)
-      t           <- SetScriptTransaction.create(_sender, _script, fee, timestamp, _proofs)
+      t           <- SetScriptTransaction.create(version, _sender, _script, fee, timestamp, _proofs)
     } yield t
 }

--- a/src/main/scala/scorex/api/http/assets/SignedSetScriptRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedSetScriptRequest.scala
@@ -24,9 +24,7 @@ case class SignedSetScriptRequest(@ApiModelProperty(required = true)
                                   @ApiModelProperty(required = true)
                                   timestamp: Long,
                                   @ApiModelProperty(required = true)
-                                  proofs: List[String],
-                                  @ApiModelProperty(required = true)
-                                  version: Int)
+                                  proofs: List[String])
     extends BroadcastRequest {
   def toTx: Either[ValidationError, SetScriptTransaction] =
     for {

--- a/src/main/scala/scorex/api/http/assets/SignedTransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedTransferRequest.scala
@@ -5,13 +5,13 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import scorex.account.{AddressOrAlias, PublicKeyAccount}
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.assets.TransferTransaction
 import scorex.transaction.{AssetIdStringLength, ValidationError}
 
 object SignedTransferRequest {
   implicit val reads: Reads[SignedTransferRequest] = (
-      (JsPath \ "senderPublicKey").read[String] and
+    (JsPath \ "senderPublicKey").read[String] and
       (JsPath \ "assetId").readNullable[String] and
       (JsPath \ "recipient").read[String] and
       (JsPath \ "amount").read[Long] and
@@ -20,37 +20,39 @@ object SignedTransferRequest {
       (JsPath \ "timestamp").read[Long] and
       (JsPath \ "attachment").readNullable[String] and
       (JsPath \ "signature").read[String]
-    )(SignedTransferRequest.apply _)
+  )(SignedTransferRequest.apply _)
 
   implicit val writes: Writes[SignedTransferRequest] = Json.writes[SignedTransferRequest]
 }
 
 @ApiModel(value = "Signed Asset transfer transaction")
 case class SignedTransferRequest(@ApiModelProperty(value = "Base58 encoded sender public key", required = true)
-                                senderPublicKey: String,
+                                 senderPublicKey: String,
                                  @ApiModelProperty(value = "Base58 encoded Asset ID")
-                                assetId: Option[String],
+                                 assetId: Option[String],
                                  @ApiModelProperty(value = "Recipient address", required = true)
-                                recipient: String,
+                                 recipient: String,
                                  @ApiModelProperty(required = true, example = "1000000")
-                                amount: Long,
+                                 amount: Long,
                                  @ApiModelProperty(required = true)
-                                fee: Long,
+                                 fee: Long,
                                  @ApiModelProperty(value = "Fee asset ID")
-                                feeAssetId: Option[String],
+                                 feeAssetId: Option[String],
                                  @ApiModelProperty(required = true)
-                                timestamp: Long,
+                                 timestamp: Long,
                                  @ApiModelProperty(value = "Base58 encoded attachment")
-                                attachment: Option[String],
+                                 attachment: Option[String],
                                  @ApiModelProperty(required = true)
-                                signature: String) extends BroadcastRequest {
-  def toTx: Either[ValidationError, TransferTransaction] = for {
-    _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
-    _assetId <- parseBase58ToOption(assetId.filter(_.length > 0), "invalid.assetId", AssetIdStringLength)
-    _feeAssetId <- parseBase58ToOption(feeAssetId.filter(_.length > 0), "invalid.feeAssetId", AssetIdStringLength)
-    _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
-    _attachment <- parseBase58(attachment.filter(_.length > 0), "invalid.attachment", TransferTransaction.MaxAttachmentStringSize)
-    _account <-  AddressOrAlias.fromString(recipient)
-    t <- TransferTransaction.create(_assetId, _sender, _account, amount, timestamp, _feeAssetId, fee, _attachment.arr,  _signature)
-  } yield t
+                                 signature: String)
+    extends BroadcastRequest {
+  def toTx: Either[ValidationError, TransferTransaction] =
+    for {
+      _sender     <- PublicKeyAccount.fromBase58String(senderPublicKey)
+      _assetId    <- parseBase58ToOption(assetId.filter(_.length > 0), "invalid.assetId", AssetIdStringLength)
+      _feeAssetId <- parseBase58ToOption(feeAssetId.filter(_.length > 0), "invalid.feeAssetId", AssetIdStringLength)
+      _signature  <- parseBase58(signature, "invalid.signature", SignatureStringLength)
+      _attachment <- parseBase58(attachment.filter(_.length > 0), "invalid.attachment", TransferTransaction.MaxAttachmentStringSize)
+      _account    <- AddressOrAlias.fromString(recipient)
+      t           <- TransferTransaction.create(_assetId, _sender, _account, amount, timestamp, _feeAssetId, fee, _attachment.arr, _signature)
+    } yield t
 }

--- a/src/main/scala/scorex/api/http/assets/SignedVersionedTransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedVersionedTransferRequest.scala
@@ -26,7 +26,7 @@ case class SignedVersionedTransferRequest(@ApiModelProperty(value = "Base58 enco
                                           @ApiModelProperty(required = true)
                                           timestamp: Long,
                                           @ApiModelProperty(required = true)
-                                          version: Int,
+                                          version: Byte,
                                           @ApiModelProperty(value = "Base58 encoded attachment")
                                           attachment: Option[String],
                                           @ApiModelProperty(required = true)
@@ -40,6 +40,6 @@ case class SignedVersionedTransferRequest(@ApiModelProperty(value = "Base58 enco
       _proofs     <- Proofs.create(_proofBytes)
       _recipient <- AddressOrAlias.fromString(recipient)
       _attachment <- parseBase58(attachment.filter(_.length > 0), "invalid.attachment", TransferTransaction.MaxAttachmentStringSize)
-      t           <- VersionedTransferTransaction.create(version.toByte, _assetId, _sender,_recipient, amount, timestamp, fee, _attachment.arr, _proofs)
+      t           <- VersionedTransferTransaction.create(version, _assetId, _sender,_recipient, amount, timestamp, fee, _attachment.arr, _proofs)
     } yield t
 }

--- a/src/main/scala/scorex/api/http/assets/SignedVersionedTransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedVersionedTransferRequest.scala
@@ -9,7 +9,7 @@ import scorex.transaction.assets.{TransferTransaction, VersionedTransferTransact
 import scorex.transaction.{AssetIdStringLength, Proofs, ValidationError}
 
 object SignedVersionedTransferRequest {
-   implicit val jsonFormat: OFormat[SignedVersionedTransferRequest] = Json.format
+   implicit val format: OFormat[SignedVersionedTransferRequest] = Json.format
 }
 
 @ApiModel(value = "Signed Asset transfer transaction")

--- a/src/main/scala/scorex/api/http/assets/TransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/TransferRequest.scala
@@ -12,5 +12,5 @@ case class TransferRequest(assetId: Option[String],
                            timestamp: Option[Long] = None)
 
 object TransferRequest {
-  implicit val transferFormat: Format[TransferRequest] = Json.format
+  implicit val format: Format[TransferRequest] = Json.format
 }

--- a/src/main/scala/scorex/api/http/assets/VersionedTransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/VersionedTransferRequest.scala
@@ -2,7 +2,8 @@ package scorex.api.http.assets
 
 import play.api.libs.json.{Format, Json}
 
-case class VersionedTransferRequest(assetId: Option[String],
+case class VersionedTransferRequest(version: Byte,
+                                    assetId: Option[String],
                                     amount: Long,
                                     fee: Long,
                                     sender: String,

--- a/src/main/scala/scorex/api/http/assets/VersionedTransferRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/VersionedTransferRequest.scala
@@ -12,5 +12,5 @@ case class VersionedTransferRequest(version: Byte,
                                     timestamp: Option[Long] = None)
 
 object VersionedTransferRequest {
-  implicit val versionedTransferFormat: Format[VersionedTransferRequest] = Json.format
+  implicit val format: Format[VersionedTransferRequest] = Json.format
 }

--- a/src/main/scala/scorex/api/http/assets/package.scala
+++ b/src/main/scala/scorex/api/http/assets/package.scala
@@ -1,0 +1,18 @@
+package scorex.api.http
+
+import play.api.libs.json.Reads
+import scorex.api.http.assets.TransferRequest.transferFormat
+import scorex.api.http.assets.VersionedTransferRequest.versionedTransferFormat
+import shapeless.{:+:, CNil, Coproduct}
+
+package object assets {
+
+  type TransferRequests = TransferRequest :+: VersionedTransferRequest :+: CNil
+  implicit val autoVersionTransferRequestsReads: Reads[TransferRequests] = Reads { json =>
+    (json \ "version").asOpt[Byte] match {
+      case None => transferFormat.reads(json).map(Coproduct[TransferRequests](_))
+      case _    => versionedTransferFormat.reads(json).map(Coproduct[TransferRequests](_))
+    }
+  }
+
+}

--- a/src/main/scala/scorex/api/http/assets/package.scala
+++ b/src/main/scala/scorex/api/http/assets/package.scala
@@ -1,18 +1,42 @@
 package scorex.api.http
 
-import play.api.libs.json.Reads
-import scorex.api.http.assets.TransferRequest.transferFormat
-import scorex.api.http.assets.VersionedTransferRequest.versionedTransferFormat
+import play.api.libs.json._
 import shapeless.{:+:, CNil, Coproduct}
 
 package object assets {
 
   type TransferRequests = TransferRequest :+: VersionedTransferRequest :+: CNil
-  implicit val autoVersionTransferRequestsReads: Reads[TransferRequests] = Reads { json =>
+  implicit val autoTransferRequestsReads: Reads[TransferRequests] = Reads { json =>
     (json \ "version").asOpt[Byte] match {
-      case None => transferFormat.reads(json).map(Coproduct[TransferRequests](_))
-      case _    => versionedTransferFormat.reads(json).map(Coproduct[TransferRequests](_))
+      case None => TransferRequest.format.reads(json).map(Coproduct[TransferRequests](_))
+      case _    => VersionedTransferRequest.format.reads(json).map(Coproduct[TransferRequests](_))
     }
+  }
+  implicit val autoTransferRequestsWrites: Writes[TransferRequests] = Writes {
+    _.eliminate(
+      TransferRequest.format.writes,
+      _.eliminate(
+        VersionedTransferRequest.format.writes,
+        _ => JsNull
+      )
+    )
+  }
+
+  type SignedTransferRequests = SignedTransferRequest :+: SignedVersionedTransferRequest :+: CNil
+  implicit val autoSignedTransferRequestsReads: Reads[SignedTransferRequests] = Reads { json =>
+    (json \ "version").asOpt[Byte] match {
+      case None => SignedTransferRequest.reads.reads(json).map(Coproduct[SignedTransferRequests](_))
+      case _    => SignedVersionedTransferRequest.format.reads(json).map(Coproduct[SignedTransferRequests](_))
+    }
+  }
+  implicit val autoSignedTransferRequestsWrites: Writes[SignedTransferRequests] = Writes {
+    _.eliminate(
+      SignedTransferRequest.writes.writes,
+      _.eliminate(
+        SignedVersionedTransferRequest.format.writes,
+        _ => JsNull
+      )
+    )
   }
 
 }

--- a/src/main/scala/scorex/api/http/leasing/SignedLeaseCancelRequest.scala
+++ b/src/main/scala/scorex/api/http/leasing/SignedLeaseCancelRequest.scala
@@ -5,7 +5,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.ValidationError
 import scorex.transaction.lease.LeaseCancelTransaction
 
@@ -18,29 +18,25 @@ case class SignedLeaseCancelRequest(@ApiModelProperty(value = "Base58 encoded se
                                     @ApiModelProperty(required = true)
                                     signature: String,
                                     @ApiModelProperty(required = true)
-                                    fee: Long) extends BroadcastRequest {
-  def toTx: Either[ValidationError, LeaseCancelTransaction] = for {
-    _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
-    _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
-    _leaseTx <- parseBase58(txId, "invalid.leaseTx", SignatureStringLength)
-    _t <- LeaseCancelTransaction.create(
-      _sender,
-      _leaseTx,
-      fee,
-      timestamp,
-      _signature)
-  } yield _t
+                                    fee: Long)
+    extends BroadcastRequest {
+  def toTx: Either[ValidationError, LeaseCancelTransaction] =
+    for {
+      _sender    <- PublicKeyAccount.fromBase58String(senderPublicKey)
+      _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
+      _leaseTx   <- parseBase58(txId, "invalid.leaseTx", SignatureStringLength)
+      _t         <- LeaseCancelTransaction.create(_sender, _leaseTx, fee, timestamp, _signature)
+    } yield _t
 }
 
 object SignedLeaseCancelRequest {
   implicit val reads: Reads[SignedLeaseCancelRequest] = (
-      (JsPath \ "senderPublicKey").read[String] and
+    (JsPath \ "senderPublicKey").read[String] and
       (JsPath \ "txId").read[String].orElse((JsPath \ "leaseId").read[String]) and
       (JsPath \ "timestamp").read[Long] and
       (JsPath \ "signature").read[String] and
       (JsPath \ "fee").read[Long]
-    )(SignedLeaseCancelRequest.apply _)
+  )(SignedLeaseCancelRequest.apply _)
 
   implicit val writes: Writes[SignedLeaseCancelRequest] = Json.writes[SignedLeaseCancelRequest]
 }
-

--- a/src/main/scala/scorex/api/http/leasing/SignedLeaseRequest.scala
+++ b/src/main/scala/scorex/api/http/leasing/SignedLeaseRequest.scala
@@ -4,7 +4,7 @@ import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{Format, Json}
 import scorex.account.{AddressOrAlias, PublicKeyAccount}
 import scorex.api.http.BroadcastRequest
-import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.TransactionParsers.SignatureStringLength
 import scorex.transaction.ValidationError
 import scorex.transaction.lease.LeaseTransaction
 

--- a/src/main/scala/scorex/block/Block.scala
+++ b/src/main/scala/scorex/block/Block.scala
@@ -12,7 +12,7 @@ import play.api.libs.json.{JsObject, Json}
 import scorex.account.{Address, PrivateKeyAccount, PublicKeyAccount}
 import scorex.block.fields.FeaturesBlockField
 import scorex.consensus.nxt.{NxtConsensusBlockField, NxtLikeConsensusBlockData}
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction._
 import scorex.utils.ScorexLogging
@@ -215,7 +215,7 @@ object Block extends ScorexLogging {
         val transactionLengthBytes = v._1.slice(pos, pos + TransactionSizeLength)
         val transactionLength = Ints.fromByteArray(transactionLengthBytes)
         val transactionBytes = v._1.slice(pos + TransactionSizeLength, pos + TransactionSizeLength + transactionLength)
-        txs += TransactionParser.parseBytes(transactionBytes).get
+        txs += TransactionParsers.parseBytes(transactionBytes).get
         pos + TransactionSizeLength + transactionLength
       }
 

--- a/src/main/scala/scorex/block/MicroBlock.scala
+++ b/src/main/scala/scorex/block/MicroBlock.scala
@@ -7,7 +7,7 @@ import com.wavesplatform.state2._
 import monix.eval.Coeval
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
 import scorex.block.Block.{BlockId, transParseBytes}
-import scorex.transaction.TransactionParser.SignatureLength
+import scorex.transaction.TransactionParsers.SignatureLength
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction._
 import scorex.utils.ScorexLogging
@@ -57,7 +57,7 @@ object MicroBlock extends ScorexLogging {
                    totalResBlockSig: BlockId): Either[ValidationError, MicroBlock] = for {
     _ <- Either.cond(prevResBlockSig.arr.length == SignatureLength, (), GenericError(s"Incorrect prevResBlockSig: ${prevResBlockSig.arr.length}"))
     _ <- Either.cond(totalResBlockSig.arr.length == SignatureLength, (), GenericError(s"Incorrect totalResBlockSig: ${totalResBlockSig.arr.length}"))
-    _ <- Either.cond(generator.publicKey.length == TransactionParser.KeyLength, (), GenericError(s"Incorrect generator.publicKey: ${generator.publicKey.length}"))
+    _ <- Either.cond(generator.publicKey.length == TransactionParsers.KeyLength, (), GenericError(s"Incorrect generator.publicKey: ${generator.publicKey.length}"))
     nonSigned <- create(version = 3: Byte, generator, transactionData, prevResBlockSig, totalResBlockSig, ByteStr.empty)
   } yield {
     val toSign = nonSigned.bytes
@@ -84,8 +84,8 @@ object MicroBlock extends ScorexLogging {
     val txBlockField = transParseBytes(version, tBytes).get
     position += tBytesLength
 
-    val genPK = bytes.slice(position, position + TransactionParser.KeyLength)
-    position += TransactionParser.KeyLength
+    val genPK = bytes.slice(position, position + TransactionParsers.KeyLength)
+    position += TransactionParsers.KeyLength
 
     val signature = ByteStr(bytes.slice(position, position + SignatureLength))
 

--- a/src/main/scala/scorex/transaction/CreateAliasTransaction.scala
+++ b/src/main/scala/scorex/transaction/CreateAliasTransaction.scala
@@ -33,10 +33,9 @@ case class CreateAliasTransaction private (sender: PublicKeyAccount, alias: Alia
 
 }
 
-object CreateAliasTransaction extends TransactionParserFor[CreateAliasTransaction] with TransactionParser.HardcodedVersion {
+object CreateAliasTransaction extends TransactionParserFor[CreateAliasTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 10
-  override val version: Byte = 1
+  override val typeId: Byte = 10
 
   override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {

--- a/src/main/scala/scorex/transaction/CreateAliasTransaction.scala
+++ b/src/main/scala/scorex/transaction/CreateAliasTransaction.scala
@@ -15,8 +15,7 @@ case class CreateAliasTransaction private (sender: PublicKeyAccount, alias: Alia
     extends SignedTransaction {
 
   override val builder: TransactionParser = CreateAliasTransaction
-  override def version: Byte               = builder.supportedVersions.head
-  override val id: Coeval[AssetId]         = Coeval.evalOnce(ByteStr(crypto.fastHash(builder.typeId +: alias.bytes.arr)))
+  override val id: Coeval[AssetId]        = Coeval.evalOnce(ByteStr(crypto.fastHash(builder.typeId +: alias.bytes.arr)))
 
   override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
     Bytes

--- a/src/main/scala/scorex/transaction/CreateAliasTransaction.scala
+++ b/src/main/scala/scorex/transaction/CreateAliasTransaction.scala
@@ -7,69 +7,59 @@ import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.account._
 import scorex.serialization.Deser
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 
 import scala.util.{Failure, Success, Try}
 
+case class CreateAliasTransaction private (sender: PublicKeyAccount, alias: Alias, fee: Long, timestamp: Long, signature: ByteStr)
+    extends SignedTransaction {
 
-case class CreateAliasTransaction private(sender: PublicKeyAccount,
-                                          alias: Alias,
-                                          fee: Long,
-                                          timestamp: Long,
-                                          signature: ByteStr)
-  extends SignedTransaction {
+  override val builder: TransactionParser = CreateAliasTransaction
+  override def version: Byte               = builder.supportedVersions.head
+  override val id: Coeval[AssetId]         = Coeval.evalOnce(ByteStr(crypto.fastHash(builder.typeId +: alias.bytes.arr)))
 
-  override val transactionType: TransactionType.Value = TransactionType.CreateAliasTransaction
+  override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
+    Bytes
+      .concat(Array(builder.typeId), sender.publicKey, Deser.serializeArray(alias.bytes.arr), Longs.toByteArray(fee), Longs.toByteArray(timestamp)))
 
-  override val id: Coeval[AssetId] = Coeval.evalOnce(ByteStr(crypto.fastHash(transactionType.id.toByte +: alias.bytes.arr)))
-
-  override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(
-    Array(transactionType.id.toByte),
-    sender.publicKey,
-    Deser.serializeArray(alias.bytes.arr),
-    Longs.toByteArray(fee),
-    Longs.toByteArray(timestamp)))
-
-  override val json: Coeval[JsObject] = Coeval.evalOnce(jsonBase() ++ Json.obj(
-    "alias" -> alias.name,
-    "fee" -> fee,
-    "timestamp" -> timestamp
-  ))
+  override val json: Coeval[JsObject] = Coeval.evalOnce(
+    jsonBase() ++ Json.obj(
+      "alias"     -> alias.name,
+      "fee"       -> fee,
+      "timestamp" -> timestamp
+    ))
 
   override val assetFee: (Option[AssetId], Long) = (None, fee)
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), signature.arr))
+  override val bytes: Coeval[Array[Byte]]        = Coeval.evalOnce(Bytes.concat(bodyBytes(), signature.arr))
 
 }
 
-object CreateAliasTransaction {
+object CreateAliasTransaction extends TransactionParserFor[CreateAliasTransaction] with TransactionParser.HardcodedVersion {
 
-  def parseTail(bytes: Array[Byte]): Try[CreateAliasTransaction] = Try {
-    val sender = PublicKeyAccount(bytes.slice(0, KeyLength))
-    val (aliasBytes, aliasEnd) = Deser.parseArraySize(bytes, KeyLength)
-    (for {
-      alias <- Alias.fromBytes(aliasBytes)
-      fee = Longs.fromByteArray(bytes.slice(aliasEnd, aliasEnd + 8))
-      timestamp = Longs.fromByteArray(bytes.slice(aliasEnd + 8, aliasEnd + 16))
-      signature = ByteStr(bytes.slice(aliasEnd + 16, aliasEnd + 16 + SignatureLength))
-      tx <- CreateAliasTransaction.create(sender, alias, fee, timestamp, signature)
-    } yield tx).fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+  override val typeId: Byte  = 10
+  override val version: Byte = 1
 
-  def create(sender: PublicKeyAccount,
-             alias: Alias,
-             fee: Long,
-             timestamp: Long,
-             signature: ByteStr): Either[ValidationError, CreateAliasTransaction] =
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      val sender                 = PublicKeyAccount(bytes.slice(0, KeyLength))
+      val (aliasBytes, aliasEnd) = Deser.parseArraySize(bytes, KeyLength)
+      (for {
+        alias <- Alias.fromBytes(aliasBytes)
+        fee       = Longs.fromByteArray(bytes.slice(aliasEnd, aliasEnd + 8))
+        timestamp = Longs.fromByteArray(bytes.slice(aliasEnd + 8, aliasEnd + 16))
+        signature = ByteStr(bytes.slice(aliasEnd + 16, aliasEnd + 16 + SignatureLength))
+        tx <- CreateAliasTransaction.create(sender, alias, fee, timestamp, signature)
+      } yield tx).fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
+
+  def create(sender: PublicKeyAccount, alias: Alias, fee: Long, timestamp: Long, signature: ByteStr): Either[ValidationError, TransactionT] =
     if (fee <= 0) {
       Left(ValidationError.InsufficientFee)
     } else {
       Right(CreateAliasTransaction(sender, alias, fee, timestamp, signature))
     }
 
-  def create(sender: PrivateKeyAccount,
-             alias: Alias,
-             fee: Long,
-             timestamp: Long): Either[ValidationError, CreateAliasTransaction] = {
+  def create(sender: PrivateKeyAccount, alias: Alias, fee: Long, timestamp: Long): Either[ValidationError, TransactionT] = {
     create(sender, alias, fee, timestamp, ByteStr.empty).right.map { unsigned =>
       unsigned.copy(signature = ByteStr(crypto.sign(sender, unsigned.bodyBytes())))
     }

--- a/src/main/scala/scorex/transaction/DataTransaction.scala
+++ b/src/main/scala/scorex/transaction/DataTransaction.scala
@@ -6,77 +6,79 @@ import com.wavesplatform.state2._
 import monix.eval.Coeval
 import play.api.libs.json._
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
-
-import scorex.transaction.TransactionParser.{KeyLength, TransactionType}
+import scorex.transaction.TransactionParsers.KeyLength
 
 import scala.util.{Failure, Success, Try}
 
-case class DataTransaction private(version: Byte,
-                                   sender: PublicKeyAccount,
-                                   data: List[DataEntry[_]],
-                                   fee: Long,
-                                   timestamp: Long,
-                                   proofs: Proofs) extends ProvenTransaction with FastHashId {
-  override val transactionType: TransactionType.Value = TransactionType.DataTransaction
+case class DataTransaction private (override val version: Byte,
+                                    sender: PublicKeyAccount,
+                                    data: List[DataEntry[_]],
+                                    fee: Long,
+                                    timestamp: Long,
+                                    proofs: Proofs)
+    extends ProvenTransaction
+    with FastHashId {
 
+  override val builder: TransactionParser       = DataTransaction
   override val assetFee: (Option[AssetId], Long) = (None, fee)
 
   override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce {
     Bytes.concat(
-      Array(transactionType.id.toByte),
-      Array(version),
+      Array(0, builder.typeId, version),
       sender.publicKey,
       Shorts.toByteArray(data.size.toShort),
       data.flatMap(_.toBytes).toArray,
       Longs.toByteArray(timestamp),
-      Longs.toByteArray(fee))
+      Longs.toByteArray(fee)
+    )
   }
 
   implicit val dataItemFormat: Format[DataEntry[_]] = DataEntry.Format
 
   override val json: Coeval[JsObject] = Coeval.evalOnce {
-    jsonBase() ++ Json.obj(
-      "data" -> Json.toJson(data),
-      "version" -> version)
+    jsonBase() ++ Json.obj("data" -> Json.toJson(data))
   }
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
 }
 
-object DataTransaction {
-  val Version: Byte = 1
+object DataTransaction extends TransactionParserFor[DataTransaction] with TransactionParser.MultipleVersions {
+
+  override val typeId: Byte                 = 12
+  override val supportedVersions: Set[Byte] = Set(1)
+
   val MaxEntryCount: Byte = Byte.MaxValue
 
-  def parseTail(bytes: Array[Byte]): Try[DataTransaction] = Try {
-    val version = bytes(0)
-    val p0 = KeyLength + 1
-    val sender = PublicKeyAccount(bytes.slice(1, p0))
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      val p0     = KeyLength
+      val sender = PublicKeyAccount(bytes.slice(0, p0))
 
-    val entryCount = Shorts.fromByteArray(bytes.drop(p0))
-    val (entries, p1) =
-      if (entryCount > 0) {
-        val parsed = List.iterate(DataEntry.parse(bytes, p0 + 2), entryCount) { case (e, p) => DataEntry.parse(bytes, p) }
-        (parsed.map(_._1), parsed.last._2)
-      } else (List.empty, p0 + 2)
+      val entryCount = Shorts.fromByteArray(bytes.drop(p0))
+      val (entries, p1) =
+        if (entryCount > 0) {
+          val parsed = List.iterate(DataEntry.parse(bytes, p0 + 2), entryCount) { case (e, p) => DataEntry.parse(bytes, p) }
+          (parsed.map(_._1), parsed.last._2)
+        } else (List.empty, p0 + 2)
 
-    val timestamp = Longs.fromByteArray(bytes.drop(p1))
-    val feeAmount = Longs.fromByteArray(bytes.drop(p1 + 8))
-    val txEi = for {
-      proofs <- Proofs.fromBytes(bytes.drop(p1 + 16))
-      tx <- create(version, sender, entries, feeAmount, timestamp, proofs)
-    } yield tx
-    txEi.fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+      val timestamp = Longs.fromByteArray(bytes.drop(p1))
+      val feeAmount = Longs.fromByteArray(bytes.drop(p1 + 8))
+      val txEi = for {
+        proofs <- Proofs.fromBytes(bytes.drop(p1 + 16))
+        tx     <- create(version, sender, entries, feeAmount, timestamp, proofs)
+      } yield tx
+      txEi.fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
 
   def create(version: Byte,
              sender: PublicKeyAccount,
              data: List[DataEntry[_]],
              feeAmount: Long,
              timestamp: Long,
-             proofs: Proofs): Either[ValidationError, DataTransaction] = {
-    if (version != 1) {
+             proofs: Proofs): Either[ValidationError, TransactionT] = {
+    if (!supportedVersions.contains(version)) {
       Left(ValidationError.UnsupportedVersion(version))
-    } else if (data.lengthCompare(MaxEntryCount) > 0 || data.exists(! _.valid)) {
+    } else if (data.lengthCompare(MaxEntryCount) > 0 || data.exists(!_.valid)) {
       Left(ValidationError.TooBigArray)
     } else if (feeAmount <= 0) {
       Left(ValidationError.InsufficientFee)
@@ -89,7 +91,7 @@ object DataTransaction {
                  sender: PrivateKeyAccount,
                  data: List[DataEntry[_]],
                  feeAmount: Long,
-                 timestamp: Long): Either[ValidationError, DataTransaction] = {
+                 timestamp: Long): Either[ValidationError, TransactionT] = {
     create(version, sender, data, feeAmount, timestamp, Proofs.empty).right.map { unsigned =>
       unsigned.copy(proofs = Proofs.create(Seq(ByteStr(crypto.sign(sender, unsigned.bodyBytes())))).explicitGet())
     }

--- a/src/main/scala/scorex/transaction/DataTransaction.scala
+++ b/src/main/scala/scorex/transaction/DataTransaction.scala
@@ -19,7 +19,7 @@ case class DataTransaction private (override val version: Byte,
     extends ProvenTransaction
     with FastHashId {
 
-  override val builder: TransactionParser       = DataTransaction
+  override val builder: TransactionParser        = DataTransaction
   override val assetFee: (Option[AssetId], Long) = (None, fee)
 
   override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce {
@@ -36,7 +36,10 @@ case class DataTransaction private (override val version: Byte,
   implicit val dataItemFormat: Format[DataEntry[_]] = DataEntry.Format
 
   override val json: Coeval[JsObject] = Coeval.evalOnce {
-    jsonBase() ++ Json.obj("data" -> Json.toJson(data))
+    jsonBase() ++ Json.obj(
+      "version" -> version,
+      "data"    -> Json.toJson(data)
+    )
   }
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))

--- a/src/main/scala/scorex/transaction/DataTransaction.scala
+++ b/src/main/scala/scorex/transaction/DataTransaction.scala
@@ -10,7 +10,7 @@ import scorex.transaction.TransactionParsers.KeyLength
 
 import scala.util.{Failure, Success, Try}
 
-case class DataTransaction private (override val version: Byte,
+case class DataTransaction private (version: Byte,
                                     sender: PublicKeyAccount,
                                     data: List[DataEntry[_]],
                                     fee: Long,

--- a/src/main/scala/scorex/transaction/DataTransaction.scala
+++ b/src/main/scala/scorex/transaction/DataTransaction.scala
@@ -24,7 +24,7 @@ case class DataTransaction private (version: Byte,
 
   override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce {
     Bytes.concat(
-      Array(0, builder.typeId, version),
+      Array(builder.typeId, version),
       sender.publicKey,
       Shorts.toByteArray(data.size.toShort),
       data.flatMap(_.toBytes).toArray,
@@ -42,7 +42,7 @@ case class DataTransaction private (version: Byte,
     )
   }
 
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 }
 
 object DataTransaction extends TransactionParserFor[DataTransaction] with TransactionParser.MultipleVersions {

--- a/src/main/scala/scorex/transaction/GenesisTransaction.scala
+++ b/src/main/scala/scorex/transaction/GenesisTransaction.scala
@@ -14,8 +14,7 @@ case class GenesisTransaction private (recipient: Address, amount: Long, timesta
 
   import GenesisTransaction._
 
-  override val builder: TransactionParser       = GenesisTransaction
-  override def version: Byte                     = builder.supportedVersions.head
+  override val builder: TransactionParser        = GenesisTransaction
   override val assetFee: (Option[AssetId], Long) = (None, 0)
   override val id: Coeval[AssetId]               = Coeval.evalOnce(signature)
 

--- a/src/main/scala/scorex/transaction/GenesisTransaction.scala
+++ b/src/main/scala/scorex/transaction/GenesisTransaction.scala
@@ -6,33 +6,35 @@ import com.wavesplatform.state2.ByteStr
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.Address
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 
 import scala.util.{Failure, Success, Try}
 
-case class GenesisTransaction private(recipient: Address, amount: Long, timestamp: Long, signature: ByteStr) extends Transaction {
+case class GenesisTransaction private (recipient: Address, amount: Long, timestamp: Long, signature: ByteStr) extends Transaction {
 
   import GenesisTransaction._
 
+  override val builder: TransactionParser       = GenesisTransaction
+  override def version: Byte                     = builder.supportedVersions.head
   override val assetFee: (Option[AssetId], Long) = (None, 0)
-  override val id: Coeval[AssetId] = Coeval.evalOnce(signature)
-
-  val transactionType: TransactionParser.TransactionType.Value = TransactionType.GenesisTransaction
+  override val id: Coeval[AssetId]               = Coeval.evalOnce(signature)
 
   override val json: Coeval[JsObject] = Coeval.evalOnce(
-    Json.obj("type" -> transactionType.id,
-      "id" -> id().base58,
-      "fee" -> 0,
+    Json.obj(
+      "type"      -> builder.typeId,
+      "id"        -> id().base58,
+      "fee"       -> 0,
       "timestamp" -> timestamp,
       "signature" -> this.signature.base58,
       "recipient" -> recipient.address,
-      "amount" -> amount))
+      "amount"    -> amount
+    ))
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce {
-    val typeBytes = Array(transactionType.id.toByte)
+    val typeBytes      = Array(builder.typeId)
     val timestampBytes = Bytes.ensureCapacity(Longs.toByteArray(timestamp), TimestampLength, 0)
-    val amountBytes = Bytes.ensureCapacity(Longs.toByteArray(amount), AmountLength, 0)
-    val rcpBytes = recipient.bytes.arr
+    val amountBytes    = Bytes.ensureCapacity(Longs.toByteArray(amount), AmountLength, 0)
+    val rcpBytes       = recipient.bytes.arr
     require(rcpBytes.length == Address.AddressLength)
     val res = Bytes.concat(typeBytes, timestampBytes, rcpBytes, amountBytes)
     require(res.length == TypeLength + BASE_LENGTH)
@@ -40,17 +42,19 @@ case class GenesisTransaction private(recipient: Address, amount: Long, timestam
   }
 }
 
+object GenesisTransaction extends TransactionParserFor[GenesisTransaction] with TransactionParser.HardcodedVersion {
 
-object GenesisTransaction extends {
+  override val typeId: Byte  = 1
+  override val version: Byte = 1
 
   private val RECIPIENT_LENGTH = Address.AddressLength
-  private val BASE_LENGTH = TimestampLength + RECIPIENT_LENGTH + AmountLength
+  private val BASE_LENGTH      = TimestampLength + RECIPIENT_LENGTH + AmountLength
 
   def generateSignature(recipient: Address, amount: Long, timestamp: Long): Array[Byte] = {
-    val typeBytes = Bytes.ensureCapacity(Ints.toByteArray(TransactionType.GenesisTransaction.id), TypeLength, 0)
+    val typeBytes      = Bytes.ensureCapacity(Ints.toByteArray(typeId), TypeLength, 0)
     val timestampBytes = Bytes.ensureCapacity(Longs.toByteArray(timestamp), TimestampLength, 0)
-    val amountBytes = Longs.toByteArray(amount)
-    val amountFill = new Array[Byte](AmountLength - amountBytes.length)
+    val amountBytes    = Longs.toByteArray(amount)
+    val amountFill     = new Array[Byte](AmountLength - amountBytes.length)
 
     val data = Bytes.concat(typeBytes, timestampBytes, recipient.bytes.arr, Bytes.concat(amountFill, amountBytes))
 
@@ -58,23 +62,22 @@ object GenesisTransaction extends {
     Bytes.concat(h, h)
   }
 
-
-  def parseTail(data: Array[Byte]): Try[GenesisTransaction] =
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {
-      require(data.length >= BASE_LENGTH, "Data does not match base length")
+      require(bytes.length >= BASE_LENGTH, "Data does not match base length")
 
       var position = 0
 
-      val timestampBytes = java.util.Arrays.copyOfRange(data, position, position + TimestampLength)
-      val timestamp = Longs.fromByteArray(timestampBytes)
+      val timestampBytes = java.util.Arrays.copyOfRange(bytes, position, position + TimestampLength)
+      val timestamp      = Longs.fromByteArray(timestampBytes)
       position += TimestampLength
 
-      val recipientBytes = java.util.Arrays.copyOfRange(data, position, position + RECIPIENT_LENGTH)
-      val recipient = Address.fromBytes(recipientBytes).right.get
+      val recipientBytes = java.util.Arrays.copyOfRange(bytes, position, position + RECIPIENT_LENGTH)
+      val recipient      = Address.fromBytes(recipientBytes).right.get
       position += RECIPIENT_LENGTH
 
-      val amountBytes = java.util.Arrays.copyOfRange(data, position, position + AmountLength)
-      val amount = Longs.fromByteArray(amountBytes)
+      val amountBytes = java.util.Arrays.copyOfRange(bytes, position, position + AmountLength)
+      val amount      = Longs.fromByteArray(amountBytes)
 
       GenesisTransaction.create(recipient, amount, timestamp).fold(left => Failure(new Exception(left.toString)), right => Success(right))
     }.flatten

--- a/src/main/scala/scorex/transaction/GenesisTransaction.scala
+++ b/src/main/scala/scorex/transaction/GenesisTransaction.scala
@@ -41,10 +41,9 @@ case class GenesisTransaction private (recipient: Address, amount: Long, timesta
   }
 }
 
-object GenesisTransaction extends TransactionParserFor[GenesisTransaction] with TransactionParser.HardcodedVersion {
+object GenesisTransaction extends TransactionParserFor[GenesisTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 1
-  override val version: Byte = 1
+  override val typeId: Byte = 1
 
   private val RECIPIENT_LENGTH = Address.AddressLength
   private val BASE_LENGTH      = TimestampLength + RECIPIENT_LENGTH + AmountLength

--- a/src/main/scala/scorex/transaction/PaymentTransaction.scala
+++ b/src/main/scala/scorex/transaction/PaymentTransaction.scala
@@ -14,7 +14,7 @@ import scala.util.{Failure, Success, Try}
 
 case class PaymentTransaction private (sender: PublicKeyAccount, recipient: Address, amount: Long, fee: Long, timestamp: Long, signature: ByteStr)
     extends SignedTransaction {
-  override val builder: TransactionParser       = PaymentTransaction
+  override val builder: TransactionParser        = PaymentTransaction
   override def version: Byte                     = builder.supportedVersions.head
   override val assetFee: (Option[AssetId], Long) = (None, fee)
   override val id: Coeval[AssetId]               = Coeval.evalOnce(signature)

--- a/src/main/scala/scorex/transaction/PaymentTransaction.scala
+++ b/src/main/scala/scorex/transaction/PaymentTransaction.scala
@@ -15,7 +15,6 @@ import scala.util.{Failure, Success, Try}
 case class PaymentTransaction private (sender: PublicKeyAccount, recipient: Address, amount: Long, fee: Long, timestamp: Long, signature: ByteStr)
     extends SignedTransaction {
   override val builder: TransactionParser        = PaymentTransaction
-  override def version: Byte                     = builder.supportedVersions.head
   override val assetFee: (Option[AssetId], Long) = (None, fee)
   override val id: Coeval[AssetId]               = Coeval.evalOnce(signature)
 

--- a/src/main/scala/scorex/transaction/PaymentTransaction.scala
+++ b/src/main/scala/scorex/transaction/PaymentTransaction.scala
@@ -8,29 +8,34 @@ import com.wavesplatform.state2.ByteStr
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.{Address, PrivateKeyAccount, PublicKeyAccount}
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 
 import scala.util.{Failure, Success, Try}
 
-case class PaymentTransaction private(sender: PublicKeyAccount,
-                                      recipient: Address,
-                                      amount: Long,
-                                      fee: Long,
-                                      timestamp: Long,
-                                      signature: ByteStr) extends SignedTransaction {
-  override val transactionType = TransactionType.PaymentTransaction
+case class PaymentTransaction private (sender: PublicKeyAccount, recipient: Address, amount: Long, fee: Long, timestamp: Long, signature: ByteStr)
+    extends SignedTransaction {
+  override val builder: TransactionParser       = PaymentTransaction
+  override def version: Byte                     = builder.supportedVersions.head
   override val assetFee: (Option[AssetId], Long) = (None, fee)
-  override val id: Coeval[AssetId] = Coeval.evalOnce(signature)
+  override val id: Coeval[AssetId]               = Coeval.evalOnce(signature)
 
-  override val json: Coeval[JsObject] = Coeval.evalOnce(jsonBase() ++ Json.obj(
-    "recipient" -> recipient.address,
-    "amount" -> amount))
+  override val json: Coeval[JsObject] = Coeval.evalOnce(jsonBase() ++ Json.obj("recipient" -> recipient.address, "amount" -> amount))
 
-  private val hashBytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(transactionType.id.toByte),
-    Longs.toByteArray(timestamp), sender.publicKey, recipient.bytes.arr, Longs.toByteArray(amount), Longs.toByteArray(fee)))
+  private val hashBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
+    Bytes.concat(Array(builder.typeId),
+                 Longs.toByteArray(timestamp),
+                 sender.publicKey,
+                 recipient.bytes.arr,
+                 Longs.toByteArray(amount),
+                 Longs.toByteArray(fee)))
 
-  override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Ints.toByteArray(transactionType.id),
-    Longs.toByteArray(timestamp), sender.publicKey, recipient.bytes.arr, Longs.toByteArray(amount), Longs.toByteArray(fee)))
+  override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
+    Bytes.concat(Ints.toByteArray(builder.typeId),
+                 Longs.toByteArray(timestamp),
+                 sender.publicKey,
+                 recipient.bytes.arr,
+                 Longs.toByteArray(amount),
+                 Longs.toByteArray(fee)))
 
   val hash: Coeval[Array[Byte]] = Coeval.evalOnce(crypto.fastHash(hashBytes()))
 
@@ -38,15 +43,18 @@ case class PaymentTransaction private(sender: PublicKeyAccount,
 
 }
 
-object PaymentTransaction {
+object PaymentTransaction extends TransactionParserFor[PaymentTransaction] with TransactionParser.OneVersion {
+
+  override val typeId: Byte  = 2
+  override val version: Byte = 1
 
   val RecipientLength: Int = Address.AddressLength
 
   private val SenderLength = 32
-  private val FeeLength = 8
-  private val BaseLength = TimestampLength + SenderLength + RecipientLength + AmountLength + FeeLength + SignatureLength
+  private val FeeLength    = 8
+  private val BaseLength   = TimestampLength + SenderLength + RecipientLength + AmountLength + FeeLength + SignatureLength
 
-  def create(sender: PrivateKeyAccount, recipient: Address, amount: Long, fee: Long, timestamp: Long): Either[ValidationError, PaymentTransaction] = {
+  def create(sender: PrivateKeyAccount, recipient: Address, amount: Long, fee: Long, timestamp: Long): Either[ValidationError, TransactionT] = {
     create(sender, recipient, amount, fee, timestamp, ByteStr.empty).right.map(unsigned => {
       unsigned.copy(signature = ByteStr(crypto.sign(sender, unsigned.bodyBytes())))
     })
@@ -57,7 +65,7 @@ object PaymentTransaction {
              amount: Long,
              fee: Long,
              timestamp: Long,
-             signature: ByteStr): Either[ValidationError, PaymentTransaction] = {
+             signature: ByteStr): Either[ValidationError, TransactionT] = {
     if (amount <= 0) {
       Left(ValidationError.NegativeAmount(amount, "waves")) //CHECK IF AMOUNT IS POSITIVE
     } else if (fee <= 0) {
@@ -69,42 +77,43 @@ object PaymentTransaction {
     }
   }
 
-  def parseTail(data: Array[Byte]): Try[PaymentTransaction] = Try {
-    require(data.length >= BaseLength, "Data does not match base length")
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      require(bytes.length >= BaseLength, "Data does not match base length")
 
-    var position = 0
+      var position = 0
 
-    //READ TIMESTAMP
-    val timestampBytes = data.take(TimestampLength)
-    val timestamp = Longs.fromByteArray(timestampBytes)
-    position += TimestampLength
+      //READ TIMESTAMP
+      val timestampBytes = bytes.take(TimestampLength)
+      val timestamp      = Longs.fromByteArray(timestampBytes)
+      position += TimestampLength
 
-    //READ SENDER
-    val senderBytes = util.Arrays.copyOfRange(data, position, position + SenderLength)
-    val sender = PublicKeyAccount(senderBytes)
-    position += SenderLength
+      //READ SENDER
+      val senderBytes = util.Arrays.copyOfRange(bytes, position, position + SenderLength)
+      val sender      = PublicKeyAccount(senderBytes)
+      position += SenderLength
 
-    //READ RECIPIENT
-    val recipientBytes = util.Arrays.copyOfRange(data, position, position + RecipientLength)
-    val recipient = Address.fromBytes(recipientBytes).right.get
-    position += RecipientLength
+      //READ RECIPIENT
+      val recipientBytes = util.Arrays.copyOfRange(bytes, position, position + RecipientLength)
+      val recipient      = Address.fromBytes(recipientBytes).right.get
+      position += RecipientLength
 
-    //READ AMOUNT
-    val amountBytes = util.Arrays.copyOfRange(data, position, position + AmountLength)
-    val amount = Longs.fromByteArray(amountBytes)
-    position += AmountLength
+      //READ AMOUNT
+      val amountBytes = util.Arrays.copyOfRange(bytes, position, position + AmountLength)
+      val amount      = Longs.fromByteArray(amountBytes)
+      position += AmountLength
 
-    //READ FEE
-    val feeBytes = util.Arrays.copyOfRange(data, position, position + FeeLength)
-    val fee = Longs.fromByteArray(feeBytes)
-    position += FeeLength
+      //READ FEE
+      val feeBytes = util.Arrays.copyOfRange(bytes, position, position + FeeLength)
+      val fee      = Longs.fromByteArray(feeBytes)
+      position += FeeLength
 
-    //READ SIGNATURE
-    val signatureBytes = util.Arrays.copyOfRange(data, position, position + SignatureLength)
+      //READ SIGNATURE
+      val signatureBytes = util.Arrays.copyOfRange(bytes, position, position + SignatureLength)
 
-    PaymentTransaction
-      .create(sender, recipient, amount, fee, timestamp, ByteStr(signatureBytes))
-      .fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+      PaymentTransaction
+        .create(sender, recipient, amount, fee, timestamp, ByteStr(signatureBytes))
+        .fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
 
 }

--- a/src/main/scala/scorex/transaction/ProvenTransaction.scala
+++ b/src/main/scala/scorex/transaction/ProvenTransaction.scala
@@ -16,5 +16,5 @@ trait ProvenTransaction extends Transaction with Proven {
     "sender" -> sender.address,
     "senderPublicKey" -> Base58.encode(sender.publicKey),
     "fee" -> assetFee._2,
-    "timestamp" -> timestamp) ++ Json.obj(proofField) ++ Json.obj("version" -> version)
+    "timestamp" -> timestamp) ++ Json.obj(proofField)
 }

--- a/src/main/scala/scorex/transaction/ProvenTransaction.scala
+++ b/src/main/scala/scorex/transaction/ProvenTransaction.scala
@@ -11,10 +11,10 @@ trait ProvenTransaction extends Transaction with Proven {
   val bodyBytes: Coeval[Array[Byte]]
 
   protected def jsonBase(): JsObject = Json.obj(
-    "type" -> transactionType.id,
+    "type" -> builder.typeId,
     "id" -> id().base58,
     "sender" -> sender.address,
     "senderPublicKey" -> Base58.encode(sender.publicKey),
     "fee" -> assetFee._2,
-    "timestamp" -> timestamp) ++ Json.obj(proofField)
+    "timestamp" -> timestamp) ++ Json.obj(proofField) ++ Json.obj("version" -> version)
 }

--- a/src/main/scala/scorex/transaction/Transaction.scala
+++ b/src/main/scala/scorex/transaction/Transaction.scala
@@ -8,7 +8,6 @@ trait Transaction extends BytesSerializable with JsonSerializable {
   val id: Coeval[ByteStr]
 
   def builder: TransactionParser
-  def version: Byte
   def assetFee: (Option[AssetId], Long)
   def timestamp: Long
 

--- a/src/main/scala/scorex/transaction/Transaction.scala
+++ b/src/main/scala/scorex/transaction/Transaction.scala
@@ -3,14 +3,14 @@ package scorex.transaction
 import com.wavesplatform.state2._
 import monix.eval.Coeval
 import scorex.serialization.{BytesSerializable, JsonSerializable}
-import scorex.transaction.TransactionParser.TransactionType
 
 trait Transaction extends BytesSerializable with JsonSerializable {
   val id: Coeval[ByteStr]
 
-  val transactionType: TransactionType.Value
-  val assetFee: (Option[AssetId], Long)
-  val timestamp: Long
+  def builder: TransactionParser
+  def version: Byte
+  def assetFee: (Option[AssetId], Long)
+  def timestamp: Long
 
   override def toString: String = json().toString()
 
@@ -23,6 +23,8 @@ trait Transaction extends BytesSerializable with JsonSerializable {
 }
 
 object Transaction {
+
+  type Type = Byte
 
   implicit class TransactionExt(tx: Transaction) {
     def feeDiff(): Portfolio = tx.assetFee match {

--- a/src/main/scala/scorex/transaction/TransactionParser.scala
+++ b/src/main/scala/scorex/transaction/TransactionParser.scala
@@ -22,16 +22,15 @@ trait TransactionParser {
 }
 
 object TransactionParser {
-  trait HardcodedVersion extends TransactionParser {
-    def version: Byte
-    override def supportedVersions: Set[Byte] = Set(version)
+  trait HardcodedVersion1 extends TransactionParser {
+    override val supportedVersions: Set[Byte] = Set(1)
 
     override protected def parseHeader(bytes: Array[Byte]): Try[(Byte, Int)] = Try {
       if (bytes.length < 1) throw new IllegalArgumentException(s"The buffer is too small, it has ${bytes.length} elements")
 
       val parsedTypeId = bytes.head
       if (parsedTypeId != typeId) throw new IllegalArgumentException(s"Expected type of transaction '$typeId', but got '$parsedTypeId'")
-      (version, 1)
+      (1, 1)
     }
   }
 

--- a/src/main/scala/scorex/transaction/TransactionParser.scala
+++ b/src/main/scala/scorex/transaction/TransactionParser.scala
@@ -1,88 +1,72 @@
 package scorex.transaction
 
-import com.wavesplatform.utils.base58Length
-import scorex.transaction.assets._
-import scorex.transaction.assets.exchange.ExchangeTransaction
-import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
-import scorex.transaction.smart.SetScriptTransaction
+import scala.reflect.ClassTag
+import scala.util.Try
 
-import scala.util.{Failure, Try}
+trait TransactionParser {
+  type TransactionT <: Transaction
+  def classTag: ClassTag[TransactionT]
 
-object TransactionParser {
+  def typeId: Byte
+  def supportedVersions: Set[Byte]
 
-  object TransactionType extends Enumeration {
-    val GenesisTransaction = Value(1)
-    val PaymentTransaction = Value(2)
-    val IssueTransaction = Value(3)
-    val TransferTransaction = Value(4)
-    val ReissueTransaction = Value(5)
-    val BurnTransaction = Value(6)
-    val ExchangeTransaction = Value(7)
-    val LeaseTransaction = Value(8)
-    val LeaseCancelTransaction = Value(9)
-    val CreateAliasTransaction = Value(10)
-    val MassTransferTransaction = Value(11)
-    val DataTransaction = Value(12)
-    val SetScriptTransaction = Value(13)
-    val VersionedTransferTransaction = Value(14)
-    val SmartIssueTransaction = Value(15)
+  def parseBytes(bytes: Array[Byte]): Try[TransactionT] = parseHeader(bytes).flatMap { case (version, offset) =>
+    parseTail(version, bytes.drop(offset))
   }
 
-  val TimestampLength = 8
-  val AmountLength = 8
-  val TypeLength = 1
-  val SignatureLength = 64
-  val SignatureStringLength: Int = base58Length(SignatureLength)
-  val KeyLength = 32
-  val KeyStringLength: Int = base58Length(KeyLength)
+  /**
+    * @return (version, offset)
+    */
+  protected def parseHeader(bytes: Array[Byte]): Try[(Byte, Int)]
+  protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT]
+}
 
-  def parseBytes(data: Array[Byte]): Try[Transaction] =
-    data.head match {
-      case txType: Byte if txType == TransactionType.GenesisTransaction.id =>
-        GenesisTransaction.parseTail(data.tail)
+object TransactionParser {
+  trait HardcodedVersion extends TransactionParser {
+    def version: Byte
+    override def supportedVersions: Set[Byte] = Set(version)
 
-      case txType: Byte if txType == TransactionType.PaymentTransaction.id =>
-        PaymentTransaction.parseTail(data.tail)
+    override protected def parseHeader(bytes: Array[Byte]): Try[(Byte, Int)] = Try {
+      if (bytes.length < 1) throw new IllegalArgumentException(s"The buffer is too small, it has ${bytes.length} elements")
 
-      case txType: Byte if txType == TransactionType.IssueTransaction.id =>
-        IssueTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.TransferTransaction.id =>
-        TransferTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.ReissueTransaction.id =>
-        ReissueTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.BurnTransaction.id =>
-        BurnTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.ExchangeTransaction.id =>
-        ExchangeTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.LeaseTransaction.id =>
-        LeaseTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.LeaseCancelTransaction.id =>
-        LeaseCancelTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.CreateAliasTransaction.id =>
-        CreateAliasTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.MassTransferTransaction.id =>
-        MassTransferTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.SetScriptTransaction.id =>
-        SetScriptTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.VersionedTransferTransaction.id =>
-        VersionedTransferTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.SmartIssueTransaction.id =>
-        SmartIssueTransaction.parseTail(data.tail)
-
-      case txType: Byte if txType == TransactionType.DataTransaction.id =>
-        DataTransaction.parseTail(data.tail)
-
-      case txType => Failure(new Exception(s"Invalid transaction type: $txType"))
+      val parsedTypeId = bytes.head
+      if (parsedTypeId != typeId) throw new IllegalArgumentException(s"Expected type of transaction '$typeId', but got '$parsedTypeId'")
+      (version, 1)
     }
+  }
+
+  trait OneVersion extends TransactionParser {
+    def version: Byte
+    override def supportedVersions: Set[Byte] = Set(version)
+
+    override protected def parseHeader(bytes: Array[Byte]): Try[(Byte, Int)] = Try {
+      if (bytes.length < 2) throw new IllegalArgumentException(s"The buffer is too small, it has ${bytes.length} elements")
+
+      val Array(parsedTypeId, parsedVersion) = bytes.take(2)
+      if (parsedTypeId != typeId) throw new IllegalArgumentException(s"Expected type of transaction '$typeId', but got '$parsedTypeId'")
+      if (!supportedVersions.contains(parsedVersion))
+        throw new IllegalArgumentException(s"Expected version of transaction '$supportedVersions', but got '$parsedVersion'")
+
+      (parsedVersion, 2)
+    }
+  }
+
+  trait MultipleVersions extends TransactionParser {
+    override protected def parseHeader(bytes: Array[Byte]): Try[(Byte, Int)] = Try {
+      if (bytes.length < 3) throw new IllegalArgumentException(s"The buffer is too small, it has ${bytes.length} elements")
+
+      val Array(parsedMark, parsedTypeId, parsedVersion) = bytes.take(3)
+      if (parsedMark != 0) throw new IllegalArgumentException(s"Expected the '0' byte, but got '$parsedMark'")
+      if (parsedTypeId != typeId) throw new IllegalArgumentException(s"Expected type of transaction '$typeId', but got '$parsedTypeId'")
+      if (!supportedVersions.contains(parsedVersion))
+        throw new IllegalArgumentException(s"Expected version of transaction '$supportedVersions', but got '$parsedVersion'")
+
+      (parsedVersion, 3)
+    }
+  }
+
+}
+
+abstract class TransactionParserFor[T <: Transaction](implicit override val classTag: ClassTag[T]) extends TransactionParser {
+  override type TransactionT = T
 }

--- a/src/main/scala/scorex/transaction/TransactionParsers.scala
+++ b/src/main/scala/scorex/transaction/TransactionParsers.scala
@@ -1,0 +1,89 @@
+package scorex.transaction
+
+import com.wavesplatform.utils.base58Length
+import scorex.transaction.assets._
+import scorex.transaction.assets.exchange.ExchangeTransaction
+import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
+import scorex.transaction.smart.SetScriptTransaction
+
+import scala.util.{Failure, Success, Try}
+
+object TransactionParsers {
+
+  val TimestampLength            = 8
+  val AmountLength               = 8
+  val TypeLength                 = 1
+  val SignatureLength            = 64
+  val SignatureStringLength: Int = base58Length(SignatureLength)
+  val KeyLength                  = 32
+  val KeyStringLength: Int       = base58Length(KeyLength)
+
+  private val old: Map[Byte, TransactionParser] = Seq[TransactionParser](
+    GenesisTransaction,
+    PaymentTransaction,
+    IssueTransaction,
+    TransferTransaction,
+    ReissueTransaction,
+    BurnTransaction,
+    ExchangeTransaction,
+    LeaseTransaction,
+    LeaseCancelTransaction,
+    CreateAliasTransaction,
+    MassTransferTransaction
+  ).map { x =>
+    x.typeId -> x
+  }(collection.breakOut)
+
+  private val modern: Map[(Byte, Byte), TransactionParser] = Seq[TransactionParser](
+    DataTransaction,
+    VersionedTransferTransaction,
+    SetScriptTransaction,
+    SmartIssueTransaction
+  ).flatMap { x =>
+    x.supportedVersions.map { version =>
+      ((x.typeId, version), x)
+    }
+  }(collection.breakOut)
+
+  private val all: Map[(Byte, Byte), TransactionParser] = old.flatMap {
+    case (typeId, builder) =>
+      builder.supportedVersions.map { version =>
+        ((typeId, version), builder)
+      }
+  } ++ modern
+
+  private val byName: Map[String, TransactionParser] = (old ++ modern).map {
+    case (_, builder) => builder.classTag.runtimeClass.getSimpleName -> builder
+  }
+
+  def builderBy(name: String): Option[TransactionParser] = byName.get(name)
+  def builderBy(typeId: Byte, version: Byte): Option[TransactionParser] = all.get((typeId, version))
+
+  def parseBytes(data: Array[Byte]): Try[Transaction] =
+    data.headOption
+      .fold[Try[Byte]](Failure(new IllegalArgumentException("Can't find the significant byte: the buffer is empty")))(Success(_))
+      .flatMap { headByte =>
+        if (headByte == 0) modernParseBytes(data)
+        else oldParseBytes(headByte, data)
+      }
+
+  private def oldParseBytes(tpe: Byte, data: Array[Byte]): Try[Transaction] =
+    old
+      .get(tpe)
+      .fold[Try[TransactionParser]](Failure(new IllegalArgumentException(s"Unknown transaction type (old encoding): '$tpe'")))(Success(_))
+      .flatMap(_.parseBytes(data))
+
+  private def modernParseBytes(data: Array[Byte]): Try[Transaction] = {
+    if (data.length < 2)
+      Failure(new IllegalArgumentException(s"Can't determine the type and the version of transaction: the buffer has ${data.length} bytes"))
+    else {
+      val Array(_, typeId, version) = data.take(3)
+      modern
+        .get((typeId, version))
+        .fold[Try[TransactionParser]](
+          Failure(new IllegalArgumentException(s"Unknown transaction type ($typeId) and version ($version) (modern encoding)")))(Success(_))
+        .flatMap(_.parseBytes(data))
+    }
+  }
+
+}

--- a/src/main/scala/scorex/transaction/TransactionParsers.scala
+++ b/src/main/scala/scorex/transaction/TransactionParsers.scala
@@ -56,8 +56,8 @@ object TransactionParsers {
     case (_, builder) => builder.classTag.runtimeClass.getSimpleName -> builder
   }
 
-  def builderBy(name: String): Option[TransactionParser] = byName.get(name)
-  def builderBy(typeId: Byte, version: Byte): Option[TransactionParser] = all.get((typeId, version))
+  def by(name: String): Option[TransactionParser] = byName.get(name)
+  def by(typeId: Byte, version: Byte): Option[TransactionParser] = all.get((typeId, version))
 
   def parseBytes(data: Array[Byte]): Try[Transaction] =
     data.headOption

--- a/src/main/scala/scorex/transaction/assets/BurnTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/BurnTransaction.scala
@@ -6,33 +6,27 @@ import com.wavesplatform.state2.ByteStr
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 import scorex.transaction.{ValidationError, _}
 
 import scala.util.{Failure, Success, Try}
 
-case class BurnTransaction private(sender: PublicKeyAccount,
-                                   assetId: ByteStr,
-                                   amount: Long,
-                                   fee: Long,
-                                   timestamp: Long,
-                                   signature: ByteStr)
-  extends SignedTransaction with FastHashId {
+case class BurnTransaction private (sender: PublicKeyAccount, assetId: ByteStr, amount: Long, fee: Long, timestamp: Long, signature: ByteStr)
+    extends SignedTransaction
+    with FastHashId {
 
-  override val transactionType: TransactionType.Value = TransactionType.BurnTransaction
+  override val builder: BurnTransaction.type = BurnTransaction
+  override def version: Byte                 = builder.version
 
-  override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(transactionType.id.toByte),
-    sender.publicKey,
-    assetId.arr,
-    Longs.toByteArray(amount),
-    Longs.toByteArray(fee),
-    Longs.toByteArray(timestamp)))
+  override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
+    Bytes
+      .concat(Array(builder.typeId), sender.publicKey, assetId.arr, Longs.toByteArray(amount), Longs.toByteArray(fee), Longs.toByteArray(timestamp)))
 
   override val json: Coeval[JsObject] = Coeval.evalOnce {
     jsonBase() ++ Json.obj(
       "assetId" -> assetId.base58,
-      "amount" -> amount,
-      "fee" -> fee
+      "amount"  -> amount,
+      "fee"     -> fee
     )
   }
 
@@ -42,34 +36,32 @@ case class BurnTransaction private(sender: PublicKeyAccount,
 
 }
 
+object BurnTransaction extends TransactionParserFor[BurnTransaction] with TransactionParser.HardcodedVersion {
 
-object BurnTransaction {
+  override val typeId: Byte  = 6
+  override val version: Byte = 1
 
-  def parseBytes(bytes: Array[Byte]): Try[BurnTransaction] = Try {
-    require(bytes.head == TransactionType.BurnTransaction.id)
-    parseTail(bytes.tail).get
-  }
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      val sender        = PublicKeyAccount(bytes.slice(0, KeyLength))
+      val assetId       = ByteStr(bytes.slice(KeyLength, KeyLength + AssetIdLength))
+      val quantityStart = KeyLength + AssetIdLength
 
-  def parseTail(bytes: Array[Byte]): Try[BurnTransaction] = Try {
-    val sender = PublicKeyAccount(bytes.slice(0, KeyLength))
-    val assetId = ByteStr(bytes.slice(KeyLength, KeyLength + AssetIdLength))
-    val quantityStart = KeyLength + AssetIdLength
-
-    val quantity = Longs.fromByteArray(bytes.slice(quantityStart, quantityStart + 8))
-    val fee = Longs.fromByteArray(bytes.slice(quantityStart + 8, quantityStart + 16))
-    val timestamp = Longs.fromByteArray(bytes.slice(quantityStart + 16, quantityStart + 24))
-    val signature = ByteStr(bytes.slice(quantityStart + 24, quantityStart + 24 + SignatureLength))
-    BurnTransaction
-      .create(sender, assetId, quantity, fee, timestamp, signature)
-      .fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+      val quantity  = Longs.fromByteArray(bytes.slice(quantityStart, quantityStart + 8))
+      val fee       = Longs.fromByteArray(bytes.slice(quantityStart + 8, quantityStart + 16))
+      val timestamp = Longs.fromByteArray(bytes.slice(quantityStart + 16, quantityStart + 24))
+      val signature = ByteStr(bytes.slice(quantityStart + 24, quantityStart + 24 + SignatureLength))
+      BurnTransaction
+        .create(sender, assetId, quantity, fee, timestamp, signature)
+        .fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
 
   def create(sender: PublicKeyAccount,
              assetId: ByteStr,
              quantity: Long,
              fee: Long,
              timestamp: Long,
-             signature: ByteStr): Either[ValidationError, BurnTransaction] =
+             signature: ByteStr): Either[ValidationError, TransactionT] =
     if (quantity < 0) {
       Left(ValidationError.NegativeAmount(quantity, "assets"))
     } else if (fee <= 0) {
@@ -78,11 +70,7 @@ object BurnTransaction {
       Right(BurnTransaction(sender, assetId, quantity, fee, timestamp, signature))
     }
 
-  def create(sender: PrivateKeyAccount,
-             assetId: ByteStr,
-             quantity: Long,
-             fee: Long,
-             timestamp: Long): Either[ValidationError, BurnTransaction] =
+  def create(sender: PrivateKeyAccount, assetId: ByteStr, quantity: Long, fee: Long, timestamp: Long): Either[ValidationError, TransactionT] =
     create(sender, assetId, quantity, fee, timestamp, ByteStr.empty).right.map { unverified =>
       unverified.copy(signature = ByteStr(crypto.sign(sender, unverified.bodyBytes())))
     }

--- a/src/main/scala/scorex/transaction/assets/BurnTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/BurnTransaction.scala
@@ -34,10 +34,9 @@ case class BurnTransaction private (sender: PublicKeyAccount, assetId: ByteStr, 
 
 }
 
-object BurnTransaction extends TransactionParserFor[BurnTransaction] with TransactionParser.HardcodedVersion {
+object BurnTransaction extends TransactionParserFor[BurnTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 6
-  override val version: Byte = 1
+  override val typeId: Byte = 6
 
   override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {

--- a/src/main/scala/scorex/transaction/assets/BurnTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/BurnTransaction.scala
@@ -16,8 +16,6 @@ case class BurnTransaction private (sender: PublicKeyAccount, assetId: ByteStr, 
     with FastHashId {
 
   override val builder: BurnTransaction.type = BurnTransaction
-  override def version: Byte                 = builder.version
-
   override val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
     Bytes
       .concat(Array(builder.typeId), sender.publicKey, assetId.arr, Longs.toByteArray(amount), Longs.toByteArray(fee), Longs.toByteArray(timestamp)))

--- a/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
@@ -27,7 +27,6 @@ case class IssueTransaction private (sender: PublicKeyAccount,
 
   override val assetFee: (Option[AssetId], Long) = (None, fee)
   override val builder: IssueTransaction.type    = IssueTransaction
-  override def version: Byte                     = builder.version
 
   val assetId = id
 

--- a/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
@@ -57,10 +57,9 @@ case class IssueTransaction private (sender: PublicKeyAccount,
 
 }
 
-object IssueTransaction extends TransactionParserFor[IssueTransaction] with TransactionParser.HardcodedVersion {
+object IssueTransaction extends TransactionParserFor[IssueTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 3
-  override val version: Byte = 1
+  override val typeId: Byte = 3
 
   val MaxDescriptionLength = 1000
   val MaxAssetNameLength   = 16

--- a/src/main/scala/scorex/transaction/assets/MassTransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/MassTransferTransaction.scala
@@ -16,7 +16,7 @@ import scorex.transaction.assets.MassTransferTransaction.{ParsedTransfer, toJson
 
 import scala.util.{Either, Failure, Success, Try}
 
-case class MassTransferTransaction private (override val version: Byte,
+case class MassTransferTransaction private (version: Byte,
                                             assetId: Option[AssetId],
                                             sender: PublicKeyAccount,
                                             transfers: List[ParsedTransfer],

--- a/src/main/scala/scorex/transaction/assets/MassTransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/MassTransferTransaction.scala
@@ -9,22 +9,24 @@ import play.api.libs.json.{Format, JsObject, JsValue, Json}
 import scorex.account.{AddressOrAlias, PrivateKeyAccount, PublicKeyAccount}
 import scorex.crypto.encode.Base58
 import scorex.serialization.Deser
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 import scorex.transaction.ValidationError.Validation
 import scorex.transaction._
 import scorex.transaction.assets.MassTransferTransaction.{ParsedTransfer, toJson}
 
 import scala.util.{Either, Failure, Success, Try}
 
-case class MassTransferTransaction private(version: Byte,
-                                           assetId: Option[AssetId],
-                                           sender: PublicKeyAccount,
-                                           transfers: List[ParsedTransfer],
-                                           timestamp: Long,
-                                           fee: Long,
-                                           attachment: Array[Byte],
-                                           proofs: Proofs) extends ProvenTransaction with FastHashId {
-  override val transactionType: TransactionType.Value = TransactionType.MassTransferTransaction
+case class MassTransferTransaction private (override val version: Byte,
+                                            assetId: Option[AssetId],
+                                            sender: PublicKeyAccount,
+                                            transfers: List[ParsedTransfer],
+                                            timestamp: Long,
+                                            fee: Long,
+                                            attachment: Array[Byte],
+                                            proofs: Proofs)
+    extends ProvenTransaction
+    with FastHashId {
+  override val builder: MassTransferTransaction.type = MassTransferTransaction
 
   override val assetFee: (Option[AssetId], Long) = (None, fee)
 
@@ -35,37 +37,37 @@ case class MassTransferTransaction private(version: Byte,
       .fold(Array())(_ ++ _)
 
     Bytes.concat(
-      Array(transactionType.id.toByte),
-      Array(version),
+      Array(builder.typeId, version),
       sender.publicKey,
       assetIdBytes,
       Shorts.toByteArray(transfers.size.toShort),
       transferBytes,
       Longs.toByteArray(timestamp),
       Longs.toByteArray(fee),
-      Deser.serializeArray(attachment))
+      Deser.serializeArray(attachment)
+    )
   }
 
-  override def jsonBase(): JsObject = super.jsonBase() ++ Json.obj(
-    "version" -> version,
-    "assetId" -> assetId.map(_.base58),
-    "attachment" -> Base58.encode(attachment),
-    "transferCount" -> transfers.size,
-    "totalAmount" -> transfers.map(_.amount).sum)
-
+  override def jsonBase(): JsObject =
+    super.jsonBase() ++ Json.obj("assetId"       -> assetId.map(_.base58),
+                                 "attachment"    -> Base58.encode(attachment),
+                                 "transferCount" -> transfers.size,
+                                 "totalAmount"   -> transfers.map(_.amount).sum)
 
   override val json: Coeval[JsObject] = Coeval.evalOnce {
     jsonBase() ++ Json.obj("transfers" -> toJson(transfers))
   }
 
-  def compactJson(recipient: AddressOrAlias): JsObject = jsonBase() ++ Json.obj(
-    "transfers" -> toJson(transfers.filter(_.address == recipient)))
+  def compactJson(recipient: AddressOrAlias): JsObject = jsonBase() ++ Json.obj("transfers" -> toJson(transfers.filter(_.address == recipient)))
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
 }
 
-object MassTransferTransaction {
-  val Version: Byte = 1
+object MassTransferTransaction extends TransactionParserFor[MassTransferTransaction] with TransactionParser.OneVersion {
+
+  override val typeId: Byte  = 11
+  override val version: Byte = 1
+
   val MaxTransferCount = 100
 
   case class Transfer(recipient: String, amount: Long)
@@ -74,35 +76,35 @@ object MassTransferTransaction {
 
   implicit val transferFormat: Format[Transfer] = Json.format
 
-  def parseTail(bytes: Array[Byte]): Try[MassTransferTransaction] = Try {
-    val version = bytes(0)
-    val sender = PublicKeyAccount(bytes.slice(1, KeyLength + 1))
-    val (assetIdOpt, s0) = Deser.parseByteArrayOption(bytes, KeyLength + 1, AssetIdLength)
-    val transferCount = Shorts.fromByteArray(bytes.slice(s0, s0 + 2))
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      val sender           = PublicKeyAccount(bytes.slice(0, KeyLength))
+      val (assetIdOpt, s0) = Deser.parseByteArrayOption(bytes, KeyLength, AssetIdLength)
+      val transferCount    = Shorts.fromByteArray(bytes.slice(s0, s0 + 2))
 
-    def readTransfer(offset: Int): (Validation[ParsedTransfer], Int) = {
-      AddressOrAlias.fromBytes(bytes, offset) match {
-        case Right((addr, ofs)) =>
-          val amount = Longs.fromByteArray(bytes.slice(ofs, ofs + 8))
-          (Right[ValidationError, ParsedTransfer](ParsedTransfer(addr, amount)), ofs + 8)
-        case Left(e) => (Left(e), offset)
+      def readTransfer(offset: Int): (Validation[ParsedTransfer], Int) = {
+        AddressOrAlias.fromBytes(bytes, offset) match {
+          case Right((addr, ofs)) =>
+            val amount = Longs.fromByteArray(bytes.slice(ofs, ofs + 8))
+            (Right[ValidationError, ParsedTransfer](ParsedTransfer(addr, amount)), ofs + 8)
+          case Left(e) => (Left(e), offset)
+        }
       }
-    }
 
-    val transfersList: List[(Validation[ParsedTransfer], Int)] =
-      List.iterate(readTransfer(s0 + 2), transferCount) { case (_, offset) => readTransfer(offset) }
+      val transfersList: List[(Validation[ParsedTransfer], Int)] =
+        List.iterate(readTransfer(s0 + 2), transferCount) { case (_, offset) => readTransfer(offset) }
 
-    val s1 = transfersList.lastOption.map(_._2).getOrElse(s0 + 2)
-    val tx: Validation[MassTransferTransaction] = for {
-      transfers <- transfersList.map { case (ei, _) => ei }.sequence
-      timestamp = Longs.fromByteArray(bytes.slice(s1, s1 + 8))
-      feeAmount = Longs.fromByteArray(bytes.slice(s1 + 8, s1 + 16))
-      (attachment, attachEnd) = Deser.parseArraySize(bytes, s1 + 16)
-      proofs <- Proofs.fromBytes(bytes.drop(attachEnd))
-      mtt <- MassTransferTransaction.create(version, assetIdOpt.map(ByteStr(_)), sender, transfers, timestamp, feeAmount, attachment, proofs)
-    } yield mtt
-    tx.fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+      val s1 = transfersList.lastOption.map(_._2).getOrElse(s0 + 2)
+      val tx: Validation[MassTransferTransaction] = for {
+        transfers <- transfersList.map { case (ei, _) => ei }.sequence
+        timestamp               = Longs.fromByteArray(bytes.slice(s1, s1 + 8))
+        feeAmount               = Longs.fromByteArray(bytes.slice(s1 + 8, s1 + 16))
+        (attachment, attachEnd) = Deser.parseArraySize(bytes, s1 + 16)
+        proofs <- Proofs.fromBytes(bytes.drop(attachEnd))
+        mtt    <- MassTransferTransaction.create(version, assetIdOpt.map(ByteStr(_)), sender, transfers, timestamp, feeAmount, attachment, proofs)
+      } yield mtt
+      tx.fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
 
   def create(version: Byte,
              assetId: Option[AssetId],
@@ -111,13 +113,13 @@ object MassTransferTransaction {
              timestamp: Long,
              feeAmount: Long,
              attachment: Array[Byte],
-             proofs: Proofs): Either[ValidationError, MassTransferTransaction] = {
+             proofs: Proofs): Either[ValidationError, TransactionT] = {
     Try {
       transfers.map(_.amount).fold(feeAmount)(Math.addExact)
     }.fold(
       ex => Left(ValidationError.OverflowError),
       totalAmount =>
-        if (version != 1) {
+        if (version != MassTransferTransaction.version) {
           Left(ValidationError.UnsupportedVersion(version))
         } else if (transfers.lengthCompare(MaxTransferCount) > 0) {
           Left(ValidationError.GenericError(s"Number of transfers is greater than $MaxTransferCount"))
@@ -129,7 +131,7 @@ object MassTransferTransaction {
           Left(ValidationError.InsufficientFee)
         } else {
           Right(MassTransferTransaction(version, assetId, sender, transfers, timestamp, feeAmount, attachment, proofs))
-        }
+      }
     )
   }
 
@@ -139,15 +141,16 @@ object MassTransferTransaction {
                  transfers: List[ParsedTransfer],
                  timestamp: Long,
                  feeAmount: Long,
-                 attachment: Array[Byte]): Either[ValidationError, MassTransferTransaction] = {
+                 attachment: Array[Byte]): Either[ValidationError, TransactionT] = {
     create(version, assetId, sender, transfers, timestamp, feeAmount, attachment, Proofs.empty).right.map { unsigned =>
       unsigned.copy(proofs = Proofs.create(Seq(ByteStr(crypto.sign(sender, unsigned.bodyBytes())))).explicitGet())
     }
   }
 
   def parseTransfersList(transfers: List[Transfer]): Validation[List[ParsedTransfer]] = {
-    transfers.traverse { case Transfer(recipient, amount) =>
-      AddressOrAlias.fromString(recipient).map(ParsedTransfer(_, amount))
+    transfers.traverse {
+      case Transfer(recipient, amount) =>
+        AddressOrAlias.fromString(recipient).map(ParsedTransfer(_, amount))
     }
   }
 

--- a/src/main/scala/scorex/transaction/assets/MassTransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/MassTransferTransaction.scala
@@ -49,10 +49,13 @@ case class MassTransferTransaction private (override val version: Byte,
   }
 
   override def jsonBase(): JsObject =
-    super.jsonBase() ++ Json.obj("assetId"       -> assetId.map(_.base58),
-                                 "attachment"    -> Base58.encode(attachment),
-                                 "transferCount" -> transfers.size,
-                                 "totalAmount"   -> transfers.map(_.amount).sum)
+    super.jsonBase() ++ Json.obj(
+      "version"       -> version,
+      "assetId"       -> assetId.map(_.base58),
+      "attachment"    -> Base58.encode(attachment),
+      "transferCount" -> transfers.size,
+      "totalAmount"   -> transfers.map(_.amount).sum
+    )
 
   override val json: Coeval[JsObject] = Coeval.evalOnce {
     jsonBase() ++ Json.obj("transfers" -> toJson(transfers))

--- a/src/main/scala/scorex/transaction/assets/ReissueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/ReissueTransaction.scala
@@ -46,10 +46,9 @@ case class ReissueTransaction private (sender: PublicKeyAccount,
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(builder.typeId), signature.arr, bodyBytes()))
 }
 
-object ReissueTransaction extends TransactionParserFor[ReissueTransaction] with TransactionParser.HardcodedVersion {
+object ReissueTransaction extends TransactionParserFor[ReissueTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 5
-  override val version: Byte = 1
+  override val typeId: Byte = 5
 
   override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {

--- a/src/main/scala/scorex/transaction/assets/ReissueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/ReissueTransaction.scala
@@ -22,7 +22,6 @@ case class ReissueTransaction private (sender: PublicKeyAccount,
     with FastHashId {
 
   override val builder: ReissueTransaction.type = ReissueTransaction
-  override def version: Byte                    = builder.version
 
   val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
     Bytes.concat(

--- a/src/main/scala/scorex/transaction/assets/SmartIssueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/SmartIssueTransaction.scala
@@ -13,7 +13,7 @@ import scorex.transaction._
 
 import scala.util.Try
 
-case class SmartIssueTransaction private (override val version: Byte,
+case class SmartIssueTransaction private (version: Byte,
                                           chainId: Byte,
                                           sender: PublicKeyAccount,
                                           name: Array[Byte],

--- a/src/main/scala/scorex/transaction/assets/SmartIssueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/SmartIssueTransaction.scala
@@ -33,7 +33,7 @@ case class SmartIssueTransaction private (version: Byte,
 
   val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
     Bytes.concat(
-      Array(0, builder.typeId, version, chainId),
+      Array(builder.typeId, version, chainId),
       sender.publicKey,
       Deser.serializeArray(name),
       Deser.serializeArray(description),
@@ -52,7 +52,7 @@ case class SmartIssueTransaction private (version: Byte,
       "script"  -> script.map(_.text)
     ))
 
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 }
 
 object SmartIssueTransaction extends TransactionParserFor[SmartIssueTransaction] with TransactionParser.MultipleVersions {

--- a/src/main/scala/scorex/transaction/assets/SmartIssueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/SmartIssueTransaction.scala
@@ -7,14 +7,13 @@ import monix.eval.Coeval
 import play.api.libs.json.Json
 import scorex.account.{AddressScheme, PrivateKeyAccount, PublicKeyAccount}
 import scorex.serialization.Deser
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.ValidationError.{GenericError, UnsupportedVersion}
 import scorex.transaction.smart.Script
 import scorex.transaction._
 
 import scala.util.Try
 
-case class SmartIssueTransaction private (version: Byte,
+case class SmartIssueTransaction private (override val version: Byte,
                                           chainId: Byte,
                                           sender: PublicKeyAccount,
                                           name: Array[Byte],
@@ -30,10 +29,11 @@ case class SmartIssueTransaction private (version: Byte,
     with FastHashId
     with ChainSpecific {
 
+  override val builder: TransactionParser = SmartIssueTransaction
+
   val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
     Bytes.concat(
-      Array(version),
-      Array(chainId),
+      Array(0, builder.typeId, version, chainId),
       sender.publicKey,
       Deser.serializeArray(name),
       Deser.serializeArray(description),
@@ -45,27 +45,23 @@ case class SmartIssueTransaction private (version: Byte,
       Longs.toByteArray(timestamp)
     ))
 
-  override val transactionType            = TransactionType.SmartIssueTransaction
   override val assetFee                   = (None, fee)
-  override val json                       = Coeval.evalOnce(jsonBase() ++ Json.obj("version" -> version, "script" -> script.map(_.text)))
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(transactionType.id.toByte), bodyBytes(), proofs.bytes()))
+  override val json                       = Coeval.evalOnce(jsonBase() ++ Json.obj("script" -> script.map(_.text)))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
 }
 
-object SmartIssueTransaction {
+object SmartIssueTransaction extends TransactionParserFor[SmartIssueTransaction] with TransactionParser.MultipleVersions {
+
+  override val typeId: Byte                 = 3
+  override val supportedVersions: Set[Byte] = Set(2)
 
   private val networkByte = AddressScheme.current.chainId
 
-  def parseBytes(bytes: Array[Byte]): Try[SmartIssueTransaction] = Try {
-    require(bytes.head == TransactionType.SmartIssueTransaction.id)
-    parseTail(bytes.tail).get
-  }
-
-  def parseTail(bytes: Array[Byte]): Try[SmartIssueTransaction] =
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {
-      val version                       = bytes(0)
-      val chainId                       = bytes(1)
-      val sender                        = PublicKeyAccount(bytes.slice(2, TransactionParser.KeyLength + 2))
-      val (assetName, descriptionStart) = Deser.parseArraySize(bytes, TransactionParser.KeyLength + 2)
+      val chainId                       = bytes(0)
+      val sender                        = PublicKeyAccount(bytes.slice(1, TransactionParsers.KeyLength + 1))
+      val (assetName, descriptionStart) = Deser.parseArraySize(bytes, TransactionParsers.KeyLength + 1)
       val (description, quantityStart)  = Deser.parseArraySize(bytes, descriptionStart)
       val quantity                      = Longs.fromByteArray(bytes.slice(quantityStart, quantityStart + 8))
       val decimals                      = bytes.slice(quantityStart + 8, quantityStart + 9).head
@@ -100,9 +96,9 @@ object SmartIssueTransaction {
              script: Option[Script],
              fee: Long,
              timestamp: Long,
-             proofs: Proofs): Either[ValidationError, SmartIssueTransaction] =
+             proofs: Proofs): Either[ValidationError, TransactionT] =
     for {
-      _ <- Either.cond(version == 1, (), UnsupportedVersion(version))
+     _<- Either.cond(supportedVersions.contains(version), (), UnsupportedVersion(version))
       _ <- Either.cond(chainId == networkByte, (), GenericError(s"Wrong chainId ${chainId.toInt}"))
       _ <- IssueTransaction.validateIssueParams(name, description, quantity, decimals, reissuable, fee)
     } yield SmartIssueTransaction(version, chainId, sender, name, description, quantity, decimals, reissuable, script, fee, timestamp, proofs)
@@ -117,7 +113,7 @@ object SmartIssueTransaction {
                  reissuable: Boolean,
                  script: Option[Script],
                  fee: Long,
-                 timestamp: Long): Either[ValidationError, SmartIssueTransaction] =
+                 timestamp: Long): Either[ValidationError, TransactionT] =
     for {
       unverified <- create(version, chainId, sender, name, description, quantity, decimals, reissuable, script, fee, timestamp, Proofs.empty)
       proofs     <- Proofs.create(Seq(ByteStr(crypto.sign(sender, unverified.bodyBytes()))))

--- a/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
@@ -27,7 +27,6 @@ case class TransferTransaction private (assetId: Option[AssetId],
     with FastHashId {
 
   override val builder: TransactionParser = TransferTransaction
-  override def version: Byte              = builder.supportedVersions.head
 
   override val assetFee: (Option[AssetId], Long) = (feeAssetId, fee)
 

--- a/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
@@ -9,33 +9,37 @@ import play.api.libs.json.{JsObject, Json}
 import scorex.account.{AddressOrAlias, PrivateKeyAccount, PublicKeyAccount}
 import scorex.crypto.encode.Base58
 import scorex.serialization.Deser
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 import scorex.transaction.{ValidationError, _}
 
 import scala.util.{Failure, Success, Try}
 
-case class TransferTransaction private(assetId: Option[AssetId],
-                                       sender: PublicKeyAccount,
-                                       recipient: AddressOrAlias,
-                                       amount: Long,
-                                       timestamp: Long,
-                                       feeAssetId: Option[AssetId],
-                                       fee: Long,
-                                       attachment: Array[Byte],
-                                       signature: ByteStr)
-  extends SignedTransaction with FastHashId {
-  override val transactionType: TransactionType.Value = TransactionType.TransferTransaction
+case class TransferTransaction private (assetId: Option[AssetId],
+                                        sender: PublicKeyAccount,
+                                        recipient: AddressOrAlias,
+                                        amount: Long,
+                                        timestamp: Long,
+                                        feeAssetId: Option[AssetId],
+                                        fee: Long,
+                                        attachment: Array[Byte],
+                                        signature: ByteStr)
+    extends SignedTransaction
+    with FastHashId {
+
+  override val builder: TransactionParser = TransferTransaction
+  override def version: Byte               = builder.supportedVersions.head
 
   override val assetFee: (Option[AssetId], Long) = (feeAssetId, fee)
 
   val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce {
-    val timestampBytes = Longs.toByteArray(timestamp)
-    val assetIdBytes = assetId.map(a => (1: Byte) +: a.arr).getOrElse(Array(0: Byte))
-    val amountBytes = Longs.toByteArray(amount)
+    val timestampBytes  = Longs.toByteArray(timestamp)
+    val assetIdBytes    = assetId.map(a => (1: Byte) +: a.arr).getOrElse(Array(0: Byte))
+    val amountBytes     = Longs.toByteArray(amount)
     val feeAssetIdBytes = feeAssetId.map(a => (1: Byte) +: a.arr).getOrElse(Array(0: Byte))
-    val feeBytes = Longs.toByteArray(fee)
+    val feeBytes        = Longs.toByteArray(fee)
 
-    Bytes.concat(Array(transactionType.id.toByte),
+    Bytes.concat(
+      Array(builder.typeId),
       sender.publicKey,
       assetIdBytes,
       feeAssetIdBytes,
@@ -43,46 +47,58 @@ case class TransferTransaction private(assetId: Option[AssetId],
       amountBytes,
       feeBytes,
       recipient.bytes.arr,
-      Deser.serializeArray(attachment))
+      Deser.serializeArray(attachment)
+    )
   }
 
-  override val json: Coeval[JsObject] = Coeval.evalOnce(jsonBase() ++ Json.obj(
-    "recipient" -> recipient.stringRepr,
-    "assetId" -> assetId.map(_.base58),
-    "amount" -> amount,
-    "feeAsset" -> feeAssetId.map(_.base58),
-    "attachment" -> Base58.encode(attachment)
-  ))
+  override val json: Coeval[JsObject] = Coeval.evalOnce(
+    jsonBase() ++ Json.obj(
+      "recipient"  -> recipient.stringRepr,
+      "assetId"    -> assetId.map(_.base58),
+      "amount"     -> amount,
+      "feeAsset"   -> feeAssetId.map(_.base58),
+      "attachment" -> Base58.encode(attachment)
+    ))
 
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(transactionType.id.toByte), signature.arr, bodyBytes()))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(builder.typeId), signature.arr, bodyBytes()))
 
 }
 
-object TransferTransaction {
+object TransferTransaction extends TransactionParserFor[TransferTransaction] with TransactionParser.HardcodedVersion {
 
-  val MaxAttachmentSize = 140
-  val MaxAttachmentStringSize = base58Length(MaxAttachmentSize)
+  override val typeId: Byte  = 4
+  override val version: Byte = 1
 
+  val MaxAttachmentSize            = 140
+  val MaxAttachmentStringSize: Int = base58Length(MaxAttachmentSize)
 
-  def parseTail(bytes: Array[Byte]): Try[TransferTransaction] = Try {
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      val signature = ByteStr(bytes.slice(0, SignatureLength))
+      val txId      = bytes(SignatureLength)
+      require(txId == typeId, s"Signed tx id is not match")
+      val sender              = PublicKeyAccount(bytes.slice(SignatureLength + 1, SignatureLength + KeyLength + 1))
+      val (assetIdOpt, s0)    = Deser.parseByteArrayOption(bytes, SignatureLength + KeyLength + 1, AssetIdLength)
+      val (feeAssetIdOpt, s1) = Deser.parseByteArrayOption(bytes, s0, AssetIdLength)
+      val timestamp           = Longs.fromByteArray(bytes.slice(s1, s1 + 8))
+      val amount              = Longs.fromByteArray(bytes.slice(s1 + 8, s1 + 16))
+      val feeAmount           = Longs.fromByteArray(bytes.slice(s1 + 16, s1 + 24))
 
-    val signature = ByteStr(bytes.slice(0, SignatureLength))
-    val txId = bytes(SignatureLength)
-    require(txId == TransactionType.TransferTransaction.id.toByte, s"Signed tx id is not match")
-    val sender = PublicKeyAccount(bytes.slice(SignatureLength + 1, SignatureLength + KeyLength + 1))
-    val (assetIdOpt, s0) = Deser.parseByteArrayOption(bytes, SignatureLength + KeyLength + 1, AssetIdLength)
-    val (feeAssetIdOpt, s1) = Deser.parseByteArrayOption(bytes, s0, AssetIdLength)
-    val timestamp = Longs.fromByteArray(bytes.slice(s1, s1 + 8))
-    val amount = Longs.fromByteArray(bytes.slice(s1 + 8, s1 + 16))
-    val feeAmount = Longs.fromByteArray(bytes.slice(s1 + 16, s1 + 24))
-
-    (for {
-      recRes <- AddressOrAlias.fromBytes(bytes, s1 + 24)
-      (recipient, recipientEnd) = recRes
-      (attachment, _) = Deser.parseArraySize(bytes, recipientEnd)
-      tt <- TransferTransaction.create(assetIdOpt.map(ByteStr(_)), sender, recipient, amount, timestamp, feeAssetIdOpt.map(ByteStr(_)), feeAmount, attachment, signature)
-    } yield tt).fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+      (for {
+        recRes <- AddressOrAlias.fromBytes(bytes, s1 + 24)
+        (recipient, recipientEnd) = recRes
+        (attachment, _)           = Deser.parseArraySize(bytes, recipientEnd)
+        tt <- TransferTransaction.create(assetIdOpt.map(ByteStr(_)),
+                                         sender,
+                                         recipient,
+                                         amount,
+                                         timestamp,
+                                         feeAssetIdOpt.map(ByteStr(_)),
+                                         feeAmount,
+                                         attachment,
+                                         signature)
+      } yield tt).fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
 
   def create(assetId: Option[AssetId],
              sender: PublicKeyAccount,
@@ -92,7 +108,7 @@ object TransferTransaction {
              feeAssetId: Option[AssetId],
              feeAmount: Long,
              attachment: Array[Byte],
-             signature: ByteStr): Either[ValidationError, TransferTransaction] = {
+             signature: ByteStr): Either[ValidationError, TransactionT] = {
     if (attachment.length > TransferTransaction.MaxAttachmentSize) {
       Left(ValidationError.TooBigArray)
     } else if (amount <= 0) {
@@ -113,7 +129,7 @@ object TransferTransaction {
              timestamp: Long,
              feeAssetId: Option[AssetId],
              feeAmount: Long,
-             attachment: Array[Byte]): Either[ValidationError, TransferTransaction] = {
+             attachment: Array[Byte]): Either[ValidationError, TransactionT] = {
     create(assetId, sender, recipient, amount, timestamp, feeAssetId, feeAmount, attachment, ByteStr.empty).right.map { unsigned =>
       unsigned.copy(signature = ByteStr(crypto.sign(sender, unsigned.bodyBytes())))
     }

--- a/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
@@ -63,10 +63,9 @@ case class TransferTransaction private (assetId: Option[AssetId],
 
 }
 
-object TransferTransaction extends TransactionParserFor[TransferTransaction] with TransactionParser.HardcodedVersion {
+object TransferTransaction extends TransactionParserFor[TransferTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 4
-  override val version: Byte = 1
+  override val typeId: Byte = 4
 
   val MaxAttachmentSize            = 140
   val MaxAttachmentStringSize: Int = base58Length(MaxAttachmentSize)

--- a/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
@@ -27,7 +27,7 @@ case class TransferTransaction private (assetId: Option[AssetId],
     with FastHashId {
 
   override val builder: TransactionParser = TransferTransaction
-  override def version: Byte               = builder.supportedVersions.head
+  override def version: Byte              = builder.supportedVersions.head
 
   override val assetFee: (Option[AssetId], Long) = (feeAssetId, fee)
 

--- a/src/main/scala/scorex/transaction/assets/VersionedTransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/VersionedTransferTransaction.scala
@@ -8,73 +8,77 @@ import play.api.libs.json.{JsObject, Json}
 import scorex.account.{AddressOrAlias, PrivateKeyAccount, PublicKeyAccount}
 import scorex.crypto.encode.Base58
 import scorex.serialization.Deser
-import scorex.transaction.TransactionParser._
-import scorex.transaction.ValidationError.GenericError
+import scorex.transaction.TransactionParsers._
 import scorex.transaction._
 
 import scala.util.{Failure, Success, Try}
 
-case class VersionedTransferTransaction private(version: Byte,
-                                                sender: PublicKeyAccount,
-                                                recipient: AddressOrAlias,
-                                                assetId: Option[AssetId],
-                                                amount: Long,
-                                                timestamp: Long,
-                                                fee: Long,
-                                                attachment: Array[Byte],
-                                                proofs: Proofs)
-  extends ProvenTransaction with FastHashId {
-  override val transactionType: TransactionType.Value = TransactionType.VersionedTransferTransaction
+case class VersionedTransferTransaction private (override val version: Byte,
+                                                 sender: PublicKeyAccount,
+                                                 recipient: AddressOrAlias,
+                                                 assetId: Option[AssetId],
+                                                 amount: Long,
+                                                 timestamp: Long,
+                                                 fee: Long,
+                                                 attachment: Array[Byte],
+                                                 proofs: Proofs)
+    extends ProvenTransaction
+    with FastHashId {
 
+  override val builder: TransactionParser       = VersionedTransferTransaction
   override val assetFee: (Option[AssetId], Long) = (None, fee)
 
   val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce {
     val timestampBytes = Longs.toByteArray(timestamp)
-    val assetIdBytes = assetId.map(a => (1: Byte) +: a.arr).getOrElse(Array(0: Byte))
-    val amountBytes = Longs.toByteArray(amount)
-    val feeBytes = Longs.toByteArray(fee)
+    val assetIdBytes   = assetId.map(a => (1: Byte) +: a.arr).getOrElse(Array(0: Byte))
+    val amountBytes    = Longs.toByteArray(amount)
+    val feeBytes       = Longs.toByteArray(fee)
 
-    Bytes.concat(Array(version),
+    Bytes.concat(
+      Array(0, builder.typeId, version),
       sender.publicKey,
       assetIdBytes,
       timestampBytes,
       amountBytes,
       feeBytes,
       recipient.bytes.arr,
-      Deser.serializeArray(attachment))
+      Deser.serializeArray(attachment)
+    )
   }
 
-  override val json: Coeval[JsObject] = Coeval.evalOnce(jsonBase() ++ Json.obj(
-    "version" -> version,
-    "recipient" -> recipient.stringRepr,
-    "assetId" -> assetId.map(_.base58),
-    "amount" -> amount,
-    "attachment" -> Base58.encode(attachment)
-  ))
+  override val json: Coeval[JsObject] = Coeval.evalOnce(
+    jsonBase() ++ Json.obj(
+      "recipient"  -> recipient.stringRepr,
+      "assetId"    -> assetId.map(_.base58),
+      "amount"     -> amount,
+      "attachment" -> Base58.encode(attachment)
+    ))
 
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(transactionType.id.toByte), bodyBytes(), proofs.bytes()))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
 
 }
 
+object VersionedTransferTransaction extends TransactionParserFor[VersionedTransferTransaction] with TransactionParser.MultipleVersions {
 
-object VersionedTransferTransaction {
+  override val typeId: Byte                 = 4
+  override val supportedVersions: Set[Byte] = Set(2)
 
-  def parseTail(bytes: Array[Byte]): Try[VersionedTransferTransaction] = Try {
-    val version = bytes(0)
-    val sender = PublicKeyAccount(bytes.slice(1, KeyLength + 1))
-    val (assetIdOpt, s0) = Deser.parseByteArrayOption(bytes, KeyLength + 1, AssetIdLength)
-    val timestamp = Longs.fromByteArray(bytes.slice(s0, s0 + 8))
-    val amount = Longs.fromByteArray(bytes.slice(s0 + 8, s0 + 16))
-    val feeAmount = Longs.fromByteArray(bytes.slice(s0 + 16, s0 + 24))
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      val sender           = PublicKeyAccount(bytes.slice(0, KeyLength))
+      val (assetIdOpt, s0) = Deser.parseByteArrayOption(bytes, KeyLength, AssetIdLength)
+      val timestamp        = Longs.fromByteArray(bytes.slice(s0, s0 + 8))
+      val amount           = Longs.fromByteArray(bytes.slice(s0 + 8, s0 + 16))
+      val feeAmount        = Longs.fromByteArray(bytes.slice(s0 + 16, s0 + 24))
 
-    (for {
-      recRes <- AddressOrAlias.fromBytes(bytes, s0 + 24)
-      (recipient, recipientEnd) = recRes
-      (attachment, attachEnd) = Deser.parseArraySize(bytes, recipientEnd)
-      proofs <- Proofs.fromBytes(bytes.drop(attachEnd))
-      tt <- VersionedTransferTransaction.create(version, assetIdOpt.map(ByteStr(_)), sender, recipient, amount, timestamp, feeAmount, attachment, proofs)
-    } yield tt).fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+      (for {
+        recRes <- AddressOrAlias.fromBytes(bytes, s0 + 24)
+        (recipient, recipientEnd) = recRes
+        (attachment, attachEnd)   = Deser.parseArraySize(bytes, recipientEnd)
+        proofs <- Proofs.fromBytes(bytes.drop(attachEnd))
+        tt     <- VersionedTransferTransaction.create(version, assetIdOpt.map(ByteStr(_)), sender, recipient, amount, timestamp, feeAmount, attachment, proofs)
+      } yield tt).fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
 
   def create(version: Byte,
              assetId: Option[AssetId],
@@ -84,9 +88,9 @@ object VersionedTransferTransaction {
              timestamp: Long,
              feeAmount: Long,
              attachment: Array[Byte],
-             proofs: Proofs): Either[ValidationError, VersionedTransferTransaction] = {
-    if (version != 2.toByte) {
-      Left(GenericError("Version must be 2"))
+             proofs: Proofs): Either[ValidationError, TransactionT] = {
+    if (!supportedVersions.contains(version)) {
+      Left(ValidationError.UnsupportedVersion(version))
     } else if (attachment.length > TransferTransaction.MaxAttachmentSize) {
       Left(ValidationError.TooBigArray)
     } else if (amount <= 0) {
@@ -107,12 +111,9 @@ object VersionedTransferTransaction {
                  amount: Long,
                  timestamp: Long,
                  feeAmount: Long,
-                 attachment: Array[Byte]): Either[ValidationError, VersionedTransferTransaction] = {
+                 attachment: Array[Byte]): Either[ValidationError, TransactionT] = {
     create(version, assetId, sender, recipient, amount, timestamp, feeAmount, attachment, Proofs.empty).right.map { unsigned =>
       unsigned.copy(proofs = Proofs.create(Seq(ByteStr(crypto.sign(sender, unsigned.bodyBytes())))).explicitGet())
     }
   }
 }
-
-
-

--- a/src/main/scala/scorex/transaction/assets/VersionedTransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/VersionedTransferTransaction.scala
@@ -13,7 +13,7 @@ import scorex.transaction._
 
 import scala.util.{Failure, Success, Try}
 
-case class VersionedTransferTransaction private (override val version: Byte,
+case class VersionedTransferTransaction private (version: Byte,
                                                  sender: PublicKeyAccount,
                                                  recipient: AddressOrAlias,
                                                  assetId: Option[AssetId],

--- a/src/main/scala/scorex/transaction/assets/VersionedTransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/VersionedTransferTransaction.scala
@@ -35,7 +35,7 @@ case class VersionedTransferTransaction private (version: Byte,
     val feeBytes       = Longs.toByteArray(fee)
 
     Bytes.concat(
-      Array(0, builder.typeId, version),
+      Array(builder.typeId, version),
       sender.publicKey,
       assetIdBytes,
       timestampBytes,
@@ -55,7 +55,7 @@ case class VersionedTransferTransaction private (version: Byte,
       "attachment" -> Base58.encode(attachment)
     ))
 
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 
 }
 

--- a/src/main/scala/scorex/transaction/assets/exchange/ExchangeTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/exchange/ExchangeTransaction.scala
@@ -52,10 +52,9 @@ case class ExchangeTransaction private (buyOrder: Order,
   override val signedDescendants: Coeval[Seq[Order]] = Coeval.evalOnce(Seq(buyOrder, sellOrder))
 }
 
-object ExchangeTransaction extends TransactionParserFor[ExchangeTransaction] with TransactionParser.HardcodedVersion {
+object ExchangeTransaction extends TransactionParserFor[ExchangeTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 7
-  override val version: Byte = 1
+  override val typeId: Byte = 7
 
   def create(matcher: PrivateKeyAccount,
              buyOrder: Order,

--- a/src/main/scala/scorex/transaction/assets/exchange/ExchangeTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/exchange/ExchangeTransaction.scala
@@ -25,8 +25,6 @@ case class ExchangeTransaction private (buyOrder: Order,
     with FastHashId {
 
   override val builder: ExchangeTransaction.type = ExchangeTransaction
-  override def version: Byte                     = builder.version
-
   override val assetFee: (Option[AssetId], Long) = (None, fee)
 
   @ApiModelProperty(hidden = true)

--- a/src/main/scala/scorex/transaction/assets/exchange/Order.scala
+++ b/src/main/scala/scorex/transaction/assets/exchange/Order.scala
@@ -9,7 +9,7 @@ import play.api.libs.json.{JsObject, Json}
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
 import scorex.crypto.encode.Base58
 import scorex.serialization.{BytesSerializable, Deser, JsonSerializable}
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction._
 import scorex.transaction.assets.exchange.Validation.booleanOperators

--- a/src/main/scala/scorex/transaction/lease/LeaseCancelTransaction.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseCancelTransaction.scala
@@ -32,10 +32,9 @@ case class LeaseCancelTransaction private (sender: PublicKeyAccount, leaseId: By
 
 }
 
-object LeaseCancelTransaction extends TransactionParserFor[LeaseCancelTransaction] with TransactionParser.HardcodedVersion {
+object LeaseCancelTransaction extends TransactionParserFor[LeaseCancelTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 9
-  override val version: Byte = 1
+  override val typeId: Byte = 9
 
   override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {

--- a/src/main/scala/scorex/transaction/lease/LeaseCancelTransaction.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseCancelTransaction.scala
@@ -6,55 +6,51 @@ import com.wavesplatform.state2.ByteStr
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
-import scorex.transaction.TransactionParser.{KeyLength, _}
+import scorex.transaction.TransactionParsers._
 import scorex.transaction._
 
 import scala.util.{Failure, Success, Try}
 
-case class LeaseCancelTransaction private(sender: PublicKeyAccount,
-                                          leaseId: ByteStr,
-                                          fee: Long,
-                                          timestamp: Long,
-                                          signature: ByteStr)
-  extends SignedTransaction with FastHashId {
+case class LeaseCancelTransaction private (sender: PublicKeyAccount, leaseId: ByteStr, fee: Long, timestamp: Long, signature: ByteStr)
+    extends SignedTransaction
+    with FastHashId {
 
-  override val transactionType: TransactionType.Value = TransactionType.LeaseCancelTransaction
+  override val builder: TransactionParser = LeaseCancelTransaction
+  override def version: Byte               = builder.supportedVersions.head
 
-  val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(transactionType.id.toByte),
-    sender.publicKey,
-    Longs.toByteArray(fee),
-    Longs.toByteArray(timestamp),
-    leaseId.arr))
+  val bodyBytes: Coeval[Array[Byte]] =
+    Coeval.evalOnce(Bytes.concat(Array(builder.typeId), sender.publicKey, Longs.toByteArray(fee), Longs.toByteArray(timestamp), leaseId.arr))
 
-  override val json: Coeval[JsObject] = Coeval.evalOnce(jsonBase() ++ Json.obj(
-    "fee" -> fee,
-    "timestamp" -> timestamp,
-    "leaseId" -> leaseId.base58
-  ))
+  override val json: Coeval[JsObject] = Coeval.evalOnce(
+    jsonBase() ++ Json.obj(
+      "fee"       -> fee,
+      "timestamp" -> timestamp,
+      "leaseId"   -> leaseId.base58
+    ))
 
   override val assetFee: (Option[AssetId], Long) = (None, fee)
-  override val bytes = Coeval.evalOnce(Bytes.concat(bodyBytes(), signature.arr))
+  override val bytes                             = Coeval.evalOnce(Bytes.concat(bodyBytes(), signature.arr))
 
 }
 
-object LeaseCancelTransaction {
+object LeaseCancelTransaction extends TransactionParserFor[LeaseCancelTransaction] with TransactionParser.HardcodedVersion {
 
-  def parseTail(bytes: Array[Byte]): Try[LeaseCancelTransaction] = Try {
-    val sender = PublicKeyAccount(bytes.slice(0, KeyLength))
-    val fee = Longs.fromByteArray(bytes.slice(KeyLength, KeyLength + 8))
-    val timestamp = Longs.fromByteArray(bytes.slice(KeyLength + 8, KeyLength + 16))
-    val leaseId = ByteStr(bytes.slice(KeyLength + 16, KeyLength + 16 + crypto.DigestSize))
-    val signature = ByteStr(bytes.slice(KeyLength + 16 + crypto.DigestSize, KeyLength + 16 + crypto.DigestSize + SignatureLength))
-    LeaseCancelTransaction
-      .create(sender, leaseId, fee, timestamp, signature)
-      .fold(left => Failure(new Exception(left.toString)), right => Success(right))
-  }.flatten
+  override val typeId: Byte  = 9
+  override val version: Byte = 1
 
-  def create(sender: PublicKeyAccount,
-             leaseId: ByteStr,
-             fee: Long,
-             timestamp: Long,
-             signature: ByteStr): Either[ValidationError, LeaseCancelTransaction] =
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
+    Try {
+      val sender    = PublicKeyAccount(bytes.slice(0, KeyLength))
+      val fee       = Longs.fromByteArray(bytes.slice(KeyLength, KeyLength + 8))
+      val timestamp = Longs.fromByteArray(bytes.slice(KeyLength + 8, KeyLength + 16))
+      val leaseId   = ByteStr(bytes.slice(KeyLength + 16, KeyLength + 16 + crypto.DigestSize))
+      val signature = ByteStr(bytes.slice(KeyLength + 16 + crypto.DigestSize, KeyLength + 16 + crypto.DigestSize + SignatureLength))
+      LeaseCancelTransaction
+        .create(sender, leaseId, fee, timestamp, signature)
+        .fold(left => Failure(new Exception(left.toString)), right => Success(right))
+    }.flatten
+
+  def create(sender: PublicKeyAccount, leaseId: ByteStr, fee: Long, timestamp: Long, signature: ByteStr): Either[ValidationError, TransactionT] =
     if (leaseId.arr.length != crypto.DigestSize) {
       Left(ValidationError.GenericError("Lease transaction id is invalid"))
     } else if (fee <= 0) {
@@ -63,10 +59,7 @@ object LeaseCancelTransaction {
       Right(LeaseCancelTransaction(sender, leaseId, fee, timestamp, signature))
     }
 
-  def create(sender: PrivateKeyAccount,
-             leaseId: ByteStr,
-             fee: Long,
-             timestamp: Long): Either[ValidationError, LeaseCancelTransaction] = {
+  def create(sender: PrivateKeyAccount, leaseId: ByteStr, fee: Long, timestamp: Long): Either[ValidationError, TransactionT] = {
     create(sender, leaseId, fee, timestamp, ByteStr.empty).right.map { unsigned =>
       unsigned.copy(signature = ByteStr(crypto.sign(sender, unsigned.bodyBytes())))
     }

--- a/src/main/scala/scorex/transaction/lease/LeaseCancelTransaction.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseCancelTransaction.scala
@@ -16,7 +16,6 @@ case class LeaseCancelTransaction private (sender: PublicKeyAccount, leaseId: By
     with FastHashId {
 
   override val builder: TransactionParser = LeaseCancelTransaction
-  override def version: Byte               = builder.supportedVersions.head
 
   val bodyBytes: Coeval[Array[Byte]] =
     Coeval.evalOnce(Bytes.concat(Array(builder.typeId), sender.publicKey, Longs.toByteArray(fee), Longs.toByteArray(timestamp), leaseId.arr))

--- a/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
@@ -43,10 +43,9 @@ case class LeaseTransaction private (sender: PublicKeyAccount,
 
 }
 
-object LeaseTransaction extends TransactionParserFor[LeaseTransaction] with TransactionParser.HardcodedVersion {
+object LeaseTransaction extends TransactionParserFor[LeaseTransaction] with TransactionParser.HardcodedVersion1 {
 
-  override val typeId: Byte  = 8
-  override val version: Byte = 1
+  override val typeId: Byte = 8
 
   object Status {
     val Active   = "active"

--- a/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
@@ -21,7 +21,6 @@ case class LeaseTransaction private (sender: PublicKeyAccount,
     with FastHashId {
 
   override val builder: TransactionParser = LeaseTransaction
-  override def version: Byte               = builder.supportedVersions.head
 
   val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
     Bytes.concat(Array(builder.typeId),

--- a/src/main/scala/scorex/transaction/smart/BlockchainContext.scala
+++ b/src/main/scala/scorex/transaction/smart/BlockchainContext.scala
@@ -60,7 +60,7 @@ object BlockchainContext {
       case _                     => Left("Transaction is not Proven, doesn't contain bodyBytes")
     }
 
-    override def transactionType: Int = tx.transactionType.id
+    override def transactionType: Int = tx.builder.typeId
 
     override def senderPk: Either[String, ByteVector] = tx match {
       case pt: Authorized => Right(ByteVector(pt.sender.publicKey))
@@ -104,6 +104,7 @@ object BlockchainContext {
       case _: SetScriptTransaction         => Left("Transaction doesn't contain amount")
       case _: MassTransferTransaction      => Left("Transaction doesn't contain amount")
       case _: LeaseCancelTransaction       => Left("Transaction doesn't contain amount")
+      // DATA?
     }
 
     override def feeAssetId: Option[ByteVector] =

--- a/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
+++ b/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
@@ -13,7 +13,7 @@ import scorex.transaction._
 
 import scala.util.{Failure, Success, Try}
 
-case class SetScriptTransaction private (override val version: Byte,
+case class SetScriptTransaction private (version: Byte,
                                          chainId: Byte,
                                          sender: PublicKeyAccount,
                                          script: Option[Script],

--- a/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
+++ b/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
@@ -27,7 +27,7 @@ case class SetScriptTransaction private (version: Byte,
 
   val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
     Bytes.concat(
-      Array(0, builder.typeId, version, chainId),
+      Array(builder.typeId, version, chainId),
       sender.publicKey,
       Deser.serializeOption(script)(s => Deser.serializeArray(s.bytes().arr)),
       Longs.toByteArray(fee),
@@ -40,7 +40,7 @@ case class SetScriptTransaction private (version: Byte,
     "script"  -> script.map(_.bytes()))
   )
 
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 }
 
 object SetScriptTransaction extends TransactionParserFor[SetScriptTransaction] with TransactionParser.MultipleVersions {

--- a/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
+++ b/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
@@ -7,47 +7,53 @@ import monix.eval.Coeval
 import play.api.libs.json.Json
 import scorex.account._
 import scorex.serialization.Deser
-import scorex.transaction.TransactionParser.{KeyLength, TransactionType}
+import scorex.transaction.TransactionParsers.KeyLength
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction._
 
 import scala.util.{Failure, Success, Try}
 
-case class SetScriptTransaction private(version: Byte,
-                                        chainId: Byte,
-                                        sender: PublicKeyAccount,
-                                        script: Option[Script],
-                                        fee: Long,
-                                        timestamp: Long,
-                                        proofs: Proofs) extends ProvenTransaction with FastHashId {
+case class SetScriptTransaction private (override val version: Byte,
+                                         chainId: Byte,
+                                         sender: PublicKeyAccount,
+                                         script: Option[Script],
+                                         fee: Long,
+                                         timestamp: Long,
+                                         proofs: Proofs)
+    extends ProvenTransaction
+    with FastHashId {
 
-  val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(version),
-    Array(chainId),
-    sender.publicKey,
-    Deser.serializeOption(script)(s => Deser.serializeArray(s.bytes().arr)),
-    Longs.toByteArray(fee),
-    Longs.toByteArray(timestamp)))
+  override val builder: TransactionParser = SetScriptTransaction
 
-  override val transactionType = TransactionType.SetScriptTransaction
+  val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
+    Bytes.concat(
+      Array(0, builder.typeId, version, chainId),
+      sender.publicKey,
+      Deser.serializeOption(script)(s => Deser.serializeArray(s.bytes().arr)),
+      Longs.toByteArray(fee),
+      Longs.toByteArray(timestamp)
+    ))
 
   override val assetFee = (None, fee)
-  override val json = Coeval.evalOnce(jsonBase() ++ Json.obj(
+  override val json     = Coeval.evalOnce(jsonBase() ++ Json.obj(
     "version" -> version,
-    "script" -> script.map(_.bytes()))
+    "script"  -> script.map(_.bytes()))
   )
 
-  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(transactionType.id.toByte), bodyBytes(), proofs.bytes()))
+  override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(bodyBytes(), proofs.bytes()))
 }
 
-object SetScriptTransaction {
+object SetScriptTransaction extends TransactionParserFor[SetScriptTransaction] with TransactionParser.MultipleVersions {
+
+  override val typeId: Byte                 = 13
+  override val supportedVersions: Set[Byte] = Set(1)
 
   private val networkByte = AddressScheme.current.chainId
 
-  def parseTail(bytes: Array[Byte]): Try[SetScriptTransaction] = Try {
-    val version = bytes(0)
-    val chainId = bytes(1)
-    val sender = PublicKeyAccount(bytes.slice(2, KeyLength + 2))
-    val (scriptOptEi: Option[Either[ValidationError.ScriptParseError, Script]], scriptEnd) = Deser.parseOption(bytes, KeyLength + 2)(str => Script.fromBytes(Deser.parseArraySize(str, 0)._1))
+  override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] = Try {
+    val chainId = bytes(0)
+    val sender = PublicKeyAccount(bytes.slice(1, KeyLength + 1))
+    val (scriptOptEi: Option[Either[ValidationError.ScriptParseError, Script]], scriptEnd) = Deser.parseOption(bytes, KeyLength + 1)(str => Script.fromBytes(Deser.parseArraySize(str, 0)._1))
     val scriptEiOpt = scriptOptEi match {
       case None => Right(None)
       case Some(Right(sc)) => Right(Some(sc))
@@ -58,29 +64,25 @@ object SetScriptTransaction {
     val timestamp = Longs.fromByteArray(bytes.slice(scriptEnd + 8, scriptEnd + 16))
     (for {
       scriptOpt <- scriptEiOpt
-      _ <- Either.cond(version == 1, (), GenericError(s"Unsupported SetScriptTransaction version ${version.toInt}"))
       _ <- Either.cond(chainId == networkByte, (), GenericError(s"Wrong chainId ${chainId.toInt}"))
       proofs <- Proofs.fromBytes(bytes.drop(scriptEnd + 16))
-      tx <- create(sender, scriptOpt, fee, timestamp, proofs)
+      tx <- create(version, sender, scriptOpt, fee, timestamp, proofs)
     } yield tx).fold(left => Failure(new Exception(left.toString)), right => Success(right))
   }.flatten
 
-  def create(sender: PublicKeyAccount,
+  def create(version: Byte,
+             sender: PublicKeyAccount,
              script: Option[Script],
              fee: Long,
              timestamp: Long,
-             proofs: Proofs): Either[ValidationError, SetScriptTransaction] =
-    if (fee <= 0) {
-      Left(ValidationError.InsufficientFee)
-    } else {
-      Right(new SetScriptTransaction(1, networkByte, sender, script, fee, timestamp, proofs))
+             proofs: Proofs): Either[ValidationError, TransactionT] =
+    for {
+      _ <- Either.cond(supportedVersions.contains(version), (), ValidationError.UnsupportedVersion(version))
+      _ <- Either.cond(fee > 0, (), ValidationError.InsufficientFee)
+    } yield new SetScriptTransaction(version, networkByte, sender, script, fee, timestamp, proofs)
+
+  def selfSigned(version: Byte, sender: PrivateKeyAccount, script: Option[Script], fee: Long, timestamp: Long): Either[ValidationError, TransactionT] =
+    create(version, sender, script, fee, timestamp, Proofs.empty).right.map { unsigned =>
+      unsigned.copy(proofs = Proofs.create(Seq(ByteStr(crypto.sign(sender, unsigned.bodyBytes())))).explicitGet())
     }
-
-
-  def selfSigned(sender: PrivateKeyAccount,
-                 script: Option[Script],
-                 fee: Long,
-                 timestamp: Long): Either[ValidationError, SetScriptTransaction] = create(sender, script, fee, timestamp, Proofs.empty).right.map { unsigned =>
-    unsigned.copy(proofs = Proofs.create(Seq(ByteStr(crypto.sign(sender, unsigned.bodyBytes())))).explicitGet())
-  }
 }

--- a/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
+++ b/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
@@ -48,7 +48,7 @@ object SetScriptTransaction extends TransactionParserFor[SetScriptTransaction] w
   override val typeId: Byte                 = 13
   override val supportedVersions: Set[Byte] = Set(1)
 
-  private val networkByte = AddressScheme.current.chainId
+  private def networkByte = AddressScheme.current.chainId
 
   override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {

--- a/src/test/scala/com/wavesplatform/RequestGen.scala
+++ b/src/test/scala/com/wavesplatform/RequestGen.scala
@@ -8,7 +8,7 @@ import scorex.api.http.alias.SignedCreateAliasRequest
 import scorex.api.http.assets._
 import scorex.api.http.leasing.{SignedLeaseCancelRequest, SignedLeaseRequest}
 import scorex.crypto.encode.Base58
-import scorex.transaction.TransactionParser
+import scorex.transaction.TransactionParsers
 import scorex.transaction.assets.{IssueTransaction, TransferTransaction}
 
 trait RequestGen extends TransactionGen { _: Suite =>
@@ -39,7 +39,7 @@ trait RequestGen extends TransactionGen { _: Suite =>
       .map(Base58.encode)
 
   val addressGen: G[String] = listOfN(32, Arbitrary.arbByte.arbitrary).map(b => Base58.encode(b.toArray))
-  val signatureGen: G[String] = listOfN(TransactionParser.SignatureLength, Arbitrary.arbByte.arbitrary)
+  val signatureGen: G[String] = listOfN(TransactionParsers.SignatureLength, Arbitrary.arbByte.arbitrary)
     .map(b => Base58.encode(b.toArray))
   private val assetIdStringGen = assetIdGen.map(_.map(_.base58))
 

--- a/src/test/scala/com/wavesplatform/RxScheduler.scala
+++ b/src/test/scala/com/wavesplatform/RxScheduler.scala
@@ -8,7 +8,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 import scorex.account.PrivateKeyAccount
 import scorex.block.{Block, MicroBlock, SignerData}
 import scorex.lagonaki.mocks.TestBlock
-import scorex.transaction.TransactionParser
+import scorex.transaction.TransactionParsers
 import scorex.transaction.assets.TransferTransaction
 
 import scala.concurrent.duration._
@@ -28,7 +28,7 @@ trait RxScheduler extends BeforeAndAfterAll { _: Suite =>
     ack
   })
 
-  def byteStr(id: Int): ByteStr = ByteStr(Array.concat(Array.fill(TransactionParser.SignatureLength - 1)(0), Array(id.toByte)))
+  def byteStr(id: Int): ByteStr = ByteStr(Array.concat(Array.fill(TransactionParsers.SignatureLength - 1)(0), Array(id.toByte)))
 
   val signer: PrivateKeyAccount = TestBlock.defaultSigner
 

--- a/src/test/scala/com/wavesplatform/TransactionGen.scala
+++ b/src/test/scala/com/wavesplatform/TransactionGen.scala
@@ -106,18 +106,20 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
   }
 
   val setScriptTransactionGen: Gen[SetScriptTransaction] = for {
+    version                   <- Gen.oneOf(SetScriptTransaction.supportedVersions.toSeq)
     sender: PrivateKeyAccount <- accountGen
     fee                       <- smallFeeGen
     timestamp                 <- timestampGen
     proofs                    <- proofsGen
     script                    <- Gen.option(scriptGen)
-  } yield SetScriptTransaction.create(sender, script, fee, timestamp, proofs).explicitGet()
+  } yield SetScriptTransaction.create(version, sender, script, fee, timestamp, proofs).explicitGet()
 
   def selfSignedSetScriptTransactionGenP(sender: PrivateKeyAccount, s: Script): Gen[SetScriptTransaction] =
     for {
+      version   <- Gen.oneOf(SetScriptTransaction.supportedVersions.toSeq)
       fee       <- smallFeeGen
       timestamp <- timestampGen
-    } yield SetScriptTransaction.selfSigned(sender, Some(s), fee, timestamp).explicitGet()
+    } yield SetScriptTransaction.selfSigned(version, sender, Some(s), fee, timestamp).explicitGet()
 
   val paymentGen: Gen[PaymentTransaction] = for {
     sender: PrivateKeyAccount    <- accountGen
@@ -216,8 +218,9 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
 
   def massTransferGeneratorP(sender: PrivateKeyAccount, transfers: List[ParsedTransfer], assetId: Option[AssetId]): Gen[MassTransferTransaction] =
     for {
+      version                                           <- Gen.oneOf(MassTransferTransaction.supportedVersions.toSeq)
       (_, _, _, _, timestamp, _, feeAmount, attachment) <- transferParamGen
-    } yield MassTransferTransaction.selfSigned(Proofs.Version, assetId, sender, transfers, timestamp, feeAmount, attachment).right.get
+    } yield MassTransferTransaction.selfSigned(version, assetId, sender, transfers, timestamp, feeAmount, attachment).right.get
 
   def createWavesTransfer(sender: PrivateKeyAccount,
                           recipient: Address,
@@ -232,17 +235,19 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
     .label("transferTransaction")
 
   val versionedTransferGen = (for {
+    version                                                                   <- Gen.oneOf(VersionedTransferTransaction.supportedVersions.toSeq)
     (assetId, sender, recipient, amount, timestamp, _, feeAmount, attachment) <- transferParamGen
     proofs                                                                    <- proofsGen
-  } yield VersionedTransferTransaction.create(2, assetId, sender, recipient, amount, timestamp, feeAmount, attachment, proofs).explicitGet())
+  } yield VersionedTransferTransaction.create(version, assetId, sender, recipient, amount, timestamp, feeAmount, attachment, proofs).explicitGet())
     .label("VersionedTransferTransaction")
 
   def versionedTransferGenP(sender: PublicKeyAccount, recipient: Address, proofs: Proofs) =
     (for {
+      version   <- Gen.oneOf(VersionedTransferTransaction.supportedVersions.toSeq)
       amt       <- positiveLongGen
       fee       <- smallFeeGen
       timestamp <- timestampGen
-    } yield VersionedTransferTransaction.create(2, None, sender, recipient, amt, timestamp, fee, Array.emptyByteArray, proofs).explicitGet())
+    } yield VersionedTransferTransaction.create(version, None, sender, recipient, amt, timestamp, fee, Array.emptyByteArray, proofs).explicitGet())
       .label("VersionedTransferTransactionP")
 
   val transferWithWavesFeeGen = for {
@@ -260,6 +265,7 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
   val massTransferGen = {
     import MassTransferTransaction.MaxTransferCount
     for {
+      version                                                      <- Gen.oneOf(MassTransferTransaction.supportedVersions.toSeq)
       (assetId, sender, _, _, timestamp, _, feeAmount, attachment) <- transferParamGen
       transferCount                                                <- Gen.choose(0, MaxTransferCount)
       transferGen = for {
@@ -268,7 +274,7 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
       } yield ParsedTransfer(recipient, amount)
       recipients <- Gen.listOfN(transferCount, transferGen)
     } yield
-      MassTransferTransaction.selfSigned(MassTransferTransaction.Version, assetId, sender, recipients, timestamp, feeAmount, attachment).right.get
+      MassTransferTransaction.selfSigned(version, assetId, sender, recipients, timestamp, feeAmount, attachment).right.get
   }.label("massTransferTransaction")
 
   val MinIssueFee = 100000000
@@ -453,15 +459,17 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
       timestamp <- timestampGen
       size      <- Gen.choose(0, MaxEntryCount)
       data      <- Gen.listOfN(size, dataEntryGen)
+      version   <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
     } yield DataTransaction.selfSigned(DataTransaction.Version, sender, data, 15000000, timestamp).right.get)
       .label("DataTransaction")
   }
 
   def dataTransactionGenP(sender: PrivateKeyAccount, data: List[DataEntry[_]]): Gen[DataTransaction] =
     (for {
+      version   <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
       timestamp <- timestampGen
       size      <- Gen.choose(0, MaxEntryCount)
-    } yield DataTransaction.selfSigned(DataTransaction.Version, sender, data, 15000000, timestamp).right.get)
+    } yield DataTransaction.selfSigned(version, sender, data, 15000000, timestamp).right.get)
       .label("DataTransactionP")
 
   def preconditionsTransferAndLease(typed: Typed.EXPR): Gen[(GenesisTransaction, SetScriptTransaction, LeaseTransaction, TransferTransaction)] =
@@ -478,13 +486,12 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
   def smartIssueTransactionGen(senderGen: Gen[PrivateKeyAccount] = accountGen,
                                sGen: Gen[Option[Script]] = Gen.option(scriptGen)): Gen[SmartIssueTransaction] =
     for {
-
+      version                                                                     <- Gen.oneOf(SmartIssueTransaction.supportedVersions.toSeq)
       script                                                                      <- sGen
       (_, assetName, description, quantity, decimals, reissuable, fee, timestamp) <- issueParamGen
       sender                                                                      <- senderGen
-
     } yield
       SmartIssueTransaction
-        .selfSigned(1, AddressScheme.current.chainId, sender, assetName, description, quantity, decimals, reissuable, script, fee, timestamp)
+        .selfSigned(version, AddressScheme.current.chainId, sender, assetName, description, quantity, decimals, reissuable, script, fee, timestamp)
         .explicitGet()
 }

--- a/src/test/scala/com/wavesplatform/TransactionGen.scala
+++ b/src/test/scala/com/wavesplatform/TransactionGen.scala
@@ -460,7 +460,7 @@ trait TransactionGen extends BeforeAndAfterAll with ScriptGen {
       size      <- Gen.choose(0, MaxEntryCount)
       data      <- Gen.listOfN(size, dataEntryGen)
       version   <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
-    } yield DataTransaction.selfSigned(DataTransaction.Version, sender, data, 15000000, timestamp).right.get)
+    } yield DataTransaction.selfSigned(version, sender, data, 15000000, timestamp).right.get)
       .label("DataTransaction")
   }
 

--- a/src/test/scala/com/wavesplatform/history/BlockchainUpdaterMicroblockBadSignaturesTest.scala
+++ b/src/test/scala/com/wavesplatform/history/BlockchainUpdaterMicroblockBadSignaturesTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.prop.PropertyChecks
 import scorex.account.PrivateKeyAccount
 import scorex.lagonaki.mocks.TestBlock
 import scorex.transaction.assets.TransferTransaction
-import scorex.transaction.{GenesisTransaction, TransactionParser}
+import scorex.transaction.{GenesisTransaction, TransactionParsers}
 
 class BlockchainUpdaterMicroblockBadSignaturesTest extends PropSpec with PropertyChecks
   with DomainScenarioDrivenPropertyCheck with Matchers with TransactionGen {
@@ -47,7 +47,7 @@ class BlockchainUpdaterMicroblockBadSignaturesTest extends PropSpec with Propert
 
   property("other sender") {
     scenario(preconditionsAndPayments) { case (domain, (genesis, payment, payment2)) =>
-      val otherSigner = PrivateKeyAccount(TestBlock.randomOfLength(TransactionParser.KeyLength).arr)
+      val otherSigner = PrivateKeyAccount(TestBlock.randomOfLength(TransactionParsers.KeyLength).arr)
       val block0 = buildBlockOfTxs(randomSig, Seq(genesis))
       val block1 = buildBlockOfTxs(block0.uniqueId, Seq(payment))
       val badSigMicro = buildMicroBlockOfTxs(block0.uniqueId, block1, Seq(payment2), otherSigner)._2

--- a/src/test/scala/com/wavesplatform/history/BlockchainUpdaterMicroblockSunnyDayTest.scala
+++ b/src/test/scala/com/wavesplatform/history/BlockchainUpdaterMicroblockSunnyDayTest.scala
@@ -118,7 +118,7 @@ class BlockchainUpdaterMicroblockSunnyDayTest extends PropSpec
     scenario(preconditionsAndPayments, MicroblocksActivatedAt0WavesSettings) { case (domain, (genesis, masterToAlice, aliceToBob, aliceToBob2)) =>
       val block0 = buildBlockOfTxs(randomSig, Seq(genesis))
       val (block1, microBlocks1) = chainBaseAndMicro(block0.uniqueId, masterToAlice, Seq(Seq(aliceToBob)))
-      val otherSigner = PrivateKeyAccount(Array.fill(TransactionParser.KeyLength)(1))
+      val otherSigner = PrivateKeyAccount(Array.fill(TransactionParsers.KeyLength)(1))
       val block2 = customBuildBlockOfTxs(block0.uniqueId, Seq(masterToAlice, aliceToBob2), otherSigner, 1, 0L, DefaultBaseTarget / 2)
       domain.blockchainUpdater.processBlock(block0).explicitGet()
       domain.blockchainUpdater.processBlock(block1).explicitGet()

--- a/src/test/scala/com/wavesplatform/history/package.scala
+++ b/src/test/scala/com/wavesplatform/history/package.scala
@@ -9,7 +9,7 @@ import scorex.block.{Block, MicroBlock}
 import scorex.consensus.nxt.NxtLikeConsensusBlockData
 import scorex.lagonaki.mocks.TestBlock
 import scorex.settings.TestFunctionalitySettings
-import scorex.transaction.{Transaction, TransactionParser}
+import scorex.transaction.{Transaction, TransactionParsers}
 
 package object history {
   val MaxTransactionsPerBlockDiff = 10
@@ -33,7 +33,7 @@ package object history {
 
   val DefaultWavesSettings: WavesSettings = settings.copy(blockchainSettings = DefaultBlockchainSettings)
 
-  val defaultSigner = PrivateKeyAccount(Array.fill(TransactionParser.KeyLength)(0))
+  val defaultSigner = PrivateKeyAccount(Array.fill(TransactionParsers.KeyLength)(0))
   val generationSignature = ByteStr(Array.fill(Block.GeneratorSignatureLength)(0: Byte))
 
   def buildBlockOfTxs(refTo: ByteStr, txs: Seq[Transaction]): Block = customBuildBlockOfTxs(refTo, txs, defaultSigner, 1, 0L)

--- a/src/test/scala/com/wavesplatform/http/AssetsBroadcastRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AssetsBroadcastRouteSpec.scala
@@ -1,11 +1,13 @@
 package com.wavesplatform.http
 
+import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.RequestGen
 import com.wavesplatform.http.ApiMarshallers._
 import com.wavesplatform.settings.RestAPISettings
+import com.wavesplatform.state2.Diff
 import com.wavesplatform.state2.diffs.TransactionDiffer.TransactionValidationError
-import com.wavesplatform.utx.UtxPool
+import com.wavesplatform.utx.{UtxBatchOps, UtxPool}
 import io.netty.channel.group.ChannelGroup
 import org.scalacheck.Gen._
 import org.scalacheck.{Gen => G}
@@ -13,14 +15,17 @@ import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.{JsObject, JsValue, Json, Writes}
 import scorex.api.http._
-import scorex.api.http.assets.AssetsBroadcastApiRoute
+import scorex.api.http.assets._
+import scorex.crypto.encode.Base58
 import scorex.transaction.ValidationError.GenericError
-import scorex.transaction.Transaction
-
+import scorex.transaction.assets.{TransferTransaction, VersionedTransferTransaction}
+import scorex.transaction.{Proofs, Transaction, ValidationError}
+import scorex.wallet.Wallet
+import shapeless.Coproduct
 
 class AssetsBroadcastRouteSpec extends RouteSpec("/assets/broadcast/") with RequestGen with PathMockFactory with PropertyChecks {
-  private val settings = RestAPISettings.fromConfig(ConfigFactory.load())
-  private val utx = stub[UtxPool]
+  private val settings    = RestAPISettings.fromConfig(ConfigFactory.load())
+  private val utx         = stub[UtxPool]
   private val allChannels = stub[ChannelGroup]
 
   (utx.putIfNew _).when(*).onCall((t: Transaction) => Left(TransactionValidationError(GenericError("foo"), t))).anyNumberOfTimes()
@@ -35,7 +40,7 @@ class AssetsBroadcastRouteSpec extends RouteSpec("/assets/broadcast/") with Requ
       ("reissue", reissueGen, identity),
       ("burn", burnGen, {
         case o: JsObject => o ++ Json.obj("quantity" -> o.value("amount"))
-        case other => other
+        case other       => other
       }),
       ("transfer", transferGen, {
         case o: JsObject if o.value.contains("feeAsset") =>
@@ -61,42 +66,198 @@ class AssetsBroadcastRouteSpec extends RouteSpec("/assets/broadcast/") with Requ
     "issue transaction" in forAll(broadcastIssueReq) { ir =>
       def posting[A: Writes](v: A): RouteTestResult = Post(routePath("issue"), v) ~> route
 
-      forAll(nonPositiveLong) { q => posting(ir.copy(fee = q)) should produce(InsufficientFee) }
-      forAll(nonPositiveLong) { q => posting(ir.copy(quantity = q)) should produce(NegativeAmount(s"$q of assets")) }
-      forAll(invalidDecimals) { d => posting(ir.copy(decimals = d)) should produce(TooBigArrayAllocation) }
-      forAll(longDescription) { d => posting(ir.copy(description = d)) should produce(TooBigArrayAllocation) }
-      forAll(invalidName) { name => posting(ir.copy(name = name)) should produce(InvalidName) }
-      forAll(invalidBase58) { name => posting(ir.copy(name = name)) should produce(InvalidName) }
-      forAll(nonPositiveLong) { fee => posting(ir.copy(fee = fee)) should produce(InsufficientFee) }
+      forAll(nonPositiveLong) { q =>
+        posting(ir.copy(fee = q)) should produce(InsufficientFee)
+      }
+      forAll(nonPositiveLong) { q =>
+        posting(ir.copy(quantity = q)) should produce(NegativeAmount(s"$q of assets"))
+      }
+      forAll(invalidDecimals) { d =>
+        posting(ir.copy(decimals = d)) should produce(TooBigArrayAllocation)
+      }
+      forAll(longDescription) { d =>
+        posting(ir.copy(description = d)) should produce(TooBigArrayAllocation)
+      }
+      forAll(invalidName) { name =>
+        posting(ir.copy(name = name)) should produce(InvalidName)
+      }
+      forAll(invalidBase58) { name =>
+        posting(ir.copy(name = name)) should produce(InvalidName)
+      }
+      forAll(nonPositiveLong) { fee =>
+        posting(ir.copy(fee = fee)) should produce(InsufficientFee)
+      }
     }
 
     "reissue transaction" in forAll(broadcastReissueReq) { rr =>
       def posting[A: Writes](v: A): RouteTestResult = Post(routePath("reissue"), v) ~> route
 
       // todo: invalid sender
-      forAll(nonPositiveLong) { q => posting(rr.copy(quantity = q)) should produce(NegativeAmount(s"$q of assets")) }
-      forAll(nonPositiveLong) { fee => posting(rr.copy(fee = fee)) should produce(InsufficientFee) }
+      forAll(nonPositiveLong) { q =>
+        posting(rr.copy(quantity = q)) should produce(NegativeAmount(s"$q of assets"))
+      }
+      forAll(nonPositiveLong) { fee =>
+        posting(rr.copy(fee = fee)) should produce(InsufficientFee)
+      }
     }
 
     "burn transaction" in forAll(broadcastBurnReq) { br =>
       def posting[A: Writes](v: A): RouteTestResult = Post(routePath("burn"), v) ~> route
 
-      forAll(invalidBase58) { pk => posting(br.copy(senderPublicKey = pk)) should produce(InvalidAddress) }
-      forAll(nonPositiveLong) { q => posting(br.copy(quantity = q)) should produce(NegativeAmount(s"$q of assets")) }
-      forAll(nonPositiveLong) { fee => posting(br.copy(fee = fee)) should produce(InsufficientFee) }
+      forAll(invalidBase58) { pk =>
+        posting(br.copy(senderPublicKey = pk)) should produce(InvalidAddress)
+      }
+      forAll(nonPositiveLong) { q =>
+        posting(br.copy(quantity = q)) should produce(NegativeAmount(s"$q of assets"))
+      }
+      forAll(nonPositiveLong) { fee =>
+        posting(br.copy(fee = fee)) should produce(InsufficientFee)
+      }
     }
 
     "transfer transaction" in forAll(broadcastTransferReq) { tr =>
       def posting[A: Writes](v: A): RouteTestResult = Post(routePath("transfer"), v) ~> route
 
-      forAll(nonPositiveLong) { q => posting(tr.copy(amount = q)) should produce(NegativeAmount(s"$q of waves")) }
-      forAll(invalidBase58) { pk => posting(tr.copy(senderPublicKey = pk)) should produce(InvalidAddress) }
-      forAll(invalidBase58) { a => posting(tr.copy(recipient = a)) should produce(InvalidAddress) }
-      forAll(invalidBase58) { a => posting(tr.copy(assetId = Some(a))) should produce(CustomValidationError("invalid.assetId")) }
-      forAll(invalidBase58) { a => posting(tr.copy(feeAssetId = Some(a))) should produce(CustomValidationError("invalid.feeAssetId")) }
-      forAll(longAttachment) { a => posting(tr.copy(attachment = Some(a))) should produce(CustomValidationError("invalid.attachment")) }
-      forAll(posNum[Long]) { quantity => posting(tr.copy(amount = quantity, fee = Long.MaxValue)) should produce(OverflowError) }
-      forAll(nonPositiveLong) { fee => posting(tr.copy(fee = fee)) should produce(InsufficientFee) }
+      forAll(nonPositiveLong) { q =>
+        posting(tr.copy(amount = q)) should produce(NegativeAmount(s"$q of waves"))
+      }
+      forAll(invalidBase58) { pk =>
+        posting(tr.copy(senderPublicKey = pk)) should produce(InvalidAddress)
+      }
+      forAll(invalidBase58) { a =>
+        posting(tr.copy(recipient = a)) should produce(InvalidAddress)
+      }
+      forAll(invalidBase58) { a =>
+        posting(tr.copy(assetId = Some(a))) should produce(CustomValidationError("invalid.assetId"))
+      }
+      forAll(invalidBase58) { a =>
+        posting(tr.copy(feeAssetId = Some(a))) should produce(CustomValidationError("invalid.feeAssetId"))
+      }
+      forAll(longAttachment) { a =>
+        posting(tr.copy(attachment = Some(a))) should produce(CustomValidationError("invalid.attachment"))
+      }
+      forAll(posNum[Long]) { quantity =>
+        posting(tr.copy(amount = quantity, fee = Long.MaxValue)) should produce(OverflowError)
+      }
+      forAll(nonPositiveLong) { fee =>
+        posting(tr.copy(fee = fee)) should produce(InsufficientFee)
+      }
     }
   }
+
+  "/batch-transfer" - {
+    val alwaysApproveUtx = stub[UtxPool]
+    val utxOps = new UtxBatchOps {
+      override def putIfNew(tx: Transaction): Either[ValidationError, (Boolean, Diff)] = alwaysApproveUtx.putIfNew(tx)
+    }
+    (alwaysApproveUtx.batched[Any] _).when(*).onCall((f: UtxBatchOps => Any) => f(utxOps)).anyNumberOfTimes()
+    (alwaysApproveUtx.putIfNew _).when(*).onCall((_: Transaction) => Right((true, Diff.empty))).anyNumberOfTimes()
+
+    val alwaysSendAllChannels = stub[ChannelGroup]
+    (alwaysSendAllChannels.writeAndFlush(_: Any)).when(*).onCall((_: Any) => null).anyNumberOfTimes()
+
+    val route = AssetsBroadcastApiRoute(settings, alwaysApproveUtx, alwaysSendAllChannels).route
+
+    def posting[A: Writes](v: A): RouteTestResult = Post(routePath("batch-transfer"), v).addHeader(ApiKeyHeader) ~> route
+
+    val seed               = "seed".getBytes()
+    val senderPrivateKey   = Wallet.generateNewAccount(seed, 0)
+    val receiverPrivateKey = Wallet.generateNewAccount(seed, 1)
+
+    val transferRequest = createSignedTransferRequest(
+      TransferTransaction
+        .create(
+          assetId = None,
+          sender = senderPrivateKey,
+          recipient = receiverPrivateKey.toAddress,
+          amount = 1 * Waves,
+          timestamp = System.currentTimeMillis(),
+          feeAssetId = None,
+          feeAmount = Waves / 3,
+          attachment = Array.emptyByteArray
+        )
+        .right
+        .get
+    )
+
+    val versionedTransferRequest = createSignedVersionedTransferRequest(
+      VersionedTransferTransaction
+        .create(
+          assetId = None,
+          sender = senderPrivateKey,
+          recipient = receiverPrivateKey.toAddress,
+          amount = 1 * Waves,
+          timestamp = System.currentTimeMillis(),
+          feeAmount = Waves / 3,
+          attachment = Array.emptyByteArray,
+          version = 2,
+          proofs = Proofs(Seq.empty)
+        )
+        .right
+        .get)
+
+    "accepts TransferRequest" in posting(List(transferRequest)) ~> check {
+      status shouldBe StatusCodes.OK
+      val xs = responseAs[Seq[TransferTransactions]]
+      xs.size shouldBe 1
+      xs.head.select[TransferTransaction] shouldBe defined
+    }
+
+    "accepts VersionedTransferRequest" in posting(List(versionedTransferRequest)) ~> check {
+      status shouldBe StatusCodes.OK
+      val xs = responseAs[Seq[TransferTransactions]]
+      xs.size shouldBe 1
+      xs.head.select[VersionedTransferTransaction] shouldBe defined
+    }
+
+    "accepts both TransferRequest and VersionedTransferRequest" in {
+      val reqs = List(
+        Coproduct[SignedTransferRequests](transferRequest),
+        Coproduct[SignedTransferRequests](versionedTransferRequest)
+      )
+
+      posting(reqs) ~> check {
+        status shouldBe StatusCodes.OK
+        val xs = responseAs[Seq[TransferTransactions]]
+        xs.size shouldBe 2
+        xs.flatMap(_.select[TransferTransaction]) shouldNot be(empty)
+        xs.flatMap(_.select[VersionedTransferTransaction]) shouldNot be(empty)
+      }
+    }
+
+    "returns a error if it is not a transfer request" in posting(List(issueReq.sample.get)) ~> check {
+      status shouldNot be(StatusCodes.OK)
+    }
+  }
+
+  protected def createSignedTransferRequest(tx: TransferTransaction): SignedTransferRequest = {
+    import tx._
+    SignedTransferRequest(
+      Base58.encode(tx.sender.publicKey),
+      assetId.map(_.base58),
+      recipient.stringRepr,
+      amount,
+      fee,
+      feeAssetId.map(_.base58),
+      timestamp,
+      attachment.headOption.map(_ => Base58.encode(attachment)),
+      signature.base58
+    )
+  }
+
+  protected def createSignedVersionedTransferRequest(tx: VersionedTransferTransaction): SignedVersionedTransferRequest = {
+    import tx._
+    SignedVersionedTransferRequest(
+      Base58.encode(tx.sender.publicKey),
+      assetId.map(_.base58),
+      recipient.stringRepr,
+      amount,
+      fee,
+      timestamp,
+      version,
+      attachment.headOption.map(_ => Base58.encode(attachment)),
+      proofs.proofs.map(_.base58).toList
+    )
+  }
+
 }

--- a/src/test/scala/com/wavesplatform/http/AssetsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AssetsRouteSpec.scala
@@ -37,12 +37,12 @@ class AssetsRouteSpec extends RouteSpec("/assets") with RequestGen with PathMock
   (utx.putIfNew _).when(*).onCall((_: Transaction) => Right((true, Diff.empty))).anyNumberOfTimes()
   (allChannels.writeAndFlush(_: Any)).when(*).onCall((_: Any) => null).anyNumberOfTimes()
 
-  "/transfer accepts TransferRequest and VersionedTransferRequest" - {
+  "/transfer" - {
     val route = AssetsApiRoute(settings, wallet, utx, allChannels, state, new TestTime()).route
 
     def posting[A: Writes](v: A): RouteTestResult = Post(routePath("/transfer"), v).addHeader(apiKeyHeader) ~> route
 
-    "TransferRequest" in {
+    "accepts TransferRequest" in {
       val req = TransferRequest(
         assetId = None,
         feeAssetId = None,
@@ -62,7 +62,7 @@ class AssetsRouteSpec extends RouteSpec("/assets") with RequestGen with PathMock
       }
     }
 
-    "VersionedTransferRequest" in {
+    "accepts VersionedTransferRequest" in {
       val req = VersionedTransferRequest(
         version = 2,
         assetId = None,
@@ -79,6 +79,13 @@ class AssetsRouteSpec extends RouteSpec("/assets") with RequestGen with PathMock
         val r = responseAs[String]
         r should include(""""type" : 4""")
         r should include(""""version" : 2""")
+      }
+    }
+
+    "returns a error if it is not a transfer request" in {
+      val req = issueReq.sample.get
+      posting(req) ~> check {
+        status shouldNot be(StatusCodes.OK)
       }
     }
   }

--- a/src/test/scala/com/wavesplatform/http/AssetsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AssetsRouteSpec.scala
@@ -1,0 +1,86 @@
+package com.wavesplatform.http
+
+import akka.http.scaladsl.model.StatusCodes
+import com.typesafe.config.ConfigFactory
+import com.wavesplatform.http.ApiMarshallers._
+import com.wavesplatform.settings.RestAPISettings
+import com.wavesplatform.state2.Diff
+import com.wavesplatform.state2.reader.SnapshotStateReader
+import com.wavesplatform.utx.UtxPool
+import com.wavesplatform.{RequestGen, TestTime}
+import io.netty.channel.group.ChannelGroup
+import org.scalamock.scalatest.PathMockFactory
+import org.scalatest.concurrent.Eventually
+import play.api.libs.json.Writes
+import scorex.account.Address
+import scorex.api.http.assets.{AssetsApiRoute, TransferRequest, VersionedTransferRequest}
+import scorex.transaction.Transaction
+import scorex.wallet.Wallet
+
+class AssetsRouteSpec extends RouteSpec("/assets") with RequestGen with PathMockFactory with Eventually {
+
+  private val Waves: Long = 100000000L
+
+  private val settings    = RestAPISettings.fromConfig(ConfigFactory.load())
+  private val wallet      = stub[Wallet]
+  private val utx         = stub[UtxPool]
+  private val allChannels = stub[ChannelGroup]
+  private val state       = stub[SnapshotStateReader]
+
+  private val seed               = "seed".getBytes()
+  private val senderPrivateKey   = Wallet.generateNewAccount(seed, 0)
+  private val receiverPrivateKey = Wallet.generateNewAccount(seed, 1)
+
+  private val apiKeyHeader = api_key("ridethewaves!")
+
+  (wallet.privateKeyAccount _).when(senderPrivateKey.toAddress).onCall((_: Address) => Right(senderPrivateKey)).anyNumberOfTimes()
+  (utx.putIfNew _).when(*).onCall((_: Transaction) => Right((true, Diff.empty))).anyNumberOfTimes()
+  (allChannels.writeAndFlush(_: Any)).when(*).onCall((_: Any) => null).anyNumberOfTimes()
+
+  "/transfer accepts TransferRequest and VersionedTransferRequest" - {
+    val route = AssetsApiRoute(settings, wallet, utx, allChannels, state, new TestTime()).route
+
+    def posting[A: Writes](v: A): RouteTestResult = Post(routePath("/transfer"), v).addHeader(apiKeyHeader) ~> route
+
+    "TransferRequest" in {
+      val req = TransferRequest(
+        assetId = None,
+        feeAssetId = None,
+        amount = 1 * Waves,
+        fee = Waves / 3,
+        sender = senderPrivateKey.address,
+        attachment = None,
+        recipient = receiverPrivateKey.address,
+        timestamp = Some(System.currentTimeMillis())
+      )
+
+      posting(req) ~> check {
+        status shouldBe StatusCodes.OK
+        val r = responseAs[String]
+        r should include(""""type" : 4""")
+        r shouldNot include("version")
+      }
+    }
+
+    "VersionedTransferRequest" in {
+      val req = VersionedTransferRequest(
+        version = 2,
+        assetId = None,
+        amount = 1 * Waves,
+        fee = Waves / 3,
+        sender = senderPrivateKey.address,
+        attachment = None,
+        recipient = receiverPrivateKey.address,
+        timestamp = Some(System.currentTimeMillis())
+      )
+
+      posting(req) ~> check {
+        status shouldBe StatusCodes.OK
+        val r = responseAs[String]
+        r should include(""""type" : 4""")
+        r should include(""""version" : 2""")
+      }
+    }
+  }
+
+}

--- a/src/test/scala/com/wavesplatform/http/package.scala
+++ b/src/test/scala/com/wavesplatform/http/package.scala
@@ -1,11 +1,24 @@
 package com.wavesplatform
 
+import java.nio.charset.StandardCharsets
+
+import com.wavesplatform.state2.ByteStr
 import org.scalatest.matchers.{HavePropertyMatchResult, HavePropertyMatcher}
-import play.api.libs.json.{JsValue, Reads}
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import scorex.account.{AddressOrAlias, PublicKeyAccount}
+import scorex.crypto.encode.Base58
+import scorex.transaction.{AssetId, Proofs}
+import scorex.transaction.assets.{TransferTransaction, VersionedTransferTransaction}
+import shapeless.{:+:, CNil, Coproduct}
 
 import scala.reflect.ClassTag
+import scala.util.{Failure, Success}
 
 package object http {
+
+  val Waves: Long  = 100000000L
+  val ApiKeyHeader = api_key("ridethewaves!")
 
   def sameSignature(target: Array[Byte])(actual: Array[Byte]): Boolean = target sameElements actual
 
@@ -21,4 +34,98 @@ package object http {
       val actualFieldValue = (json \ v._1).as[JsValue]
       HavePropertyMatchResult(actualFieldValue == v._2, v._1, v._2, actualFieldValue)
     }
+
+  implicit val byteStrFormat: Format[ByteStr] = Format(
+    Reads {
+      case JsString(str) =>
+        ByteStr.decodeBase58(str) match {
+          case Success(x) => JsSuccess(x)
+          case Failure(e) => JsError(e.getMessage)
+        }
+
+      case _ => JsError("Can't read PublicKeyAccount")
+    },
+    Writes(x => JsString(x.base58))
+  )
+
+  implicit val publicKeyAccountFormat: Format[PublicKeyAccount] = byteStrFormat.inmap[PublicKeyAccount](
+    x => PublicKeyAccount(x.arr),
+    x => ByteStr(x.publicKey)
+  )
+
+  implicit val proofsFormat: Format[Proofs] = Format(
+    Reads {
+      case JsArray(xs) =>
+        xs.foldLeft[JsResult[Proofs]](JsSuccess(Proofs.empty)) {
+          case (r: JsError, _) => r
+          case (JsSuccess(r, _), JsString(rawProof)) =>
+            ByteStr.decodeBase58(rawProof) match {
+              case Failure(e) => JsError(e.toString)
+              case Success(x) => JsSuccess(Proofs(r.proofs :+ x))
+            }
+          case _ => JsError("Can't parse proofs")
+        }
+      case _ => JsError("Can't parse proofs")
+    },
+    Writes { proofs =>
+      JsArray(proofs.proofs.map(byteStrFormat.writes))
+    }
+  )
+
+  implicit val addressOrAliasFormat: Format[AddressOrAlias] = Format[AddressOrAlias](
+    Reads {
+      case JsString(str) =>
+        Base58
+          .decode(str)
+          .toEither
+          .flatMap(AddressOrAlias.fromBytes(_, 0))
+          .map { case (x, _) => JsSuccess(x) }
+          .getOrElse(JsError("Can't read PublicKeyAccount"))
+
+      case _ => JsError("Can't read PublicKeyAccount")
+    },
+    Writes(x => JsString(x.bytes.base58))
+  )
+
+  implicit val transferTransactionFormat: Format[TransferTransaction] = (
+    (JsPath \ "assetId").formatNullable[AssetId] and
+      (JsPath \ "sender").format[PublicKeyAccount] and
+      (JsPath \ "recipient").format[AddressOrAlias] and
+      (JsPath \ "amount").format[Long] and
+      (JsPath \ "timestamp").format[Long] and
+      (JsPath \ "feeAsset").formatNullable[AssetId] and
+      (JsPath \ "fee").format[Long] and
+      (JsPath \ "attachment")
+        .format[String]
+        .inmap[Array[Byte]](
+          _.getBytes(StandardCharsets.UTF_8),
+          xs => new String(xs, StandardCharsets.UTF_8)
+        ) and
+      (JsPath \ "signature").format[ByteStr]
+  )(TransferTransaction.apply, unlift(TransferTransaction.unapply))
+
+  implicit val versionedTransferTransactionFormat: Format[VersionedTransferTransaction] = (
+    (JsPath \ "version").format[Byte] and
+      (JsPath \ "sender").format[PublicKeyAccount] and
+      (JsPath \ "recipient").format[AddressOrAlias] and
+      (JsPath \ "assetId").formatNullable[AssetId] and
+      (JsPath \ "amount").format[Long] and
+      (JsPath \ "timestamp").format[Long] and
+      (JsPath \ "fee").format[Long] and
+      (JsPath \ "attachment")
+        .format[String]
+        .inmap[Array[Byte]](
+          _.getBytes(StandardCharsets.UTF_8),
+          xs => new String(xs, StandardCharsets.UTF_8)
+        ) and
+      (JsPath \ "proofs").format[Proofs]
+  )(VersionedTransferTransaction.apply, unlift(VersionedTransferTransaction.unapply))
+
+  type TransferTransactions = TransferTransaction :+: VersionedTransferTransaction :+: CNil
+  implicit val autoTransferTransactionsReads: Reads[TransferTransactions] = Reads { json =>
+    (json \ "version").asOpt[Byte] match {
+      case None => transferTransactionFormat.reads(json).map(Coproduct[TransferTransactions](_))
+      case _    => versionedTransferTransactionFormat.reads(json).map(Coproduct[TransferTransactions](_))
+    }
+  }
 }

--- a/src/test/scala/com/wavesplatform/network/MessageCodecSpec.scala
+++ b/src/test/scala/com/wavesplatform/network/MessageCodecSpec.scala
@@ -31,7 +31,7 @@ class MessageCodecSpec extends FreeSpec
     val codec = new SpiedMessageCodec
     val ch = new EmbeddedChannel(codec)
 
-    ch.writeInbound(RawBytes(TransactionSpec.messageCode, origTx.bytes()))
+    ch.writeInbound(RawBytes.from(origTx))
     val decodedTx = ch.readInbound[Transaction]()
 
     decodedTx shouldBe origTx

--- a/src/test/scala/com/wavesplatform/network/MicroBlockInvSpecSpec.scala
+++ b/src/test/scala/com/wavesplatform/network/MicroBlockInvSpecSpec.scala
@@ -6,7 +6,7 @@ import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
-import scorex.transaction.TransactionParser
+import scorex.transaction.TransactionParsers
 
 class MicroBlockInvSpecSpec extends FreeSpec
   with Matchers
@@ -16,8 +16,8 @@ class MicroBlockInvSpecSpec extends FreeSpec
 
   private val microBlockInvGen: Gen[MicroBlockInv] = for {
     acc <- accountGen
-    totalSig <- byteArrayGen(TransactionParser.SignatureLength)
-    prevBlockSig <- byteArrayGen(TransactionParser.SignatureLength)
+    totalSig <- byteArrayGen(TransactionParsers.SignatureLength)
+    prevBlockSig <- byteArrayGen(TransactionParsers.SignatureLength)
   } yield MicroBlockInv(acc, ByteStr(totalSig), ByteStr(prevBlockSig))
 
   "MicroBlockInvMessageSpec" - {

--- a/src/test/scala/com/wavesplatform/settings/FeesSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/FeesSettingsSpecification.scala
@@ -149,13 +149,10 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
         |  set-script {
         |    WAVES = 300000
         |  }
-        |  versioned-transfer {
-        |    WAVES = 400000
-        |  }
         |}
       """.stripMargin).withFallback(defaultConfig).resolve()
     val settings = FeesSettings.fromConfig(config)
-    settings.fees.size should be(12)
+    settings.fees.size should be(11)
     settings.fees(3).toSet should equal(Set(FeeSettings("WAVES", 200000000)))
     settings.fees(4).toSet should equal(Set(FeeSettings("WAVES", 300000), FeeSettings("6MPKrD5B7GrfbciHECg1MwdvRUhRETApgNZspreBJ8JL", 1)))
     settings.fees(5).toSet should equal(Set(FeeSettings("WAVES", 400000)))
@@ -167,6 +164,5 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
     settings.fees(11).toSet should equal(Set(FeeSettings("WAVES", 10000)))
     settings.fees(12).toSet should equal(Set(FeeSettings("WAVES", 200000)))
     settings.fees(13).toSet should equal(Set(FeeSettings("WAVES", 300000)))
-    settings.fees(14).toSet should equal(Set(FeeSettings("WAVES", 400000)))
   }
 }

--- a/src/test/scala/com/wavesplatform/state2/HistoryTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/HistoryTest.scala
@@ -3,7 +3,7 @@ package com.wavesplatform.state2
 import scorex.block.Block
 import scorex.lagonaki.mocks.TestBlock
 import scorex.transaction.History
-import scorex.transaction.TransactionParser.SignatureLength
+import scorex.transaction.TransactionParsers.SignatureLength
 
 trait HistoryTest {
   val genesisBlock: Block = TestBlock.withReference(ByteStr(Array.fill(SignatureLength)(0: Byte)))

--- a/src/test/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiffTest.scala
@@ -105,6 +105,7 @@ class AssetTransactionsDiffTest extends PropSpec with PropertyChecks with Matche
 
   def genesisIssueTransferReissue(code: String): Gen[(Seq[GenesisTransaction], SmartIssueTransaction, TransferTransaction, ReissueTransaction)] =
     for {
+      version            <- Gen.oneOf(SmartIssueTransaction.supportedVersions.toSeq)
       timestamp          <- timestampGen
       initialWavesAmount <- Gen.choose(Long.MaxValue / 1000, Long.MaxValue / 100)
       accountA           <- accountGen
@@ -115,17 +116,17 @@ class AssetTransactionsDiffTest extends PropSpec with PropertyChecks with Matche
       reissuable = true
       (_, assetName, description, quantity, decimals, _, _, _) <- issueParamGen
       issue = SmartIssueTransaction
-        .selfSigned(1,
-                AddressScheme.current.chainId,
-                accountA,
-                assetName,
-                description,
-                quantity,
-                decimals,
-                reissuable,
-                Some(createScript(code)),
-                smallFee,
-                timestamp + 1)
+        .selfSigned(version,
+                    AddressScheme.current.chainId,
+                    accountA,
+                    assetName,
+                    description,
+                    quantity,
+                    decimals,
+                    reissuable,
+                    Some(createScript(code)),
+                    smallFee,
+                    timestamp + 1)
         .explicitGet()
       assetId = issue.id()
       transfer = TransferTransaction

--- a/src/test/scala/com/wavesplatform/state2/diffs/BlockDifferTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/BlockDifferTest.scala
@@ -13,14 +13,14 @@ import scorex.account.PrivateKeyAccount
 import scorex.block.Block
 import scorex.lagonaki.mocks.TestBlock
 import scorex.settings.TestFunctionalitySettings
-import scorex.transaction.{GenesisTransaction, TransactionParser, ValidationError}
+import scorex.transaction.{GenesisTransaction, TransactionParsers, ValidationError}
 
 class BlockDifferTest extends FreeSpecLike with Matchers with BlockGen with WithState {
 
   private val TransactionFee = 10
 
   def randomPrivateKeyAccount(): PrivateKeyAccount = {
-    val seed = Array.ofDim[Byte](TransactionParser.KeyLength)
+    val seed = Array.ofDim[Byte](TransactionParsers.KeyLength)
     ThreadLocalRandom.current().nextBytes(seed)
     PrivateKeyAccount(seed)
   }

--- a/src/test/scala/com/wavesplatform/state2/diffs/DataTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/DataTransactionDiffTest.scala
@@ -21,8 +21,8 @@ class DataTransactionDiffTest extends PropSpec with PropertyChecks with Matchers
     genesis: GenesisTransaction = GenesisTransaction.create(master, ENOUGH_AMT, ts).right.get
   } yield (genesis, master, ts)
 
-  def data(sender: PrivateKeyAccount, data: List[DataEntry[_]], fee: Long, timestamp: Long): DataTransaction =
-    DataTransaction.selfSigned(DataTransaction.Version, sender, data, fee, timestamp).right.get
+  def data(version: Byte, sender: PrivateKeyAccount, data: List[DataEntry[_]], fee: Long, timestamp: Long): DataTransaction =
+    DataTransaction.selfSigned(version, sender, data, fee, timestamp).right.get
 
   property("state invariants hold") {
     val setup = for {
@@ -32,18 +32,21 @@ class DataTransactionDiffTest extends PropSpec with PropertyChecks with Matchers
       value1 <- positiveLongGen
       item1 = LongDataEntry(key1, value1)
       fee1 <- smallFeeGen
-      dataTx1 = data(master, List(item1), fee1, ts + 10000)
+      version1 <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
+      dataTx1 = data(version1, master, List(item1), fee1, ts + 10000)
 
       key2 <- validAliasStringGen
       value2 <- Arbitrary.arbitrary[Boolean]
       item2 = BooleanDataEntry(key2, value2)
       fee2 <- smallFeeGen
-      dataTx2 = data(master, List(item2), fee2, ts + 20000)
+      version2 <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
+      dataTx2 = data(version2, master, List(item2), fee2, ts + 20000)
 
       value3 <- positiveLongGen
       item3 = LongDataEntry(key1, value3)
       fee3 <- smallFeeGen
-      dataTx3 = data(master, List(item3), fee3, ts + 30000)
+      version3 <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
+      dataTx3 = data(version3, master, List(item3), fee3, ts + 30000)
     } yield (genesis, Seq(item1, item2, item3), Seq(dataTx1, dataTx2, dataTx3))
 
     forAll(setup) { case (genesisTx, items, txs) =>
@@ -87,7 +90,8 @@ class DataTransactionDiffTest extends PropSpec with PropertyChecks with Matchers
       key <- validAliasStringGen
       value <- bytes64gen
       feeOverhead <- Gen.choose[Long](1, ENOUGH_AMT)
-      dataTx = data(master, List(BinaryDataEntry(key, ByteStr(value))), ENOUGH_AMT + feeOverhead, ts + 10000)
+      version <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
+      dataTx = data(version, master, List(BinaryDataEntry(key, ByteStr(value))), ENOUGH_AMT + feeOverhead, ts + 10000)
     } yield (genesis, dataTx)
 
     forAll(setup) { case (genesis, dataTx) =>
@@ -101,7 +105,8 @@ class DataTransactionDiffTest extends PropSpec with PropertyChecks with Matchers
     val setup = for {
       (genesis, master, ts) <- baseSetup
       fee <- smallFeeGen
-      dataTx = data(master, List(), fee, ts + 10000)
+      version <- Gen.oneOf(DataTransaction.supportedVersions.toSeq)
+      dataTx = data(version, master, List(), fee, ts + 10000)
     } yield (genesis, dataTx)
     val settings = TestFunctionalitySettings.Enabled.copy(preActivatedFeatures = Map(BlockchainFeatures.DataTransaction.id -> 10))
 

--- a/src/test/scala/com/wavesplatform/state2/diffs/ExchangeTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/ExchangeTransactionDiffTest.scala
@@ -54,13 +54,14 @@ class ExchangeTransactionDiffTest
     val fs = TestFunctionalitySettings.Enabled.copy(preActivatedFeatures = Map(BlockchainFeatures.SmartAccounts.id -> 0))
 
     val preconditionsAndExchange: Gen[(GenesisTransaction, GenesisTransaction, SetScriptTransaction, IssueTransaction, IssueTransaction, ExchangeTransaction)] = for {
+      version <- Gen.oneOf(SetScriptTransaction.supportedVersions.toSeq)
       buyer <- accountGen
       seller <- accountGen
       fee <- smallFeeGen
       ts <- timestampGen
       gen1: GenesisTransaction = GenesisTransaction.create(buyer, ENOUGH_AMT, ts).right.get
       gen2: GenesisTransaction = GenesisTransaction.create(seller, ENOUGH_AMT, ts).right.get
-      setScript = SetScriptTransaction.selfSigned(seller, Some(Script(TRUE)), fee, ts).explicitGet()
+      setScript = SetScriptTransaction.selfSigned(version, seller, Some(Script(TRUE)), fee, ts).explicitGet()
       issue1: IssueTransaction <- issueReissueBurnGeneratorP(ENOUGH_AMT, seller).map(_._1)
       issue2: IssueTransaction <- issueReissueBurnGeneratorP(ENOUGH_AMT, buyer).map(_._1)
       maybeAsset1 <- Gen.option(issue1.id())

--- a/src/test/scala/com/wavesplatform/state2/diffs/smart/performance/SigVerifyPerformanceTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/smart/performance/SigVerifyPerformanceTest.scala
@@ -29,9 +29,10 @@ class SigVerifyPerformanceTest extends PropSpec with PropertyChecks with Matcher
 
   private def scriptedSendGen(from: PrivateKeyAccount, to: PublicKeyAccount, ts: Long): Gen[VersionedTransferTransaction] =
     for {
-      amt <- smallFeeGen
-      fee <- smallFeeGen
-    } yield VersionedTransferTransaction.selfSigned(1, None, from, to.toAddress, amt, ts, fee, Array.emptyByteArray).explicitGet()
+      version <- Gen.oneOf(VersionedTransferTransaction.supportedVersions.toSeq)
+      amt     <- smallFeeGen
+      fee     <- smallFeeGen
+    } yield VersionedTransferTransaction.selfSigned(version, None, from, to.toAddress, amt, ts, fee, Array.emptyByteArray).explicitGet()
 
   private def differentTransfers(typed: Typed.EXPR) =
     for {
@@ -56,9 +57,10 @@ class SigVerifyPerformanceTest extends PropSpec with PropertyChecks with Matcher
     forAll(differentTransfers(typedScript)) {
       case (gen, setScript, transfers, scriptTransfers) =>
         def simpleCheck(): Unit = assertDiffAndState(Seq(TestBlock.create(Seq(gen))), TestBlock.create(transfers), smartEnabledFS) { case _ => }
-        def scriptedCheck(): Unit = assertDiffAndState(Seq(TestBlock.create(Seq(gen, setScript))), TestBlock.create(scriptTransfers), smartEnabledFS) {
-          case _ =>
-        }
+        def scriptedCheck(): Unit =
+          assertDiffAndState(Seq(TestBlock.create(Seq(gen, setScript))), TestBlock.create(scriptTransfers), smartEnabledFS) {
+            case _ =>
+          }
 
         val simeplCheckTime   = Instrumented.withTime(simpleCheck())._2
         val scriptedCheckTime = Instrumented.withTime(scriptedCheck())._2

--- a/src/test/scala/com/wavesplatform/state2/diffs/smart/scenarios/MultiSig2of3Test.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/smart/scenarios/MultiSig2of3Test.scala
@@ -38,6 +38,7 @@ class MultiSig2of3Test extends PropSpec with PropertyChecks with Matchers with T
   }
 
   val preconditionsAndTransfer: Gen[(GenesisTransaction, SetScriptTransaction, VersionedTransferTransaction, Seq[ByteStr])] = for {
+    version   <- Gen.oneOf(VersionedTransferTransaction.supportedVersions.toSeq)
     master    <- accountGen
     s0        <- accountGen
     s1        <- accountGen
@@ -52,7 +53,7 @@ class MultiSig2of3Test extends PropSpec with PropertyChecks with Matchers with T
   } yield {
     val unsigned =
       VersionedTransferTransaction
-        .create(2, None, master, recepient, amount, timestamp, fee, Array.emptyByteArray, proofs = Proofs.empty)
+        .create(version, None, master, recepient, amount, timestamp, fee, Array.emptyByteArray, proofs = Proofs.empty)
         .explicitGet()
     val sig0 = ByteStr(crypto.sign(s0, unsigned.bodyBytes()))
     val sig1 = ByteStr(crypto.sign(s1, unsigned.bodyBytes()))

--- a/src/test/scala/com/wavesplatform/state2/diffs/smart/scenarios/OneProofForNonScriptedAccountTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/smart/scenarios/OneProofForNonScriptedAccountTest.scala
@@ -5,6 +5,7 @@ import com.wavesplatform.state2._
 import com.wavesplatform.state2.diffs.smart.smartEnabledFS
 import com.wavesplatform.state2.diffs.{ENOUGH_AMT, assertDiffEi, produce}
 import com.wavesplatform.{NoShrink, TransactionGen}
+import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import scorex.lagonaki.mocks.TestBlock
@@ -15,8 +16,8 @@ import scorex.transaction.smart.Script
 class OneProofForNonScriptedAccountTest extends PropSpec with PropertyChecks with Matchers with TransactionGen with NoShrink {
 
   property("exactly 1 proof required for non-scripted accounts") {
-
     val s = for {
+      version   <- Gen.oneOf(VersionedTransferTransaction.supportedVersions.toSeq)
       master    <- accountGen
       recepient <- accountGen
       amt       <- positiveLongGen
@@ -24,7 +25,7 @@ class OneProofForNonScriptedAccountTest extends PropSpec with PropertyChecks wit
       ts        <- positiveIntGen
       genesis = GenesisTransaction.create(master, ENOUGH_AMT, ts).explicitGet()
       setScript <- selfSignedSetScriptTransactionGenP(master, Script(Typed.TRUE))
-      transfer = VersionedTransferTransaction.selfSigned(2, None, master, recepient, amt, ts, fee, Array.emptyByteArray).explicitGet()
+      transfer = VersionedTransferTransaction.selfSigned(version, None, master, recepient, amt, ts, fee, Array.emptyByteArray).explicitGet()
     } yield (genesis, setScript, transfer)
 
     forAll(s) {

--- a/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
+++ b/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
@@ -14,33 +14,38 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
 import scorex.account.{Address, PrivateKeyAccount, PublicKeyAccount}
 import scorex.block.Block
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.ValidationError.SenderIsBlacklisted
 import scorex.transaction.assets.MassTransferTransaction.ParsedTransfer
-import scorex.transaction.assets.{MassTransferTransaction, TransferTransaction}
-import scorex.transaction.{FeeCalculator, Proofs, Transaction}
+import scorex.transaction.assets.{IssueTransaction, MassTransferTransaction, TransferTransaction}
+import scorex.transaction.{FeeCalculator, GenesisTransaction, Transaction}
 import scorex.utils.{NTP, Time}
 
 import scala.concurrent.duration._
 
-class UtxPoolSpecification extends FreeSpec
-  with Matchers with MockFactory with PropertyChecks with TransactionGen with NoShrink with WithDB {
+class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with PropertyChecks with TransactionGen with NoShrink with WithDB {
 
-  private val calculator = new FeeCalculator(FeesSettings(Seq(
-    TransactionType.GenesisTransaction,
-    TransactionType.IssueTransaction,
-    TransactionType.TransferTransaction,
-    TransactionType.MassTransferTransaction
-  ).map(_.id -> List(FeeSettings("", 0))).toMap))
+  private val calculatorSettings = FeesSettings(
+    Seq(
+      GenesisTransaction,
+      IssueTransaction,
+      TransferTransaction,
+      MassTransferTransaction
+    ).map(_.typeId.toInt -> List(FeeSettings("", 0))).toMap)
+
+  private val calculator = new FeeCalculator(calculatorSettings)
 
   private def mkState(senderAccount: Address, senderBalance: Long) = {
-
-    val config = ConfigFactory.load()
+    val config          = ConfigFactory.load()
     val genesisSettings = TestHelpers.genesisSettings(Map(senderAccount -> senderBalance))
-    val settings = WavesSettings.fromConfig(config).copy(
-      blockchainSettings = BlockchainSettings('T', 5, 5,
-        FunctionalitySettings.TESTNET.copy(preActivatedFeatures = Map(BlockchainFeatures.MassTransfer.id -> 0)),
-        genesisSettings))
+    val settings = WavesSettings
+      .fromConfig(config)
+      .copy(
+        blockchainSettings =
+          BlockchainSettings('T',
+                             5,
+                             5,
+                             FunctionalitySettings.TESTNET.copy(preActivatedFeatures = Map(BlockchainFeatures.MassTransfer.id -> 0)),
+                             genesisSettings))
 
     val (history, state, bcu) = StorageFactory(settings, db, NTP)
 
@@ -49,30 +54,33 @@ class UtxPoolSpecification extends FreeSpec
     (bcu.stateReader, bcu.historyReader)
   }
 
-  private def transfer(sender: PrivateKeyAccount, maxAmount: Long, time: Time) = (for {
-    amount <- chooseNum(1, (maxAmount * 0.9).toLong)
-    recipient <- accountGen
-    fee <- chooseNum(1, (maxAmount * 0.1).toLong)
-  } yield TransferTransaction.create(None, sender, recipient, amount, time.getTimestamp(), None, fee, Array.empty[Byte]).right.get)
-    .label("transferTransaction")
+  private def transfer(sender: PrivateKeyAccount, maxAmount: Long, time: Time) =
+    (for {
+      amount    <- chooseNum(1, (maxAmount * 0.9).toLong)
+      recipient <- accountGen
+      fee       <- chooseNum(1, (maxAmount * 0.1).toLong)
+    } yield TransferTransaction.create(None, sender, recipient, amount, time.getTimestamp(), None, fee, Array.empty[Byte]).right.get)
+      .label("transferTransaction")
 
-  private def transferWithRecipient(sender: PrivateKeyAccount, recipient: PublicKeyAccount, maxAmount: Long, time: Time) = (for {
-    amount <- chooseNum(1, (maxAmount * 0.9).toLong)
-    fee <- chooseNum(1, (maxAmount * 0.1).toLong)
-  } yield TransferTransaction.create(None, sender, recipient, amount, time.getTimestamp(), None, fee, Array.empty[Byte]).right.get)
-    .label("transferWithRecipient")
+  private def transferWithRecipient(sender: PrivateKeyAccount, recipient: PublicKeyAccount, maxAmount: Long, time: Time) =
+    (for {
+      amount <- chooseNum(1, (maxAmount * 0.9).toLong)
+      fee    <- chooseNum(1, (maxAmount * 0.1).toLong)
+    } yield TransferTransaction.create(None, sender, recipient, amount, time.getTimestamp(), None, fee, Array.empty[Byte]).right.get)
+      .label("transferWithRecipient")
 
   private def massTransferWithRecipients(sender: PrivateKeyAccount, recipients: List[PublicKeyAccount], maxAmount: Long, time: Time) = {
-    val amount = maxAmount / (recipients.size + 1)
+    val amount    = maxAmount / (recipients.size + 1)
     val transfers = recipients.map(r => ParsedTransfer(r.toAddress, amount))
     val txs = for {
-      fee <- chooseNum(1, amount)
-    } yield MassTransferTransaction.selfSigned(Proofs.Version, None, sender, transfers, time.getTimestamp(), fee, Array.empty[Byte]).right.get
+      version <- Gen.oneOf(MassTransferTransaction.supportedVersions.toSeq)
+      fee     <- chooseNum(1, amount)
+    } yield MassTransferTransaction.selfSigned(version, None, sender, transfers, time.getTimestamp(), fee, Array.empty[Byte]).right.get
     txs.label("transferWithRecipient")
   }
 
   private val stateGen = for {
-    sender <- accountGen.label("sender")
+    sender        <- accountGen.label("sender")
     senderBalance <- positiveLongGen.label("senderBalance")
   } yield {
     val (state, history) = mkState(sender, senderBalance)
@@ -80,83 +88,86 @@ class UtxPoolSpecification extends FreeSpec
   }
   private val twoOutOfManyValidPayments = (for {
     (sender, senderBalance, state, history) <- stateGen
-    recipient <- accountGen
-    n <- chooseNum(3, 10)
-    fee <- chooseNum(1, (senderBalance * 0.01).toLong)
-    offset <- chooseNum(1000L, 2000L)
+    recipient                               <- accountGen
+    n                                       <- chooseNum(3, 10)
+    fee                                     <- chooseNum(1, (senderBalance * 0.01).toLong)
+    offset                                  <- chooseNum(1000L, 2000L)
   } yield {
     val time = new TestTime()
-    val utx = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, UtxSettings(10, 10.minutes, Set.empty, Set.empty, 5.minutes))
+    val utx =
+      new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, UtxSettings(10, 10.minutes, Set.empty, Set.empty, 5.minutes))
     val amountPart = (senderBalance - fee) / 2 - fee
-    val txs = for (_ <- 1 to n) yield createWavesTransfer(sender, recipient, amountPart, fee, time.getTimestamp()).right.get
+    val txs        = for (_ <- 1 to n) yield createWavesTransfer(sender, recipient, amountPart, fee, time.getTimestamp()).right.get
     (utx, time, txs, (offset + 1000).millis)
   }).label("twoOutOfManyValidPayments")
 
   private val emptyUtxPool = stateGen
-    .map { case (sender, senderBalance, state, history) =>
-      val time = new TestTime()
-      val utxPool = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, UtxSettings(10, 1.minute, Set.empty, Set.empty, 5.minutes))
-      (sender, state, utxPool)
+    .map {
+      case (sender, senderBalance, state, history) =>
+        val time = new TestTime()
+        val utxPool =
+          new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, UtxSettings(10, 1.minute, Set.empty, Set.empty, 5.minutes))
+        (sender, state, utxPool)
     }
     .label("emptyUtxPool")
 
   private val withValidPayments = (for {
     (sender, senderBalance, state, history) <- stateGen
-    recipient <- accountGen
+    recipient                               <- accountGen
     time = new TestTime()
     txs <- Gen.nonEmptyListOf(transferWithRecipient(sender, recipient, senderBalance / 10, time))
   } yield {
     val settings = UtxSettings(10, 1.minute, Set.empty, Set.empty, 5.minutes)
-    val utxPool = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
+    val utxPool  = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
     txs.foreach(utxPool.putIfNew)
     (sender, state, utxPool, time, settings)
   }).label("withValidPayments")
 
   private val withBlacklisted = (for {
     (sender, senderBalance, state, history) <- stateGen
-    recipient <- accountGen
+    recipient                               <- accountGen
     time = new TestTime()
     txs <- Gen.nonEmptyListOf(transferWithRecipient(sender, recipient, senderBalance / 10, time)) // @TODO: Random transactions
   } yield {
     val settings = UtxSettings(10, 1.minute, Set(sender.address), Set.empty, 5.minutes)
-    val utxPool = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
+    val utxPool  = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
     (sender, utxPool, txs)
   }).label("withBlacklisted")
 
   private val withBlacklistedAndAllowedByRule = (for {
     (sender, senderBalance, state, history) <- stateGen
-    recipient <- accountGen
+    recipient                               <- accountGen
     time = new TestTime()
     txs <- Gen.nonEmptyListOf(transferWithRecipient(sender, recipient, senderBalance / 10, time)) // @TODO: Random transactions
   } yield {
     val settings = UtxSettings(txs.length, 1.minute, Set(sender.address), Set(recipient.address), 5.minutes)
-    val utxPool = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
+    val utxPool  = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
     (sender, utxPool, txs)
   }).label("withBlacklistedAndAllowedByRule")
 
-  private def massTransferWithBlacklisted(allowRecipients: Boolean) = (for {
-    (sender, senderBalance, state, history) <- stateGen
-    addressGen = Gen.listOf(accountGen).filter(list => if (allowRecipients) list.nonEmpty else true)
-    recipients <- addressGen
-    time = new TestTime()
-    txs <- Gen.nonEmptyListOf(massTransferWithRecipients(sender, recipients, senderBalance / 10, time))
-  } yield {
-    val whitelist: Set[String] = if (allowRecipients) recipients.map(_.address).toSet else Set.empty
-    val settings = UtxSettings(txs.length, 1.minute, Set(sender.address), whitelist, 5.minutes)
-    val utxPool = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
-    (sender, utxPool, txs)
-  }).label("massTransferWithBlacklisted")
+  private def massTransferWithBlacklisted(allowRecipients: Boolean) =
+    (for {
+      (sender, senderBalance, state, history) <- stateGen
+      addressGen = Gen.listOf(accountGen).filter(list => if (allowRecipients) list.nonEmpty else true)
+      recipients <- addressGen
+      time = new TestTime()
+      txs <- Gen.nonEmptyListOf(massTransferWithRecipients(sender, recipients, senderBalance / 10, time))
+    } yield {
+      val whitelist: Set[String] = if (allowRecipients) recipients.map(_.address).toSet else Set.empty
+      val settings               = UtxSettings(txs.length, 1.minute, Set(sender.address), whitelist, 5.minutes)
+      val utxPool                = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, settings)
+      (sender, utxPool, txs)
+    }).label("massTransferWithBlacklisted")
 
-  private def utxTest(utxSettings: UtxSettings = UtxSettings(20, 5.seconds, Set.empty, Set.empty, 5.minutes), txCount: Int = 10)
-                     (f: (Seq[TransferTransaction], UtxPool, TestTime) => Unit): Unit = forAll(
-    stateGen,
-    chooseNum(2, txCount).label("txCount")) { case ((sender, senderBalance, state, history), count) =>
-    val time = new TestTime()
+  private def utxTest(utxSettings: UtxSettings = UtxSettings(20, 5.seconds, Set.empty, Set.empty, 5.minutes), txCount: Int = 10)(
+      f: (Seq[TransferTransaction], UtxPool, TestTime) => Unit): Unit = forAll(stateGen, chooseNum(2, txCount).label("txCount")) {
+    case ((sender, senderBalance, state, history), count) =>
+      val time = new TestTime()
 
-    forAll(listOfN(count, transfer(sender, senderBalance / 2, time))) { txs =>
-      val utx = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, utxSettings)
-      f(txs, utx, time)
-    }
+      forAll(listOfN(count, transfer(sender, senderBalance / 2, time))) { txs =>
+        val utx = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, utxSettings)
+        f(txs, utx, time)
+      }
   }
 
   private val dualTxGen: Gen[(UtxPool, TestTime, Seq[Transaction], FiniteDuration, Seq[Transaction])] =
@@ -164,12 +175,17 @@ class UtxPoolSpecification extends FreeSpec
       (sender, senderBalance, state, history) <- stateGen
       ts = System.currentTimeMillis()
       count1 <- chooseNum(5, 10)
-      tx1 <- listOfN(count1, transfer(sender, senderBalance / 2, new TestTime(ts)))
+      tx1    <- listOfN(count1, transfer(sender, senderBalance / 2, new TestTime(ts)))
       offset <- chooseNum(5000L, 10000L)
-      tx2 <- listOfN(count1, transfer(sender, senderBalance / 2, new TestTime(ts + offset + 1000)))
+      tx2    <- listOfN(count1, transfer(sender, senderBalance / 2, new TestTime(ts + offset + 1000)))
     } yield {
       val time = new TestTime()
-      val utx = new UtxPoolImpl(time, state, history, calculator, FunctionalitySettings.TESTNET, UtxSettings(10, offset.millis, Set.empty, Set.empty, 5.minutes))
+      val utx = new UtxPoolImpl(time,
+                                state,
+                                history,
+                                calculator,
+                                FunctionalitySettings.TESTNET,
+                                UtxSettings(10, offset.millis, Set.empty, Set.empty, 5.minutes))
       (utx, time, tx1, (offset + 1000).millis, tx2)
     }
 
@@ -184,126 +200,138 @@ class UtxPoolSpecification extends FreeSpec
       utx.putIfNew(txs.head) shouldBe 'right
     }
 
-    "evicts expired transactions when removeAll is called" in forAll(dualTxGen) { case (utx, time, txs1, offset, txs2) =>
-      all(txs1.map(utx.putIfNew)) shouldBe 'right
-      utx.all.size shouldEqual txs1.size
+    "evicts expired transactions when removeAll is called" in forAll(dualTxGen) {
+      case (utx, time, txs1, offset, txs2) =>
+        all(txs1.map(utx.putIfNew)) shouldBe 'right
+        utx.all.size shouldEqual txs1.size
 
-      time.advance(offset)
-      utx.removeAll(Seq.empty)
+        time.advance(offset)
+        utx.removeAll(Seq.empty)
 
-      all(txs2.map(utx.putIfNew)) shouldBe 'right
-      utx.all.size shouldEqual txs2.size
+        all(txs2.map(utx.putIfNew)) shouldBe 'right
+        utx.all.size shouldEqual txs2.size
     }
 
-    "packUnconfirmed result is limited by constraint" in forAll(dualTxGen) { case (utx, time, txs, _, _) =>
-      all(txs.map(utx.putIfNew)) shouldBe 'right
-      utx.all.size shouldEqual txs.size
+    "packUnconfirmed result is limited by constraint" in forAll(dualTxGen) {
+      case (utx, time, txs, _, _) =>
+        all(txs.map(utx.putIfNew)) shouldBe 'right
+        utx.all.size shouldEqual txs.size
 
-      val maxNumber = Math.max(utx.all.size / 2, 3)
-      val rest = limitByNumber(maxNumber)
-      val (packed, restUpdated) = utx.packUnconfirmed(rest, sortInBlock = false)
+        val maxNumber             = Math.max(utx.all.size / 2, 3)
+        val rest                  = limitByNumber(maxNumber)
+        val (packed, restUpdated) = utx.packUnconfirmed(rest, sortInBlock = false)
 
-      packed.lengthCompare(maxNumber) should be <= 0
-      if (maxNumber <= utx.all.size) restUpdated.isEmpty shouldBe true
+        packed.lengthCompare(maxNumber) should be <= 0
+        if (maxNumber <= utx.all.size) restUpdated.isEmpty shouldBe true
     }
 
-    "evicts expired transactions when packUnconfirmed is called" in forAll(dualTxGen) { case (utx, time, txs, offset, _) =>
-      all(txs.map(utx.putIfNew)) shouldBe 'right
-      utx.all.size shouldEqual txs.size
+    "evicts expired transactions when packUnconfirmed is called" in forAll(dualTxGen) {
+      case (utx, time, txs, offset, _) =>
+        all(txs.map(utx.putIfNew)) shouldBe 'right
+        utx.all.size shouldEqual txs.size
 
-      time.advance(offset)
+        time.advance(offset)
 
-      val (packed, _) = utx.packUnconfirmed(limitByNumber(100), sortInBlock = false)
-      packed shouldBe 'empty
-      utx.all shouldBe 'empty
+        val (packed, _) = utx.packUnconfirmed(limitByNumber(100), sortInBlock = false)
+        packed shouldBe 'empty
+        utx.all shouldBe 'empty
     }
 
-    "evicts one of mutually invalid transactions when packUnconfirmed is called" in forAll(twoOutOfManyValidPayments) { case (utx, time, txs, offset) =>
-      all(txs.map(utx.putIfNew)) shouldBe 'right
-      utx.all.size shouldEqual txs.size
+    "evicts one of mutually invalid transactions when packUnconfirmed is called" in forAll(twoOutOfManyValidPayments) {
+      case (utx, time, txs, offset) =>
+        all(txs.map(utx.putIfNew)) shouldBe 'right
+        utx.all.size shouldEqual txs.size
 
-      time.advance(offset)
+        time.advance(offset)
 
-      val (packed, _) = utx.packUnconfirmed(limitByNumber(100), sortInBlock = false)
-      packed.size shouldBe 2
-      utx.all.size shouldBe 2
+        val (packed, _) = utx.packUnconfirmed(limitByNumber(100), sortInBlock = false)
+        packed.size shouldBe 2
+        utx.all.size shouldBe 2
     }
 
     "portfolio" - {
-      "returns a count of assets from the state if there is no transaction" in forAll(emptyUtxPool) { case (sender, state, utxPool) =>
-        val basePortfolio = state.portfolio(sender)
+      "returns a count of assets from the state if there is no transaction" in forAll(emptyUtxPool) {
+        case (sender, state, utxPool) =>
+          val basePortfolio = state.portfolio(sender)
 
-        utxPool.size shouldBe 0
-        val utxPortfolio = utxPool.portfolio(sender)
+          utxPool.size shouldBe 0
+          val utxPortfolio = utxPool.portfolio(sender)
 
-        basePortfolio shouldBe utxPortfolio
+          basePortfolio shouldBe utxPortfolio
       }
 
-      "taking into account unconfirmed transactions" in forAll(withValidPayments) { case (sender, state, utxPool, _, _) =>
-        val basePortfolio = state.portfolio(sender)
+      "taking into account unconfirmed transactions" in forAll(withValidPayments) {
+        case (sender, state, utxPool, _, _) =>
+          val basePortfolio = state.portfolio(sender)
 
-        utxPool.size should be > 0
-        val utxPortfolio = utxPool.portfolio(sender)
+          utxPool.size should be > 0
+          val utxPortfolio = utxPool.portfolio(sender)
 
-        utxPortfolio.balance should be <= basePortfolio.balance
-        utxPortfolio.lease.out should be <= basePortfolio.lease.out
-        // should not be changed
-        utxPortfolio.lease.in shouldBe basePortfolio.lease.in
-        utxPortfolio.assets.foreach { case (assetId, count) =>
-          count should be <= basePortfolio.assets.getOrElse(assetId, count)
-        }
+          utxPortfolio.balance should be <= basePortfolio.balance
+          utxPortfolio.lease.out should be <= basePortfolio.lease.out
+          // should not be changed
+          utxPortfolio.lease.in shouldBe basePortfolio.lease.in
+          utxPortfolio.assets.foreach {
+            case (assetId, count) =>
+              count should be <= basePortfolio.assets.getOrElse(assetId, count)
+          }
       }
 
-      "is changed after transactions with these assets are removed" in forAll(withValidPayments) { case (sender, _, utxPool, time, settings) =>
-        val utxPortfolioBefore = utxPool.portfolio(sender)
-        val poolSizeBefore = utxPool.size
+      "is changed after transactions with these assets are removed" in forAll(withValidPayments) {
+        case (sender, _, utxPool, time, settings) =>
+          val utxPortfolioBefore = utxPool.portfolio(sender)
+          val poolSizeBefore     = utxPool.size
 
-        time.advance(settings.maxTransactionAge * 2)
-        utxPool.packUnconfirmed(limitByNumber(100), sortInBlock = false)
+          time.advance(settings.maxTransactionAge * 2)
+          utxPool.packUnconfirmed(limitByNumber(100), sortInBlock = false)
 
-        poolSizeBefore should be > utxPool.size
-        val utxPortfolioAfter = utxPool.portfolio(sender)
+          poolSizeBefore should be > utxPool.size
+          val utxPortfolioAfter = utxPool.portfolio(sender)
 
-        utxPortfolioAfter.balance should be >= utxPortfolioBefore.balance
-        utxPortfolioAfter.lease.out should be >= utxPortfolioBefore.lease.out
-        utxPortfolioAfter.assets.foreach { case (assetId, count) =>
-          count should be >= utxPortfolioBefore.assets.getOrElse(assetId, count)
-        }
+          utxPortfolioAfter.balance should be >= utxPortfolioBefore.balance
+          utxPortfolioAfter.lease.out should be >= utxPortfolioBefore.lease.out
+          utxPortfolioAfter.assets.foreach {
+            case (assetId, count) =>
+              count should be >= utxPortfolioBefore.assets.getOrElse(assetId, count)
+          }
       }
     }
 
     "blacklisting" - {
       "prevent a transfer transaction from specific addresses" in {
         val transferGen = Gen.oneOf(withBlacklisted, massTransferWithBlacklisted(allowRecipients = false))
-        forAll(transferGen) { case (_, utxPool, txs) =>
-          val r = txs.forall { tx =>
-            utxPool.putIfNew(tx) match {
-              case Left(SenderIsBlacklisted(_)) => true
-              case _ => false
+        forAll(transferGen) {
+          case (_, utxPool, txs) =>
+            val r = txs.forall { tx =>
+              utxPool.putIfNew(tx) match {
+                case Left(SenderIsBlacklisted(_)) => true
+                case _                            => false
+              }
             }
-          }
 
-          r shouldBe true
-          utxPool.all.size shouldEqual 0
+            r shouldBe true
+            utxPool.all.size shouldEqual 0
         }
       }
 
       "allow a transfer transaction from blacklisted address to specific addresses" in {
         val transferGen = Gen.oneOf(withBlacklistedAndAllowedByRule, massTransferWithBlacklisted(allowRecipients = true))
-        forAll(transferGen) { case (_, utxPool, txs) =>
-          all(txs.map { t =>
-            utxPool.putIfNew(t)
-          }) shouldBe 'right
-          utxPool.all.size shouldEqual txs.size
+        forAll(transferGen) {
+          case (_, utxPool, txs) =>
+            all(txs.map { t =>
+              utxPool.putIfNew(t)
+            }) shouldBe 'right
+            utxPool.all.size shouldEqual txs.size
         }
       }
     }
   }
 
-  private def limitByNumber(n: Int): TwoDimensionalMiningConstraint = TwoDimensionalMiningConstraint.full(new CounterEstimator(n), new CounterEstimator(n))
+  private def limitByNumber(n: Int): TwoDimensionalMiningConstraint =
+    TwoDimensionalMiningConstraint.full(new CounterEstimator(n), new CounterEstimator(n))
 
   private class CounterEstimator(val max: Long) extends Estimator {
-    override implicit def estimate(x: Block): Long = x.transactionCount
+    override implicit def estimate(x: Block): Long       = x.transactionCount
     override implicit def estimate(x: Transaction): Long = 1
   }
 }

--- a/src/test/scala/scorex/lagonaki/mocks/TestBlock.scala
+++ b/src/test/scala/scorex/lagonaki/mocks/TestBlock.scala
@@ -5,13 +5,13 @@ import com.wavesplatform.state2._
 import scorex.account.PrivateKeyAccount
 import scorex.block._
 import scorex.consensus.nxt.NxtLikeConsensusBlockData
-import scorex.transaction.TransactionParser._
-import scorex.transaction.{Transaction, TransactionParser}
+import scorex.transaction.TransactionParsers._
+import scorex.transaction.{Transaction, TransactionParsers}
 
 import scala.util.{Random, Try}
 
 object TestBlock {
-  val defaultSigner = PrivateKeyAccount(Array.fill(TransactionParser.KeyLength)(0))
+  val defaultSigner = PrivateKeyAccount(Array.fill(TransactionParsers.KeyLength)(0))
 
   val random: Random = new Random()
 

--- a/src/test/scala/scorex/network/CheckpointSpecification.scala
+++ b/src/test/scala/scorex/network/CheckpointSpecification.scala
@@ -3,7 +3,7 @@ package scorex.network
 import com.wavesplatform.network.{BlockCheckpoint, Checkpoint, CheckpointSpec}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest}
-import scorex.transaction.TransactionParser._
+import scorex.transaction.TransactionParsers._
 
 class CheckpointSpecification extends FreeSpec
   with Matchers

--- a/src/test/scala/scorex/transaction/BurnTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/BurnTransactionSpecification.scala
@@ -16,7 +16,7 @@ class BurnTransactionSpecification extends PropSpec with PropertyChecks with Mat
 
   property("Burn serialization from TypedTransaction") {
     forAll(burnGen) { issue: BurnTransaction =>
-      val recovered = TransactionParser.parseBytes(issue.bytes()).get
+      val recovered = TransactionParsers.parseBytes(issue.bytes()).get
       recovered.bytes() shouldEqual issue.bytes()
     }
   }

--- a/src/test/scala/scorex/transaction/CreateAliasTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/CreateAliasTransactionSpecification.scala
@@ -4,21 +4,19 @@ import com.wavesplatform.TransactionGen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import scorex.account.{Alias, PrivateKeyAccount}
-import scorex.transaction.TransactionParser.TransactionType
 
 class CreateAliasTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
   property("CreateAliasTransaction serialization roundtrip") {
     forAll(createAliasGen) { tx: CreateAliasTransaction =>
-      require(tx.bytes().head == TransactionType.CreateAliasTransaction.id)
-      val recovered = CreateAliasTransaction.parseTail(tx.bytes().tail).get
+      val recovered = CreateAliasTransaction.parseBytes(tx.bytes()).get
       assertTxs(recovered, tx)
     }
   }
 
   property("CreateAliasTransaction serialization from TypedTransaction") {
     forAll(createAliasGen) { tx: CreateAliasTransaction =>
-      val recovered = TransactionParser.parseBytes(tx.bytes()).get
+      val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       assertTxs(recovered.asInstanceOf[CreateAliasTransaction], tx)
     }
   }

--- a/src/test/scala/scorex/transaction/DataTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/DataTransactionSpecification.scala
@@ -1,23 +1,20 @@
 package scorex.transaction
 
-import com.google.common.primitives.Shorts
 import com.wavesplatform.TransactionGen
 import com.wavesplatform.state2.DataEntry._
 import com.wavesplatform.state2.{BinaryDataEntry, BooleanDataEntry, ByteStr, DataEntry, LongDataEntry}
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 import scorex.api.http.SignedDataRequest
 import scorex.crypto.encode.Base58
 import scorex.transaction.DataTransaction._
-import scorex.transaction.TransactionParser.TransactionType
 
 class DataTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
   private def checkSerialization(tx: DataTransaction): Assertion = {
-    require(tx.bytes().head == TransactionType.DataTransaction.id)
-    val parsed = DataTransaction.parseTail(tx.bytes().tail).get
+    val parsed = DataTransaction.parseBytes(tx.bytes()).get
 
     parsed.sender.address shouldEqual tx.sender.address
     parsed.timestamp shouldEqual tx.timestamp
@@ -37,7 +34,7 @@ class DataTransactionSpecification extends PropSpec with PropertyChecks with Mat
 
   property("serialization from TypedTransaction") {
     forAll(dataTransactionGen) { tx: DataTransaction =>
-      val recovered = TransactionParser.parseBytes(tx.bytes()).get
+      val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       recovered.bytes() shouldEqual tx.bytes()
     }
   }
@@ -45,19 +42,17 @@ class DataTransactionSpecification extends PropSpec with PropertyChecks with Mat
   property("unknown type handing") {
     val badTypeIdGen = Gen.choose[Byte](3, Byte.MaxValue)
     forAll(dataTransactionGen, badTypeIdGen) { case (tx, badTypeId) =>
-      val bytes = tx.bytes()
-      val entryCount = Shorts.fromByteArray(bytes.drop(34))
-      if (entryCount > 0) {
-        val p = 36 + bytes(36) // bytes(36) is key#1 length
-        val parsed = DataTransaction.parseTail((bytes.tail.take(p) :+ badTypeId) ++ bytes.drop(p + 2))
-        parsed.isFailure shouldBe true
-        parsed.failed.get.getMessage shouldBe s"Unknown type $badTypeId"
-      }
+      val bytesWithBadType = tx.bytes()
+      bytesWithBadType(1) = badTypeId
+
+      val parsed = DataTransaction.parseBytes(bytesWithBadType)
+      parsed.isFailure shouldBe true
+      parsed.failed.get.getMessage shouldBe s"Expected type of transaction '12', but got '$badTypeId'"
     }
   }
 
   property("JSON roundtrip") {
-    implicit val signedFormat = Json.format[SignedDataRequest]
+    implicit val signedFormat: Format[SignedDataRequest] = Json.format[SignedDataRequest]
 
     forAll(dataTransactionGen) { tx =>
       val json = tx.json()
@@ -86,7 +81,7 @@ class DataTransactionSpecification extends PropSpec with PropertyChecks with Mat
     forAll(dataTransactionGen, dataEntryGen, keyRepeatCountGen) {
       case (DataTransaction(version, sender, data, fee, timestamp, proofs), entry, keyRepeatCount) =>
         def check(data: List[DataEntry[_]]): Assertion = {
-          val txEi = create(version, sender, data, fee, timestamp, proofs)
+          val txEi = DataTransaction.create(version, sender, data, fee, timestamp, proofs)
           txEi shouldBe Right(DataTransaction(version, sender, data, fee, timestamp, proofs))
           checkSerialization(txEi.right.get)
         }
@@ -102,10 +97,10 @@ class DataTransactionSpecification extends PropSpec with PropertyChecks with Mat
   }
 
   property("negative validation cases") {
-    val badVersionGen = Gen.choose(DataTransaction.Version + 1, Byte.MaxValue).map(_.toByte)
+    val badVersionGen = Arbitrary.arbByte.arbitrary.filter(v => !DataTransaction.supportedVersions.contains(v))
     forAll(dataTransactionGen, badVersionGen) {
       case (DataTransaction(version, sender, data, fee, timestamp, proofs), badVersion) =>
-        val badVersionEi = create(badVersion, sender, data, fee, timestamp, proofs)
+        val badVersionEi = DataTransaction.create(badVersion, sender, data, fee, timestamp, proofs)
         badVersionEi shouldBe Left(ValidationError.UnsupportedVersion(badVersion))
 
         val dataTooBig = List.fill(MaxEntryCount + 1)(LongDataEntry("key", 4))
@@ -120,10 +115,10 @@ class DataTransactionSpecification extends PropSpec with PropertyChecks with Mat
         val valueTooLongEi = create(version, sender, valueTooLong, fee, timestamp, proofs)
         valueTooLongEi shouldBe Left(ValidationError.TooBigArray)
 
-        val noFeeEi = create(version, sender, data, 0, timestamp, proofs)
+        val noFeeEi = DataTransaction.create(version, sender, data, 0, timestamp, proofs)
         noFeeEi shouldBe Left(ValidationError.InsufficientFee)
 
-        val negativeFeeEi = create(version, sender, data, -100, timestamp, proofs)
+        val negativeFeeEi = DataTransaction.create(version, sender, data, -100, timestamp, proofs)
         negativeFeeEi shouldBe Left(ValidationError.InsufficientFee)
     }
   }

--- a/src/test/scala/scorex/transaction/GenesisTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/GenesisTransactionSpecification.scala
@@ -5,23 +5,10 @@ import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
 import scorex.crypto.encode.Base58
-import scorex.transaction.TransactionParser.TransactionType
-
-import scala.util.{Failure, Try}
 
 class GenesisTransactionSpecification extends PropSpec with PropertyChecks with Matchers {
 
   private val defaultRecipient = PublicKeyAccount(Array.fill(32)(0: Byte))
-
-
-  def parseBytes(data: Array[Byte]): Try[GenesisTransaction] = {
-    data.head match {
-      case transactionType: Byte if transactionType == TransactionType.GenesisTransaction.id =>
-        GenesisTransaction.parseTail(data.tail)
-      case transactionType =>
-        Failure(new Exception(s"Incorrect transaction type '$transactionType' in GenesisTransaction data"))
-    }
-  }
 
   property("GenesisTransaction Signature should be the same") {
     val balance = 457L
@@ -38,7 +25,7 @@ class GenesisTransactionSpecification extends PropSpec with PropertyChecks with 
   property("GenesisTransaction parse from Bytes should work fine") {
     val bytes = Base58.decode("5GoidXWjBfzuS9tZm4Fp6GAXUYFunVMsoWAew3eBnDbmaDi7WiP9yVpBD2").get
 
-    val actualTransaction = parseBytes(bytes).get
+    val actualTransaction = GenesisTransaction.parseBytes(bytes).get
 
     val balance = 12345L
     val timestamp = 1234567890L
@@ -53,7 +40,7 @@ class GenesisTransactionSpecification extends PropSpec with PropertyChecks with 
         val recipient = PrivateKeyAccount(recipientSeed)
         val source = GenesisTransaction.create(recipient, amount, time).right.get
         val bytes = source.bytes()
-        val dest = parseBytes(bytes).get
+        val dest = GenesisTransaction.parseBytes(bytes).get
 
         source should equal(dest)
     }

--- a/src/test/scala/scorex/transaction/IssueTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/IssueTransactionSpecification.scala
@@ -16,7 +16,7 @@ class IssueTransactionSpecification extends PropSpec with PropertyChecks with Ma
 
   property("Issue serialization from TypedTransaction") {
     forAll(issueGen) { issue: IssueTransaction =>
-      val recovered = TransactionParser.parseBytes(issue.bytes()).get
+      val recovered = TransactionParsers.parseBytes(issue.bytes()).get
       recovered.bytes() shouldEqual issue.bytes()
     }
   }

--- a/src/test/scala/scorex/transaction/LeaseCancelTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/LeaseCancelTransactionSpecification.scala
@@ -3,31 +3,20 @@ package scorex.transaction
 import com.wavesplatform.TransactionGen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.lease.LeaseCancelTransaction
-
-import scala.util.Try
 
 class LeaseCancelTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
-
-  def parseBytes(bytes: Array[Byte]): Try[LeaseCancelTransaction] = Try {
-    require(bytes.head == TransactionType.LeaseCancelTransaction.id)
-    LeaseCancelTransaction.parseTail(bytes.tail).get
-  }
-
   property("Lease cancel serialization roundtrip") {
     forAll(leaseCancelGen) { tx: LeaseCancelTransaction =>
-      val recovered = parseBytes(tx.bytes()).get
-
+      val recovered = LeaseCancelTransaction.parseBytes(tx.bytes()).get
       assertTxs(recovered, tx)
     }
   }
 
   property("Lease cancel serialization from TypedTransaction") {
     forAll(leaseCancelGen) { tx: LeaseCancelTransaction =>
-      val recovered = TransactionParser.parseBytes(tx.bytes()).get
-
+      val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       assertTxs(recovered.asInstanceOf[LeaseCancelTransaction], tx)
     }
   }

--- a/src/test/scala/scorex/transaction/LeaseTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/LeaseTransactionSpecification.scala
@@ -3,31 +3,20 @@ package scorex.transaction
 import com.wavesplatform.TransactionGen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.lease.LeaseTransaction
-
-import scala.util.Try
 
 class LeaseTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
-  def parseBytes(bytes: Array[Byte]): Try[LeaseTransaction] = Try {
-    require(bytes.head == TransactionType.LeaseTransaction.id)
-    LeaseTransaction.parseTail(bytes.tail).get
-  }
-
-
   property("Lease transaction serialization roundtrip") {
     forAll(leaseGen) { tx: LeaseTransaction =>
-      val recovered = parseBytes(tx.bytes()).get
-
+      val recovered = LeaseTransaction.parseBytes(tx.bytes()).get
       assertTxs(recovered, tx)
     }
   }
 
   property("Lease transaction from TransactionParser") {
     forAll(leaseGen) { tx: LeaseTransaction =>
-      val recovered = TransactionParser.parseBytes(tx.bytes()).get
-
+      val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       assertTxs(recovered.asInstanceOf[LeaseTransaction], tx)
     }
   }

--- a/src/test/scala/scorex/transaction/ReissueTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/ReissueTransactionSpecification.scala
@@ -3,29 +3,20 @@ package scorex.transaction
 import com.wavesplatform.TransactionGen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.assets.ReissueTransaction
-
-import scala.util.Try
 
 class ReissueTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
-
-  def parseBytes(bytes: Array[Byte]): Try[ReissueTransaction] = Try {
-    require(bytes.head == TransactionType.ReissueTransaction.id)
-    ReissueTransaction.parseTail(bytes.tail).get
-  }
-
   property("Reissue serialization roundtrip") {
     forAll(reissueGen) { issue: ReissueTransaction =>
-      val recovered = parseBytes(issue.bytes()).get
+      val recovered = ReissueTransaction.parseBytes(issue.bytes()).get
       recovered.bytes() shouldEqual issue.bytes()
     }
   }
 
   property("Reissue serialization from TypedTransaction") {
     forAll(reissueGen) { issue: ReissueTransaction =>
-      val recovered = TransactionParser.parseBytes(issue.bytes()).get
+      val recovered = TransactionParsers.parseBytes(issue.bytes()).get
       recovered.bytes() shouldEqual issue.bytes()
     }
   }

--- a/src/test/scala/scorex/transaction/SetScriptTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/SetScriptTransactionSpecification.scala
@@ -2,34 +2,39 @@ package scorex.transaction
 
 import com.wavesplatform.TransactionGen
 import com.wavesplatform.state2._
+import org.scalacheck.Gen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import scorex.account.PrivateKeyAccount
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.smart.SetScriptTransaction
 
 class SetScriptTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
+  private val versionGen: Gen[Byte] = Gen.oneOf(SetScriptTransaction.supportedVersions.toSeq)
+  private val versionAndAccountGen: Gen[(Byte, PrivateKeyAccount)] = for {
+    version <- versionGen
+    account <- accountGen
+  } yield (version, account)
+
   property("SetScriptTransaction serialization roundtrip") {
     forAll(setScriptTransactionGen) { tx: SetScriptTransaction =>
-      require(tx.bytes().head == TransactionType.SetScriptTransaction.id)
-      val recovered = SetScriptTransaction.parseTail(tx.bytes().tail).get
+      val recovered = SetScriptTransaction.parseBytes(tx.bytes()).get
       assertTxs(recovered, tx)
     }
   }
 
   property("SetScriptTransaction serialization from TypedTransaction") {
     forAll(setScriptTransactionGen) { tx: SetScriptTransaction =>
-      val recovered = TransactionParser.parseBytes(tx.bytes()).get
+      val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       assertTxs(recovered.asInstanceOf[SetScriptTransaction], tx)
     }
   }
 
   property("SetScriptTransaction id doesn't depend on proof") {
-    forAll(accountGen, byteArrayGen(10), byteArrayGen(15), proofsGen, proofsGen, scriptGen) {
-      case (acc: PrivateKeyAccount, p1, p2, proofs1, proofs2, script) =>
-        val tx1 = SetScriptTransaction.create(acc, Some(script), 1, 1, proofs1).explicitGet()
-        val tx2 = SetScriptTransaction.create(acc, Some(script), 1, 1, proofs2).explicitGet()
+    forAll(versionAndAccountGen, byteArrayGen(10), byteArrayGen(15), proofsGen, proofsGen, scriptGen) {
+      case ((version, acc: PrivateKeyAccount), p1, p2, proofs1, proofs2, script) =>
+        val tx1 = SetScriptTransaction.create(version, acc, Some(script), 1, 1, proofs1).explicitGet()
+        val tx2 = SetScriptTransaction.create(version, acc, Some(script), 1, 1, proofs2).explicitGet()
         tx1.id() shouldBe tx2.id()
     }
   }

--- a/src/test/scala/scorex/transaction/SmartIssueTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/SmartIssueTransactionSpecification.scala
@@ -4,15 +4,13 @@ import com.wavesplatform.{TransactionGen, WithDB}
 import com.wavesplatform.state2.HistoryTest
 import org.scalatest.{Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.assets.SmartIssueTransaction
 
 class SmartIssueTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen with WithDB with HistoryTest {
 
   property("SmartIssueTransaction serialization roundtrip") {
     forAll(smartIssueTransactionGen()) { tx: SmartIssueTransaction =>
-      require(tx.bytes().head == TransactionType.SmartIssueTransaction.id)
-      val recovered = SmartIssueTransaction.parseTail(tx.bytes().tail).get
+      val recovered = SmartIssueTransaction.parseBytes(tx.bytes()).get
 
       tx.sender.address shouldEqual recovered.sender.address
       tx.timestamp shouldEqual recovered.timestamp

--- a/src/test/scala/scorex/transaction/TransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/TransactionSpecification.scala
@@ -4,22 +4,9 @@ import com.wavesplatform.TransactionGen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import scorex.account.PrivateKeyAccount
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.assets.TransferTransaction
 
-import scala.util.{Failure, Try}
-
-
 class TransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
-
-  def parseBytes(data: Array[Byte]): Try[TransferTransaction] = {
-    data.head match {
-      case transactionType: Byte if transactionType == TransactionType.TransferTransaction.id =>
-        TransferTransaction.parseTail(data.tail)
-      case transactionType =>
-        Failure(new Exception(s"Incorrect transaction type '$transactionType' in TransferTransaction data"))
-    }
-  }
 
   property("transaction fields should be constructed in a right way") {
     forAll(bytes32gen, bytes32gen, timestampGen, positiveLongGen, positiveLongGen) {
@@ -45,7 +32,7 @@ class TransactionSpecification extends PropSpec with PropertyChecks with Matcher
         val sender = PrivateKeyAccount(senderSeed)
         val recipient = PrivateKeyAccount(recipientSeed)
         val tx = createWavesTransfer(sender, recipient, amount, fee, time).right.get
-        val txAfter = parseBytes(tx.bytes()).get
+        val txAfter = TransferTransaction.parseBytes(tx.bytes()).get
 
         txAfter.getClass.shouldBe(tx.getClass)
 
@@ -65,7 +52,7 @@ class TransactionSpecification extends PropSpec with PropertyChecks with Matcher
         val sender = PrivateKeyAccount(senderSeed)
         val recipient = PrivateKeyAccount(recipientSeed)
         val tx = createWavesTransfer(sender, recipient, amount, fee, time).right.get
-        val txAfter = TransactionParser.parseBytes(tx.bytes()).get.asInstanceOf[TransferTransaction]
+        val txAfter = TransactionParsers.parseBytes(tx.bytes()).get.asInstanceOf[TransferTransaction]
 
         txAfter.getClass.shouldBe(tx.getClass)
 

--- a/src/test/scala/scorex/transaction/TransferTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/TransferTransactionSpecification.scala
@@ -3,15 +3,13 @@ package scorex.transaction
 import com.wavesplatform.TransactionGen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.assets.TransferTransaction
 
 class TransferTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
   property("Transfer serialization roundtrip") {
     forAll(transferGen) { transfer: TransferTransaction =>
-      require(transfer.bytes().head == TransactionType.TransferTransaction.id)
-      val recovered = TransferTransaction.parseTail(transfer.bytes().tail).get
+      val recovered = TransferTransaction.parseBytes(transfer.bytes()).get
 
       recovered.sender.address shouldEqual transfer.sender.address
       recovered.assetId.map(_ == transfer.assetId.get).getOrElse(transfer.assetId.isEmpty) shouldBe true
@@ -27,7 +25,7 @@ class TransferTransactionSpecification extends PropSpec with PropertyChecks with
 
   property("Transfer serialization from TypedTransaction") {
     forAll(transferGen) { tx: TransferTransaction =>
-      val recovered = TransactionParser.parseBytes(tx.bytes()).get
+      val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       recovered.bytes() shouldEqual tx.bytes()
     }
   }

--- a/src/test/scala/scorex/transaction/VersionedTransferTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/VersionedTransferTransactionSpecification.scala
@@ -11,21 +11,21 @@ class VersionedTransferTransactionSpecification extends PropSpec with PropertyCh
 
   private val versionGen: Gen[Byte] = Gen.oneOf(VersionedTransferTransaction.supportedVersions.toSeq)
 
-  property("ScriptTransferTransaction serialization roundtrip") {
+  property("VersionedTransferTransactionSpecification serialization roundtrip") {
     forAll(versionedTransferGen) { tx: VersionedTransferTransaction =>
-      val recovered = VersionedTransferTransaction.parseBytes(tx.bytes().tail).get
+      val recovered = VersionedTransferTransaction.parseBytes(tx.bytes()).get
       assertTxs(recovered, tx)
     }
   }
 
-  property("ScriptTransferTransaction serialization from TypedTransaction") {
+  property("VersionedTransferTransactionSpecification serialization from TypedTransaction") {
     forAll(versionedTransferGen) { tx: VersionedTransferTransaction =>
       val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       assertTxs(recovered.asInstanceOf[VersionedTransferTransaction], tx)
     }
   }
 
-  property("VersionedTransferTransaction id doesn't depend on proof") {
+  property("VersionedTransferTransactionSpecification id doesn't depend on proof") {
     forAll(versionGen, accountGen, accountGen, proofsGen, proofsGen, bytes32gen) {
       case (version, acc1, acc2, proofs1, proofs2, attachment) =>
         val tx1 = VersionedTransferTransaction.create(version, None, acc2, acc2.toAddress, 1, 1, 1, attachment, proofs1).explicitGet()

--- a/src/test/scala/scorex/transaction/VersionedTransferTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/VersionedTransferTransactionSpecification.scala
@@ -2,33 +2,35 @@ package scorex.transaction
 
 import com.wavesplatform.TransactionGen
 import com.wavesplatform.state2._
+import org.scalacheck.Gen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
-import scorex.transaction.TransactionParser.TransactionType
 import scorex.transaction.assets.VersionedTransferTransaction
 
 class VersionedTransferTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
 
+  private val versionGen: Gen[Byte] = Gen.oneOf(VersionedTransferTransaction.supportedVersions.toSeq)
+
   property("ScriptTransferTransaction serialization roundtrip") {
     forAll(versionedTransferGen) { tx: VersionedTransferTransaction =>
-      tx.bytes().head shouldBe TransactionType.VersionedTransferTransaction.id
-      val recovered = VersionedTransferTransaction.parseTail(tx.bytes().tail).get
+      val recovered = VersionedTransferTransaction.parseBytes(tx.bytes().tail).get
       assertTxs(recovered, tx)
     }
   }
 
   property("ScriptTransferTransaction serialization from TypedTransaction") {
     forAll(versionedTransferGen) { tx: VersionedTransferTransaction =>
-      val recovered = TransactionParser.parseBytes(tx.bytes()).get
+      val recovered = TransactionParsers.parseBytes(tx.bytes()).get
       assertTxs(recovered.asInstanceOf[VersionedTransferTransaction], tx)
     }
   }
 
-  property("ScriptTransferTransaction id doesn't depend on proof") {
-    forAll(accountGen, accountGen, proofsGen, proofsGen, bytes32gen) { case (acc1, acc2, proofs1, proofs2, attachment) =>
-      val tx1 = VersionedTransferTransaction.create(2, None, acc2, acc2.toAddress, 1, 1, 1, attachment, proofs1).explicitGet()
-      val tx2 = VersionedTransferTransaction.create(2, None, acc2, acc2.toAddress, 1, 1, 1, attachment, proofs2).explicitGet()
-      tx1.id() shouldBe tx2.id()
+  property("VersionedTransferTransaction id doesn't depend on proof") {
+    forAll(versionGen, accountGen, accountGen, proofsGen, proofsGen, bytes32gen) {
+      case (version, acc1, acc2, proofs1, proofs2, attachment) =>
+        val tx1 = VersionedTransferTransaction.create(version, None, acc2, acc2.toAddress, 1, 1, 1, attachment, proofs1).explicitGet()
+        val tx2 = VersionedTransferTransaction.create(version, None, acc2, acc2.toAddress, 1, 1, 1, attachment, proofs2).explicitGet()
+        tx1.id() shouldBe tx2.id()
     }
   }
 

--- a/src/test/scala/scorex/transaction/api/http/alias/AliasRequestTests.scala
+++ b/src/test/scala/scorex/transaction/api/http/alias/AliasRequestTests.scala
@@ -17,7 +17,7 @@ class AliasRequestTests extends FunSuite with Matchers {
 
     val req = Json.parse(json).validate[CreateAliasRequest].get
 
-    req shouldBe CreateAliasRequest("3Myss6gmMckKYtka3cKCM563TBJofnxvfD7", "ALIAS", 10000000)
+    req shouldBe CreateAliasRequest(None, "3Myss6gmMckKYtka3cKCM563TBJofnxvfD7", "ALIAS", 10000000)
   }
 
   test("SignedCreateAliasRequest") {

--- a/src/test/scala/scorex/transaction/api/http/alias/AliasRequestTests.scala
+++ b/src/test/scala/scorex/transaction/api/http/alias/AliasRequestTests.scala
@@ -17,7 +17,7 @@ class AliasRequestTests extends FunSuite with Matchers {
 
     val req = Json.parse(json).validate[CreateAliasRequest].get
 
-    req shouldBe CreateAliasRequest(None, "3Myss6gmMckKYtka3cKCM563TBJofnxvfD7", "ALIAS", 10000000)
+    req shouldBe CreateAliasRequest("3Myss6gmMckKYtka3cKCM563TBJofnxvfD7", "ALIAS", 10000000)
   }
 
   test("SignedCreateAliasRequest") {

--- a/src/test/scala/tools/GenesisBlockGenerator.scala
+++ b/src/test/scala/tools/GenesisBlockGenerator.scala
@@ -12,7 +12,7 @@ import scorex.account.{Address, AddressScheme, PrivateKeyAccount}
 import scorex.block.Block
 import scorex.consensus.nxt.NxtLikeConsensusBlockData
 import scorex.transaction.GenesisTransaction
-import scorex.transaction.TransactionParser.SignatureLength
+import scorex.transaction.TransactionParsers.SignatureLength
 import scorex.wallet.Wallet
 
 import scala.concurrent.duration._


### PR DESCRIPTION
Sealed traits for transactions with exhaustive matching will be in future. This PR is too big for these changes :)

Support a new transfer in:
- [x] AssetsApiRoute `/ transfer` and tests;
- [x] AssetsBroadcastApiRoute `/ batch-transfer` and tests;
- [x] AssetsBroadcastApiRoute `/ transfer` and tests; 