### PR TITLE
NODE-699 Optimize base58 decode/encode funtions

### DIFF
--- a/it/src/main/scala/com/wavesplatform/it/Node.scala
+++ b/it/src/main/scala/com/wavesplatform/it/Node.scala
@@ -9,7 +9,7 @@ import org.asynchttpclient.Dsl.{config => clientConfig, _}
 import org.asynchttpclient._
 import org.slf4j.LoggerFactory
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.utils.LoggerFacade
 
 import scala.concurrent.duration.FiniteDuration

--- a/it/src/main/scala/com/wavesplatform/it/TransferSending.scala
+++ b/it/src/main/scala/com/wavesplatform/it/TransferSending.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.it.api.Transaction
 import org.scalatest.Suite
 import scorex.account.{Address, AddressOrAlias, AddressScheme, PrivateKeyAccount}
 import scorex.api.http.assets.SignedTransferV1Request
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.transfer._
 import scorex.utils.ScorexLogging
 

--- a/it/src/test/scala/com/wavesplatform/it/async/SmartTransactionsConstraintsSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/async/SmartTransactionsConstraintsSuite.scala
@@ -11,7 +11,7 @@ import org.scalatest._
 import play.api.libs.json.{JsNumber, Json}
 import scorex.account.PrivateKeyAccount
 import scorex.api.http.assets.SignedSetScriptRequest
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.smart.SetScriptTransaction
 import scorex.transaction.smart.script.v1.ScriptV1
 

--- a/it/src/test/scala/com/wavesplatform/it/async/matcher/MatcherTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/async/matcher/MatcherTestSuite.scala
@@ -12,7 +12,7 @@ import com.wavesplatform.state.ByteStr
 import org.scalatest.{BeforeAndAfterAll, CancelAfterFailure, FreeSpec, Matchers}
 import scorex.api.http.assets.SignedTransferV1Request
 import scorex.api.http.leasing.{SignedLeaseCancelV1Request, SignedLeaseV1Request}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.assets.exchange.{AssetPair, Order, OrderType}
 import scorex.transaction.lease.{LeaseCancelTransactionV1, LeaseTransactionV1}
 import scorex.transaction.transfer._

