### PR TITLE
Small fix for sync issue for MinerStateTestSuite

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/MinerStateTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/MinerStateTestSuite.scala
@@ -43,6 +43,9 @@ object MinerStateTestSuite {
   val microblockActivationHeight = 0
   private val minerConfig        = ConfigFactory.parseString(s"""
     |waves {
+    |   synchronization {
+    |      synchronization-timeout = 10s
+    |   }
     |   blockchain {
     |     custom {
     |        functionality {
@@ -66,6 +69,9 @@ object MinerStateTestSuite {
 
   private val notMinerConfig = ConfigFactory.parseString(s"""
     |waves {
+    |   synchronization {
+    |      synchronization-timeout = 10s
+    |   }
     |   blockchain {
     |     custom {
     |        functionality {


### PR DESCRIPTION
Redefined sync timeout for MinerStateTestSuite, just to avoid sync issue between local nodes.