--- a/it/src/test/scala/com/wavesplatform/it/async/matcher/MatcherUtils.scala
+++ b/it/src/test/scala/com/wavesplatform/it/async/matcher/MatcherUtils.scala
@@ -8,7 +8,7 @@ import com.wavesplatform.it.api.{AssetBalance, MatcherStatusResponse, OrderBookR
 import com.wavesplatform.it.util._
 import com.wavesplatform.state.ByteStr
 import scorex.account.PrivateKeyAccount
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.assets.exchange.Order
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/it/src/test/scala/com/wavesplatform/it/sync/DataTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/DataTransactionSuite.scala
@@ -8,7 +8,7 @@ import com.wavesplatform.state.{BinaryDataEntry, BooleanDataEntry, ByteStr, Data
 import org.scalatest.{Assertion, Assertions}
 import play.api.libs.json._
 import scorex.api.http.SignedDataRequest
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.DataTransaction
 
 import scala.concurrent.duration._

--- a/it/src/test/scala/com/wavesplatform/it/sync/MassTransferTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/MassTransferTransactionSuite.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.it.util._
 import org.scalatest.CancelAfterFailure
 import play.api.libs.json._
 import scorex.api.http.assets.{MassTransferRequest, SignedMassTransferRequest}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.transfer.MassTransferTransaction.Transfer
 import scorex.transaction.transfer.MassTransferTransaction.MaxTransferCount
 import scorex.transaction.transfer.TransferTransaction.MaxAttachmentSize

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/CustomFeeTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/CustomFeeTransactionSuite.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.state.Sponsorship
 import org.scalatest.CancelAfterFailure
 import scorex.account.PrivateKeyAccount
 import scorex.api.http.assets.SignedIssueV1Request
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.assets.IssueTransactionV1
 
 class CustomFeeTransactionSuite extends BaseTransactionSuite with CancelAfterFailure {

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/SignAndBroadcastApiSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/SignAndBroadcastApiSuite.scala
@@ -9,7 +9,7 @@ import org.asynchttpclient.util.HttpConstants
 import play.api.libs.json._
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
 import scorex.api.http.assets.{SignedTransferV1Request}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.transfer.MassTransferTransaction.Transfer
 
 import scala.util.Random

--- a/lang/jvm/src/main/scala/com/wavesplatform/lang/Global.scala
+++ b/lang/jvm/src/main/scala/com/wavesplatform/lang/Global.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.lang
 
 import com.wavesplatform.lang.v1.BaseGlobal
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.crypto.hash.{Blake2b256, Keccak256, Sha256}
 import scorex.crypto.signatures.{Curve25519, PublicKey, Signature}
 

--- a/lang/jvm/src/main/scala/com/wavesplatform/utils/Base58.scala
+++ b/lang/jvm/src/main/scala/com/wavesplatform/utils/Base58.scala
@@ -1,0 +1,75 @@
+package com.wavesplatform.utils
+
+import java.util.Arrays
+
+import scala.util.Try
+
+object Base58 {
+  import java.nio.charset.StandardCharsets.US_ASCII
+
+  private val Alphabet: Array[Byte] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".getBytes(US_ASCII)
+
+  private val DecodeTable: Array[Byte] = Array(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -1, -1, -1, -1, -1, -1,
+    9, 10, 11, 12, 13, 14, 15, 16, -1, 17, 18, 19, 20, 21, -1, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, -1, -1, -1, -1, -1, -1, 33, 34, 35, 36, 37,
+    38, 39, 40, 41, 42, 43, -1, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57)
+
+  private def toBase58(c: Char): Byte = if (c < DecodeTable.length) DecodeTable(c) else -1
+
+  def encode(bytes: Array[Byte]): String = {
+    val input     = Arrays.copyOf(bytes, bytes.length)
+    val zeroCount = input.takeWhile(_ == 0).length
+
+    var in                  = zeroCount
+    var out                 = input.length * 2
+    val output: Array[Byte] = new Array[Byte](out)
+    while (in < input.length) {
+      val mod = convert(input, in, 256, 58)
+      if (input(in) == 0) in += 1
+      out -= 1
+      output(out) = Alphabet(mod)
+    }
+
+    while (out < output.length && output(out) == Alphabet(0)) out += 1
+    for (i <- 0 until zeroCount) {
+      out -= 1
+      output(out) = Alphabet(0)
+    }
+
+    new String(output, out, output.length - out, US_ASCII)
+  }
+
+  def decode(string: String): Try[Array[Byte]] = Try {
+    val input: Array[Byte] = new Array[Byte](string.length)
+    for (i <- 0 until string.length)
+      input(i) = toBase58(string(i)).ensuring(_ != -1, "Wrong char in Base58 string")
+
+    val zeroCount = input.takeWhile(_ == 0).length
+
+    var in     = zeroCount
+    var out    = input.length
+    val output = new Array[Byte](out)
+    while (in < input.length) {
+      val mod = convert(input, in, 58, 256)
+      if (input(in) == 0) in += 1
+      out -= 1
+      output(out) = mod
+    }
+
+    while (out < output.length && output(out) == 0) out += 1
+    Arrays.copyOfRange(output, out - zeroCount, output.length)
+  }
+
+  private def convert(number: Array[Byte], offset: Int, from: Int, to: Int): Byte = {
+    var rem = 0
+    var i   = offset
+    while (i < number.length) {
+      val digit = number(i) & 0xff
+      val tmp   = rem * from + digit
+      number(i) = (tmp / to).toByte
+      rem = tmp % to
+      i += 1
+    }
+    rem.toByte
+  }
+}

--- a/lang/jvm/src/test/scala/com/wavesplatform/utils/Base58Test.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/utils/Base58Test.scala
@@ -1,0 +1,51 @@
+package com.wavesplatform.utils
+
+import org.scalacheck.Gen
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.PropertyChecks
+import scorex.crypto.encode.{Base58 => scorexBase58}
+
+class Base58Test extends PropSpec with PropertyChecks with Matchers {
+
+  private val Base58Chars  = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+  private val IllegalChars = "+/=-_0lIO"
+
+  val base58Gen: Gen[String] =
+    for {
+      length <- Gen.chooseNum(20, 100)
+      chars  <- Gen.listOfN(length, Gen.oneOf(Base58Chars))
+    } yield chars.mkString
+
+  val nonBase58Gen: Gen[String] =
+    for {
+      length <- Gen.chooseNum(20, 100)
+      chars <- Gen
+        .listOfN(length, Gen.oneOf(Base58Chars ++ IllegalChars))
+        .filter(_.toSet.intersect(IllegalChars.toSet).nonEmpty)
+    } yield chars.mkString
+
+  property("works the same as scorex implementation") {
+    forAll(base58Gen) { s =>
+      val bytes       = Base58.decode(s).get
+      val scorexBytes = scorexBase58.decode(s).get
+      bytes.sameElements(scorexBytes) shouldBe true
+
+      val str       = Base58.encode(bytes)
+      val scorexStr = scorexBase58.encode(bytes)
+      str shouldBe scorexStr
+    }
+  }
+
+  property("handles empty sequences") {
+    Base58.encode(Array.emptyByteArray) shouldBe ""
+    val d = Base58.decode("")
+    d.isSuccess shouldBe true
+    d.get.length shouldBe 0
+  }
+
+  property("decoding fails on illegal characters") {
+    forAll(nonBase58Gen) { s =>
+      Base58.decode(s).isSuccess shouldBe false
+    }
+  }
+}

--- a/src/main/scala/com/wavesplatform/Explorer.scala
+++ b/src/main/scala/com/wavesplatform/Explorer.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.settings.{WavesSettings, loadConfig}
 import com.wavesplatform.state.ByteStr
 import org.slf4j.bridge.SLF4JBridgeHandler
 import scorex.account.{Address, AddressScheme}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.utils.ScorexLogging
 
 import scala.util.Try

--- a/src/main/scala/com/wavesplatform/matcher/api/CancelOrderRequest.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/CancelOrderRequest.scala
@@ -6,7 +6,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json.{JsObject, JsPath, Json, Reads}
 import scorex.account.PublicKeyAccount
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.assets.exchange.OrderJson._
 
 case class CancelOrderRequest(@ApiModelProperty(dataType = "java.lang.String") senderPublicKey: PublicKeyAccount,

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -19,7 +19,7 @@ import io.swagger.annotations._
 import play.api.libs.json._
 import scorex.account.PublicKeyAccount
 import scorex.api.http._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.assets.exchange.OrderJson._
 import scorex.transaction.assets.exchange.{AssetPair, Order}
 import scorex.utils.NTP

--- a/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
@@ -15,7 +15,7 @@ import com.wavesplatform.utx.UtxPool
 import io.netty.channel.group.ChannelGroup
 import play.api.libs.json._
 import scorex.account.Address
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.AssetId
 import scorex.transaction.assets.exchange.Validation.booleanOperators
 import scorex.transaction.assets.exchange.{AssetPair, Order, Validation}

--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -17,7 +17,7 @@ import com.wavesplatform.state.Blockchain
 import com.wavesplatform.utx.UtxPool
 import io.netty.channel.group.ChannelGroup
 import play.api.libs.json._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.ValidationError
 import scorex.transaction.ValidationError.{AccountBalanceError, GenericError, OrderValidationError}
 import scorex.transaction.assets.exchange._

--- a/src/main/scala/com/wavesplatform/network/Checkpoint.scala
+++ b/src/main/scala/com/wavesplatform/network/Checkpoint.scala
@@ -3,7 +3,7 @@ package com.wavesplatform.network
 import com.google.common.primitives.{Bytes, Ints}
 import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.crypto.signatures.Curve25519.SignatureLength
 
 import scala.collection.immutable.Stream

--- a/src/main/scala/com/wavesplatform/state/ByteStr.scala
+++ b/src/main/scala/com/wavesplatform/state/ByteStr.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.state
 
 import play.api.libs.json._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 import scala.util.Try
 

--- a/src/main/scala/com/wavesplatform/state/DataEntry.scala
+++ b/src/main/scala/com/wavesplatform/state/DataEntry.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import com.google.common.primitives.{Longs, Shorts}
 import com.wavesplatform.state.DataEntry._
 import play.api.libs.json._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.serialization.Deser
 
 import scala.util.Success

--- a/src/main/scala/scorex/account/Address.scala
+++ b/src/main/scala/scorex/account/Address.scala
@@ -3,7 +3,7 @@ package scorex.account
 import com.wavesplatform.crypto
 import com.wavesplatform.state.ByteStr
 import com.wavesplatform.utils.base58Length
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.ValidationError
 import scorex.transaction.ValidationError.InvalidAddress
 import scorex.utils.ScorexLogging

--- a/src/main/scala/scorex/account/PrivateKeyAccount.scala
+++ b/src/main/scala/scorex/account/PrivateKeyAccount.scala
@@ -1,7 +1,7 @@
 package scorex.account
 
 import com.wavesplatform.crypto
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.ValidationError.GenericError
 
 import scala.util.{Failure, Success}

--- a/src/main/scala/scorex/account/PublicKeyAccount.scala
+++ b/src/main/scala/scorex/account/PublicKeyAccount.scala
@@ -1,7 +1,7 @@
 package scorex.account
 
 import com.wavesplatform.utils.base58Length
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.crypto.signatures.Curve25519
 import scorex.transaction.ValidationError.InvalidAddress
 

--- a/src/main/scala/scorex/api/http/AddressApiRoute.scala
+++ b/src/main/scala/scorex/api/http/AddressApiRoute.scala
@@ -15,7 +15,7 @@ import javax.ws.rs.Path
 import play.api.libs.json._
 import scorex.BroadcastRoute
 import scorex.account.{Address, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction.smart.script.ScriptCompiler
 import scorex.transaction.{PoSCalc, TransactionFactory, ValidationError}

--- a/src/main/scala/scorex/api/http/ApiRoute.scala
+++ b/src/main/scala/scorex/api/http/ApiRoute.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.crypto
 import com.wavesplatform.http.{ApiMarshallers, PlayJsonException, api_key, deprecated_api_key}
 import com.wavesplatform.settings.RestAPISettings
 import play.api.libs.json.Reads
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 trait ApiRoute extends Directives with CommonApiFunctions with ApiMarshallers {
   val settings: RestAPISettings

--- a/src/main/scala/scorex/api/http/UtilsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/UtilsApiRoute.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.state.diffs.CommonValidation
 import io.swagger.annotations._
 import javax.ws.rs.Path
 import play.api.libs.json.Json
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.smart.script.{Script, ScriptCompiler}
 import scorex.utils.Time
 

--- a/src/main/scala/scorex/api/http/WalletApiRoute.scala
+++ b/src/main/scala/scorex/api/http/WalletApiRoute.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server.Route
 import com.wavesplatform.settings.RestAPISettings
 import io.swagger.annotations._
 import play.api.libs.json.Json
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.wallet.Wallet
 
 @Path("/wallet")

--- a/src/main/scala/scorex/api/http/assets/AssetsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/assets/AssetsApiRoute.scala
@@ -13,7 +13,7 @@ import play.api.libs.json._
 import scorex.BroadcastRoute
 import scorex.account.Address
 import scorex.api.http._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.assets.IssueTransaction
 import scorex.transaction.assets.exchange.Order
 import scorex.transaction.assets.exchange.OrderJson._

--- a/src/main/scala/scorex/block/BlockField.scala
+++ b/src/main/scala/scorex/block/BlockField.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.state.ByteStr
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.PublicKeyAccount
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.serialization.{BytesSerializable, JsonSerializable}
 import scorex.transaction.Transaction
 

--- a/src/main/scala/scorex/transaction/FeeCalculator.scala
+++ b/src/main/scala/scorex/transaction/FeeCalculator.scala
@@ -14,7 +14,7 @@ class FeeCalculator(settings: FeesSettings, blockchain: Blockchain) {
     settings.fees.flatMap { fs =>
       val transactionType = fs._1
       fs._2.map { v =>
-        val maybeAsset = if (v.asset.toUpperCase == "WAVES") None else ByteStr.decodeBase58(v.asset).toOption
+        val maybeAsset = if (v.asset.toUpperCase == "WAVES") None else Some(ByteStr.decodeBase58(v.asset).get)
         val fee        = v.fee
 
         TransactionAssetFee(transactionType, maybeAsset).key -> fee

--- a/src/main/scala/scorex/transaction/Proofs.scala
+++ b/src/main/scala/scorex/transaction/Proofs.scala
@@ -3,7 +3,7 @@ package scorex.transaction
 import com.wavesplatform.state._
 import com.wavesplatform.utils.base58Length
 import monix.eval.Coeval
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.serialization.Deser
 import scorex.transaction.ValidationError.GenericError
 

--- a/src/main/scala/scorex/transaction/ProvenTransaction.scala
+++ b/src/main/scala/scorex/transaction/ProvenTransaction.scala
@@ -2,7 +2,7 @@ package scorex.transaction
 
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 trait ProvenTransaction extends Transaction with Proven {
 

--- a/src/main/scala/scorex/transaction/TransactionFactory.scala
+++ b/src/main/scala/scorex/transaction/TransactionFactory.scala
@@ -7,7 +7,7 @@ import scorex.api.http.DataRequest
 import scorex.api.http.alias.{CreateAliasV1Request, CreateAliasV2Request}
 import scorex.api.http.assets._
 import scorex.api.http.leasing.{LeaseCancelV1Request, LeaseCancelV2Request, LeaseV1Request, LeaseV2Request}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction.assets._
 import scorex.transaction.lease.{LeaseCancelTransactionV1, LeaseCancelTransactionV2, LeaseTransactionV1, LeaseTransactionV2}

--- a/src/main/scala/scorex/transaction/assets/exchange/Order.scala
+++ b/src/main/scala/scorex/transaction/assets/exchange/Order.scala
@@ -7,7 +7,7 @@ import io.swagger.annotations.ApiModelProperty
 import monix.eval.{Coeval, Task}
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.crypto.signatures.Curve25519.{KeyLength, SignatureLength}
 import scorex.serialization.{BytesSerializable, Deser, JsonSerializable}
 import scorex.transaction.ValidationError.{GenericError, InvalidSignature}

--- a/src/main/scala/scorex/transaction/assets/exchange/OrderJson.scala
+++ b/src/main/scala/scorex/transaction/assets/exchange/OrderJson.scala
@@ -3,7 +3,7 @@ package scorex.transaction.assets.exchange
 import com.wavesplatform.state.ByteStr
 import play.api.libs.json._
 import scorex.account.PublicKeyAccount
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 import scala.util.{Failure, Success}
 

--- a/src/main/scala/scorex/transaction/smart/script/Script.scala
+++ b/src/main/scala/scorex/transaction/smart/script/Script.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.lang.Versioned
 import com.wavesplatform.lang.v1.compiler.Terms
 import com.wavesplatform.state.ByteStr
 import monix.eval.Coeval
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.ValidationError.ScriptParseError
 
 trait Script extends Versioned {

--- a/src/main/scala/scorex/transaction/transfer/MassTransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/transfer/MassTransferTransaction.scala
@@ -7,7 +7,7 @@ import com.wavesplatform.state._
 import monix.eval.Coeval
 import play.api.libs.json.{Format, JsObject, JsValue, Json}
 import scorex.account.{AddressOrAlias, PrivateKeyAccount, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.crypto.signatures.Curve25519.KeyLength
 import scorex.serialization.Deser
 import scorex.transaction.ValidationError.Validation

--- a/src/main/scala/scorex/transaction/transfer/TransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/transfer/TransferTransaction.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.utils.base58Length
 import monix.eval.Coeval
 import play.api.libs.json.{JsObject, Json}
 import scorex.account.{AddressOrAlias, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.crypto.signatures.Curve25519.KeyLength
 import scorex.serialization.Deser
 import scorex.transaction._

--- a/src/main/scala/scorex/waves/http/DebugApiRoute.scala
+++ b/src/main/scala/scorex/waves/http/DebugApiRoute.scala
@@ -23,7 +23,7 @@ import scorex.account.Address
 import scorex.api.http._
 import scorex.block.Block
 import scorex.block.Block.BlockId
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction._
 import scorex.utils.ScorexLogging
 import scorex.wallet.Wallet

--- a/src/test/scala/com/wavesplatform/RequestGen.scala
+++ b/src/test/scala/com/wavesplatform/RequestGen.scala
@@ -7,7 +7,7 @@ import scorex.account.Alias
 import scorex.api.http.alias.SignedCreateAliasV1Request
 import scorex.api.http.assets._
 import scorex.api.http.leasing.{SignedLeaseCancelV1Request, SignedLeaseV1Request}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.crypto.signatures.Curve25519.SignatureLength
 import scorex.transaction.assets._
 import scorex.transaction.transfer._

--- a/src/test/scala/com/wavesplatform/http/AddressRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AddressRouteSpec.scala
@@ -4,6 +4,7 @@ import com.wavesplatform.http.ApiMarshallers._
 import com.wavesplatform.lang.v1.compiler.Terms._
 import com.wavesplatform.state.diffs.CommonValidation
 import com.wavesplatform.state.{Blockchain, EitherExt2}
+import com.wavesplatform.utils.Base58
 import com.wavesplatform.utx.UtxPool
 import com.wavesplatform.{NoShrink, TestTime, TestWallet, crypto}
 import io.netty.channel.group.ChannelGroup
@@ -12,8 +13,7 @@ import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json._
 import scorex.account.Address
-import scorex.api.http.{AddressApiRoute, ApiKeyNotValid, InvalidMessage}
-import scorex.crypto.encode.Base58
+import scorex.api.http.{AddressApiRoute, ApiKeyNotValid}
 import scorex.settings.TestFunctionalitySettings
 import scorex.transaction.smart.script.v1.ScriptV1
 
@@ -122,7 +122,9 @@ class AddressRouteSpec
           Json.obj("message" -> JsString(""), "publickey" -> JsString(Base58.encode(account.publicKey)), "signature" -> JsString(""))
 
         Post(uri, validBody) ~> route should produce(ApiKeyNotValid)
-        Post(uri, emptySignature) ~> api_key(apiKey) ~> route should produce(InvalidMessage)
+        Post(uri, emptySignature) ~> api_key(apiKey) ~> route ~> check {
+          (responseAs[JsObject] \ "valid").as[Boolean] shouldBe false
+        }
         Post(uri, validBody) ~> api_key(apiKey) ~> route ~> check {
           (responseAs[JsObject] \ "valid").as[Boolean] shouldBe true
         }

--- a/src/test/scala/com/wavesplatform/http/AssetsBroadcastRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AssetsBroadcastRouteSpec.scala
@@ -16,7 +16,7 @@ import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.{JsObject, JsValue, Json, Writes}
 import scorex.api.http._
 import scorex.api.http.assets._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction.transfer._
 import scorex.transaction.{Proofs, Transaction, ValidationError}

--- a/src/test/scala/com/wavesplatform/http/RestAPISettingsHelper.scala
+++ b/src/test/scala/com/wavesplatform/http/RestAPISettingsHelper.scala
@@ -3,7 +3,7 @@ package com.wavesplatform.http
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.crypto
 import com.wavesplatform.settings.RestAPISettings
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 trait RestAPISettingsHelper {
   def apiKey: String = "test_api_key"

--- a/src/test/scala/com/wavesplatform/http/TransactionsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/TransactionsRouteSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.Matchers
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json._
 import scorex.api.http.{InvalidAddress, InvalidSignature, TooBigArrayAllocation, TransactionsApiRoute}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.wallet.Wallet
 
 class TransactionsRouteSpec

--- a/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.{JsObject, JsValue}
 import scorex.api.http.{TooBigArrayAllocation, UtilsApiRoute}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.smart.script.Script
 import scorex.transaction.smart.script.v1.ScriptV1
 import scorex.utils.Time

--- a/src/test/scala/com/wavesplatform/http/WalletRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/WalletRouteSpec.scala
@@ -4,7 +4,7 @@ import com.wavesplatform.TestWallet
 import com.wavesplatform.http.ApiMarshallers._
 import play.api.libs.json.JsObject
 import scorex.api.http.{ApiKeyNotValid, WalletApiRoute}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 class WalletRouteSpec extends RouteSpec("/wallet") with RestAPISettingsHelper with TestWallet {
   private val route = WalletApiRoute(restAPISettings, testWallet).route

--- a/src/test/scala/com/wavesplatform/http/package.scala
+++ b/src/test/scala/com/wavesplatform/http/package.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.{HavePropertyMatchResult, HavePropertyMatcher}
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import scorex.account.{AddressOrAlias, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.{AssetId, Proofs}
 import scorex.transaction.transfer._
 import shapeless.{:+:, CNil, Coproduct}

--- a/src/test/scala/com/wavesplatform/state/diffs/SponsorshipDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/SponsorshipDiffTest.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.features.BlockchainFeatures
 import com.wavesplatform.state._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.lagonaki.mocks.TestBlock.{create => block}
 import scorex.settings.TestFunctionalitySettings
 import scorex.transaction.GenesisTransaction

--- a/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
+++ b/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
@@ -40,7 +40,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
       TransferTransactionV1,
       MassTransferTransaction,
       SetScriptTransaction
-    ).map(_.typeId.toInt -> List(FeeSettings("", 0))).toMap
+    ).map(_.typeId.toInt -> List(FeeSettings("WAVES", 0))).toMap
   )
   import CommonValidation.{ScriptExtraFee => extraFee}
 

--- a/src/test/scala/scorex/account/AccountSpecification.scala
+++ b/src/test/scala/scorex/account/AccountSpecification.scala
@@ -3,7 +3,7 @@ package scorex.account
 import com.wavesplatform.crypto
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 class AccountSpecification extends PropSpec with PropertyChecks with Matchers {
 

--- a/src/test/scala/scorex/transaction/DataTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/DataTransactionSpecification.scala
@@ -9,7 +9,7 @@ import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.{Format, Json}
 import scorex.api.http.SignedDataRequest
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.DataTransaction.MaxEntryCount
 
 class DataTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {

--- a/src/test/scala/scorex/transaction/GenesisTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/GenesisTransactionSpecification.scala
@@ -4,7 +4,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 class GenesisTransactionSpecification extends PropSpec with PropertyChecks with Matchers {
 

--- a/src/test/scala/scorex/transaction/api/http/assets/SignedRequestsTest.scala
+++ b/src/test/scala/scorex/transaction/api/http/assets/SignedRequestsTest.scala
@@ -3,7 +3,7 @@ package scorex.transaction.api.http.assets
 import org.scalatest.{FunSuite, Matchers}
 import play.api.libs.json.Json
 import scorex.api.http.assets._
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 
 class SignedRequestsTest extends FunSuite with Matchers {
 

--- a/src/test/scala/scorex/transaction/assets/exchange/OrderJsonSpecification.scala
+++ b/src/test/scala/scorex/transaction/assets/exchange/OrderJsonSpecification.scala
@@ -6,7 +6,7 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import play.api.libs.json._
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
-import scorex.crypto.encode.Base58
+import com.wavesplatform.utils.Base58
 import scorex.transaction.assets.exchange.OrderJson._
 
 class OrderJsonSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-699

Replaced Scorex implementation with one that is about twice as fast on short (32-64 byte) arrays.

Most of changes is to import statements, the real ones are
 lang/jvm/src/main/scala/com/wavesplatform/utils/Base58.scala and
 lang/jvm/src/test/scala/com/wavesplatform/utils/Base58Test.scala