### PR TITLE
NODE-745 Parser provides offsets

### DIFF
--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/IntegrationTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/IntegrationTest.scala
@@ -79,8 +79,8 @@ class IntegrationTest extends PropSpec with PropertyChecks with ScriptGen with M
   }
 
   property("equals some lang structure") {
-    eval[Boolean]("let x = (-7763390488025868909>-1171895536391400041) let v = false (v&&true)") shouldBe Right(false)
-    eval[Boolean]("let mshUmcl = (if(true) then true else true) true || mshUmcl") shouldBe Right(true)
+    eval[Boolean]("let x = (-7763390488025868909>-1171895536391400041); let v = false; (v&&true)") shouldBe Right(false)
+    eval[Boolean]("let mshUmcl = (if(true) then true else true); true || mshUmcl") shouldBe Right(true)
     eval[Long]("""if(((1+-1)==-1)) then 1 else (1+1)""") shouldBe Right(2)
     eval[Boolean]("""((((if(true) then 1 else 1)==2)||((if(true)
                     |then true else true)&&(true||true)))||(if(((1>1)||(-1>=-1)))
@@ -94,7 +94,9 @@ class IntegrationTest extends PropSpec with PropertyChecks with ScriptGen with M
         str         <- toString(expr)
       } yield (str, res)) {
         case (str, res) =>
-          eval[Long](str) shouldBe Right(res)
+          withClue(str) {
+            eval[Long](str) shouldBe Right(res)
+          }
     })
 
     forAll(for {
@@ -102,7 +104,9 @@ class IntegrationTest extends PropSpec with PropertyChecks with ScriptGen with M
       str         <- toString(expr)
     } yield (str, res)) {
       case (str, res) =>
-        eval[Boolean](str) shouldBe Right(res)
+        withClue(str) {
+          eval[Boolean](str) shouldBe Right(res)
+        }
     }
   }
 

--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
@@ -66,7 +66,7 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
     case x: IF               => x.copy(start = 0, end = 0, cond = cleanOffsets(x.cond), ifTrue = cleanOffsets(x.ifTrue), ifFalse = cleanOffsets(x.ifFalse))
     case x: BLOCK            => x.copy(start = 0, end = 0, let = cleanOffsets(x.let), body = cleanOffsets(x.body))
     case x: FUNCTION_CALL    => x.copy(start = 0, end = 0, name = cleanOffsets(x.name), args = x.args.map(cleanOffsets(_)))
-    case _                   => ???
+    case _                   => throw new NotImplementedError(s"toString for ${expr.getClass.getSimpleName}")
   }
 
   private def genElementCheck(gen: Gen[EXPR]): Unit = {

--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
@@ -470,6 +470,59 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
     )
   }
 
+  property("multiple getters") {
+    parseOne("x.y.z") shouldBe GETTER(0, 5, GETTER(0, 3, REF(0, 1, PART.VALID(0, 1, "x")), PART.VALID(2, 3, "y")), PART.VALID(4, 5, "z"))
+  }
+
+  property("array accessor") {
+    parseOne("x[0]") shouldBe FUNCTION_CALL(0, 4, PART.VALID(1, 4, "getElement"), List(REF(0, 1, PART.VALID(0, 1, "x")), CONST_LONG(2, 3, 0)))
+  }
+
+  property("multiple array accessors") {
+    parseOne("x[0][1]") shouldBe FUNCTION_CALL(
+      0,
+      7,
+      PART.VALID(4, 7, "getElement"),
+      List(
+        FUNCTION_CALL(0, 4, PART.VALID(1, 4, "getElement"), List(REF(0, 1, PART.VALID(0, 1, "x")), CONST_LONG(2, 3, 0))),
+        CONST_LONG(5, 6, 1)
+      )
+    )
+  }
+
+  property("accessor and getter") {
+    parseOne("x[0].y") shouldBe GETTER(
+      0,
+      6,
+      FUNCTION_CALL(0, 4, PART.VALID(1, 4, "getElement"), List(REF(0, 1, PART.VALID(0, 1, "x")), CONST_LONG(2, 3, 0))),
+      PART.VALID(5, 6, "y")
+    )
+  }
+
+  property("getter and accessor") {
+    parseOne("x.y[0]") shouldBe FUNCTION_CALL(
+      0,
+      6,
+      PART.VALID(3, 6, "getElement"),
+      List(
+        GETTER(0, 3, REF(0, 1, PART.VALID(0, 1, "x")), PART.VALID(2, 3, "y")),
+        CONST_LONG(4, 5, 0)
+      )
+    )
+  }
+
+  property("function call and accessor") {
+    parseOne("x(y)[0]") shouldBe FUNCTION_CALL(
+      0,
+      7,
+      PART.VALID(4, 7, "getElement"),
+      List(
+        FUNCTION_CALL(0, 4, PART.VALID(0, 1, "x"), List(REF(2, 3, PART.VALID(2, 3, "y")))),
+        CONST_LONG(5, 6, 0)
+      )
+    )
+  }
+
   property("braces in block's let and body") {
     val text =
       """let a = (foo)
@@ -481,8 +534,6 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
       REF(15, 18, PART.VALID(15, 18, "bar"))
     )
   }
-
-  // @TODO multiple getters test
 
   property("crypto functions: sha256") {
     val text        = "❤✓☀★☂♞☯☭☢€☎∞❄♫\u20BD=test message"

--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
@@ -38,11 +38,6 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
       throw new TestFailedException("Test failed", 0)
   }
 
-  private def isParsed(x: String): Boolean = Parser(x) match {
-    case Success(_, _)    => true
-    case Failure(_, _, _) => false
-  }
-
   private def genElementCheck(gen: Gen[EXPR]): Unit = {
     val testGen: Gen[(EXPR, String)] = for {
       expr <- gen
@@ -81,46 +76,62 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
   )
 
   property("priority in binary expressions") {
-    parseOne("1 == 0 || 3 == 2") shouldBe BINARY_OP(BINARY_OP(CONST_LONG(1), EQ_OP, CONST_LONG(0)),
-                                                    OR_OP,
-                                                    BINARY_OP(CONST_LONG(3), EQ_OP, CONST_LONG(2)))
-    parseOne("3 + 2 > 2 + 1") shouldBe BINARY_OP(BINARY_OP(CONST_LONG(3), SUM_OP, CONST_LONG(2)),
-                                                 GT_OP,
-                                                 BINARY_OP(CONST_LONG(2), SUM_OP, CONST_LONG(1)))
-    parseOne("1 >= 0 || 3 > 2") shouldBe BINARY_OP(BINARY_OP(CONST_LONG(1), GE_OP, CONST_LONG(0)),
-                                                   OR_OP,
-                                                   BINARY_OP(CONST_LONG(3), GT_OP, CONST_LONG(2)))
+    parseOne("1 == 0 || 3 == 2") shouldBe BINARY_OP(
+      0,
+      16,
+      BINARY_OP(0, 6, CONST_LONG(0, 1, 1), EQ_OP, CONST_LONG(5, 6, 0)),
+      OR_OP,
+      BINARY_OP(10, 16, CONST_LONG(10, 11, 3), EQ_OP, CONST_LONG(15, 16, 2))
+    )
+    parseOne("3 + 2 > 2 + 1") shouldBe BINARY_OP(
+      0,
+      13,
+      BINARY_OP(0, 5, CONST_LONG(0, 1, 3), SUM_OP, CONST_LONG(4, 5, 2)),
+      GT_OP,
+      BINARY_OP(8, 13, CONST_LONG(8, 9, 2), SUM_OP, CONST_LONG(12, 13, 1))
+    )
+    parseOne("1 >= 0 || 3 > 2") shouldBe BINARY_OP(
+      0,
+      15,
+      BINARY_OP(0, 6, CONST_LONG(0, 1, 1), GE_OP, CONST_LONG(5, 6, 0)),
+      OR_OP,
+      BINARY_OP(10, 15, CONST_LONG(10, 11, 3), GT_OP, CONST_LONG(14, 15, 2))
+    )
   }
 
   property("bytestr expressions") {
     parseOne("false || sigVerify(base58'333', base58'222', base58'111')") shouldBe BINARY_OP(
-      FALSE,
+      0,
+      57,
+      FALSE(0, 5),
       OR_OP,
       FUNCTION_CALL(
-        "sigVerify",
+        9,
+        57,
+        PART.VALID(9, 18, "sigVerify"),
         List(
-          CONST_BYTEVECTOR(ByteVector(ScorexBase58.decode("333").get)),
-          CONST_BYTEVECTOR(ByteVector(ScorexBase58.decode("222").get)),
-          CONST_BYTEVECTOR(ByteVector(ScorexBase58.decode("111").get))
+          CONST_BYTEVECTOR(19, 30, PART.VALID(27, 29, ByteVector(ScorexBase58.decode("333").get))),
+          CONST_BYTEVECTOR(32, 43, PART.VALID(40, 42, ByteVector(ScorexBase58.decode("222").get))),
+          CONST_BYTEVECTOR(45, 56, PART.VALID(53, 55, ByteVector(ScorexBase58.decode("111").get)))
         )
       )
     )
   }
 
   property("valid non-empty base58 definition") {
-    parseOne("base58'bQbp'") shouldBe CONST_BYTEVECTOR(ByteVector("foo".getBytes))
+    parseOne("base58'bQbp'") shouldBe CONST_BYTEVECTOR(0, 12, PART.VALID(8, 11, ByteVector("foo".getBytes)))
   }
 
   property("valid empty base58 definition") {
-    parseOne("base58''") shouldBe CONST_BYTEVECTOR(ByteVector.empty)
+    parseOne("base58''") shouldBe CONST_BYTEVECTOR(0, 8, PART.VALID(8, 7, ByteVector.empty))
   }
 
   property("invalid base58 definition") {
-    parseOne("base58' bQbp'") shouldBe CONST_BYTEVECTOR(PART.INVALID(" bQbp", "Can't parse Base58 string"))
+    parseOne("base58' bQbp'") shouldBe CONST_BYTEVECTOR(0, 13, PART.INVALID(8, 12, "can't parse Base58 string"))
   }
 
   property("string is consumed fully") {
-    parseOne(""" "   fooo    bar" """) shouldBe CONST_STRING("   fooo    bar")
+    parseOne(""" "   fooo    bar" """) shouldBe CONST_STRING(1, 17, PART.VALID(2, 16, "   fooo    bar"))
   }
 
   property("string literal with unicode chars") {
@@ -132,47 +143,120 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
          | "$stringWithUnicodeChars"
          |
        """.stripMargin
-    ) shouldBe CONST_STRING(stringWithUnicodeChars)
+    ) shouldBe CONST_STRING(3, 20, PART.VALID(4, 19, stringWithUnicodeChars))
   }
 
   property("string literal with unicode chars in language") {
-    parseOne("\"\\u1234\"") shouldBe CONST_STRING("ሴ")
+    parseOne("\"\\u1234\"") shouldBe CONST_STRING(0, 8, PART.VALID(1, 7, "ሴ"))
   }
 
   property("should parse invalid unicode symbols") {
-    parseOne("\"\\uqwer\"") shouldBe CONST_STRING(PART.INVALID("\\uqwer", "Can't parse 'qwer' as HEX string in '\\uqwer'"))
+    parseOne("\"\\uqwer\"") shouldBe CONST_STRING(
+      0,
+      8,
+      PART.INVALID(1, 7, "can't parse 'qwer' as HEX string in '\\uqwer'")
+    )
   }
 
   property("should parse incomplete unicode symbol definition") {
-    parseOne("\"\\u12 test\"") shouldBe CONST_STRING(PART.INVALID("\\u12 test", "Incomplete UTF-8 symbol definition: '\\u12'"))
-    parseOne("\"\\u\"") shouldBe CONST_STRING(PART.INVALID("\\u", "Incomplete UTF-8 symbol definition: '\\u'"))
+    parseOne("\"\\u12 test\"") shouldBe CONST_STRING(0, 11, PART.INVALID(1, 10, "incomplete UTF-8 symbol definition: '\\u12'"))
+    parseOne("\"\\u\"") shouldBe CONST_STRING(0, 4, PART.INVALID(1, 3, "incomplete UTF-8 symbol definition: '\\u'"))
   }
 
   property("string literal with special symbols") {
-    parseOne("\"\\t\"") shouldBe CONST_STRING("\t")
+    parseOne("\"\\t\"") shouldBe CONST_STRING(0, 4, PART.VALID(1, 3, "\t"))
   }
 
   property("should parse invalid special symbols") {
-    parseOne("\"\\ test\"") shouldBe CONST_STRING(PART.INVALID("\\ test", "Unknown escaped symbol: '\\ '"))
+    parseOne("\"\\ test\"") shouldBe CONST_STRING(0, 8, PART.INVALID(1, 7, "unknown escaped symbol: '\\ '. The valid are \b, \f, \n, \r, \t"))
   }
 
   property("should parse incomplete special symbols") {
-    parseOne("\"foo \\\"") shouldBe CONST_STRING(PART.INVALID("foo \\", "Invalid escaped symbol: '\\'"))
+    parseOne("\"foo \\\"") shouldBe CONST_STRING(0, 7, PART.INVALID(1, 6, "invalid escaped symbol: '\\'. The valid are \b, \f, \n, \r, \t"))
   }
 
-  property("reserved keywords are invalid variable names") {
-    List("if", "then", "else", "true", "false", "let").foreach { keyword =>
-      val script = s"""let $keyword = 1
-                      |true""".stripMargin
+  property("reserved keywords are invalid variable names in block: if") {
+    val script =
+      s"""let if = 1
+         |true""".stripMargin
+    parseOne(script) shouldBe BLOCK(
+      0,
+      15,
+      LET(0, 10, PART.INVALID(4, 6, "keywords are restricted"), CONST_LONG(9, 10, 1), Seq.empty),
+      TRUE(11, 15)
+    )
+  }
+
+  property("reserved keywords are invalid variable names in block: let") {
+    val script =
+      s"""let let = 1
+         |true""".stripMargin
+    parseOne(script) shouldBe BLOCK(
+      0,
+      16,
+      LET(0, 11, PART.INVALID(4, 7, "keywords are restricted"), CONST_LONG(10, 11, 1), Seq.empty),
+      TRUE(12, 16)
+    )
+  }
+
+  List("then", "else", "true").foreach { keyword =>
+    property(s"reserved keywords are invalid variable names in block: $keyword") {
+      val script =
+        s"""let ${keyword.padTo(4, " ").mkString} = 1
+           |true""".stripMargin
       parseOne(script) shouldBe BLOCK(
-        LET(PART.INVALID(keyword, "keywords are restricted"), CONST_LONG(1), Seq.empty),
-        TRUE
+        0,
+        17,
+        LET(0, 12, PART.INVALID(4, 8, "keywords are restricted"), CONST_LONG(11, 12, 1), Seq.empty),
+        TRUE(13, 17)
       )
     }
+  }
 
-    List("if", "then", "else", "let").foreach { keyword =>
+  property("reserved keywords are invalid variable names in block: false") {
+    val script =
+      s"""let false = 1
+         |true""".stripMargin
+    parseOne(script) shouldBe BLOCK(
+      0,
+      18,
+      LET(0, 13, PART.INVALID(4, 9, "keywords are restricted"), CONST_LONG(12, 13, 1), Seq.empty),
+      TRUE(14, 18)
+    )
+  }
+
+  property("reserved keywords are invalid variable names in expr: if") {
+    val script = "if + 1"
+    parseOne(script) shouldBe BINARY_OP(
+      0,
+      6,
+      REF(0, 2, PART.INVALID(0, 2, "keywords are restricted")),
+      BinaryOperation.SUM_OP,
+      CONST_LONG(5, 6, 1)
+    )
+  }
+
+  property("reserved keywords are invalid variable names in expr: let") {
+    val script = "let + 1"
+    parseOne(script) shouldBe BINARY_OP(
+      0,
+      7,
+      REF(0, 3, PART.INVALID(0, 3, "keywords are restricted")),
+      BinaryOperation.SUM_OP,
+      CONST_LONG(6, 7, 1)
+    )
+  }
+
+  List("then", "else").foreach { keyword =>
+    property(s"reserved keywords are invalid variable names in expr: $keyword") {
       val script = s"$keyword + 1"
-      parseOne(script) shouldBe BINARY_OP(REF(PART.INVALID(keyword, "keywords are restricted")), BinaryOperation.SUM_OP, CONST_LONG(1))
+      parseOne(script) shouldBe BINARY_OP(
+        0,
+        8,
+        REF(0, 4, PART.INVALID(0, 4, "keywords are restricted")),
+        BinaryOperation.SUM_OP,
+        CONST_LONG(7, 8, 1)
+      )
     }
   }
 
@@ -199,105 +283,130 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
   }
 
   property("function call") {
-    parseOne("FOO(1,2)".stripMargin) shouldBe FUNCTION_CALL("FOO", List(CONST_LONG(1), CONST_LONG(2)))
-    parseOne("FOO(X)".stripMargin) shouldBe FUNCTION_CALL("FOO", List(REF("X")))
+    parseOne("FOO(1,2)".stripMargin) shouldBe FUNCTION_CALL(0, 8, PART.VALID(0, 3, "FOO"), List(CONST_LONG(4, 5, 1), CONST_LONG(6, 7, 2)))
+    parseOne("FOO(X)".stripMargin) shouldBe FUNCTION_CALL(0, 6, PART.VALID(0, 3, "FOO"), List(REF(4, 5, PART.VALID(4, 5, "X"))))
   }
 
   property("function call on curly braces") {
     parseOne("{ 1 }(2, 3, 4)") shouldBe FUNCTION_CALL(
-      PART.INVALID("", "CONST_LONG(1) is not a function name"),
-      List(2, 3, 4).map(CONST_LONG(_))
+      0,
+      14,
+      PART.INVALID(0, 5, "'CONST_LONG(2,3,1)' is not a function name"),
+      List(CONST_LONG(6, 7, 2), CONST_LONG(9, 10, 3), CONST_LONG(12, 13, 4))
     )
   }
 
   property("function call on round braces") {
-    parseOne("(1)(2, 3, 4)") shouldBe FUNCTION_CALL(
-      PART.INVALID("", "CONST_LONG(1) is not a function name"),
-      List(2, 3, 4).map(CONST_LONG(_))
+    parseOne("( 1 )(2, 3, 4)") shouldBe FUNCTION_CALL(
+      0,
+      14,
+      PART.INVALID(0, 5, "'CONST_LONG(2,3,1)' is not a function name"),
+      List(CONST_LONG(6, 7, 2), CONST_LONG(9, 10, 3), CONST_LONG(12, 13, 4))
     )
   }
 
-  property("isDefined/extract") {
-    parseOne("isDefined(X)") shouldBe FUNCTION_CALL("isDefined", List(REF("X")))
+  property("isDefined") {
+    parseOne("isDefined(X)") shouldBe FUNCTION_CALL(0, 12, PART.VALID(0, 9, "isDefined"), List(REF(10, 11, PART.VALID(10, 11, "X"))))
+  }
+
+  property("extract") {
     parseOne("if(isDefined(X)) then extract(X) else Y") shouldBe IF(
-      FUNCTION_CALL("isDefined", List(REF("X"))),
-      FUNCTION_CALL("extract", List(REF("X"))),
-      REF("Y")
+      0,
+      39,
+      FUNCTION_CALL(3, 15, PART.VALID(3, 12, "isDefined"), List(REF(13, 14, PART.VALID(13, 14, "X")))),
+      FUNCTION_CALL(22, 32, PART.VALID(22, 29, "extract"), List(REF(30, 31, PART.VALID(30, 31, "X")))),
+      REF(38, 39, PART.VALID(38, 39, "Y"))
     )
   }
 
-  property("getter") {
-    isParsed("xxx   .yyy") shouldBe true
-    isParsed("xxx.  yyy") shouldBe true
+  property("getter: spaces from left") {
+    parseOne("xxx  .yyy") shouldBe GETTER(0, 9, REF(0, 3, PART.VALID(0, 3, "xxx")), PART.VALID(6, 9, "yyy"))
+  }
 
-    parseOne("xxx.yyy") shouldBe GETTER(REF("xxx"), "yyy")
-    parseOne(
-      """
-        |
-        | xxx.yyy
-        |
-      """.stripMargin
-    ) shouldBe GETTER(REF("xxx"), "yyy")
+  property("getter: spaces from right") {
+    parseOne("xxx.  yyy") shouldBe GETTER(0, 9, REF(0, 3, PART.VALID(0, 3, "xxx")), PART.VALID(6, 9, "yyy"))
+  }
 
-    parseOne("xxx(yyy).zzz") shouldBe GETTER(FUNCTION_CALL("xxx", List(REF("yyy"))), "zzz")
-    parseOne(
-      """
-        |
-        | xxx(yyy).zzz
-        |
-      """.stripMargin
-    ) shouldBe GETTER(FUNCTION_CALL("xxx", List(REF("yyy"))), "zzz")
+  property("getter: no spaces") {
+    parseOne("xxx.yyy") shouldBe GETTER(0, 7, REF(0, 3, PART.VALID(0, 3, "xxx")), PART.VALID(4, 7, "yyy"))
+  }
 
-    parseOne("(xxx(yyy)).zzz") shouldBe GETTER(FUNCTION_CALL("xxx", List(REF("yyy"))), "zzz")
-    parseOne(
-      """
-        |
-        | (xxx(yyy)).zzz
-        |
-      """.stripMargin
-    ) shouldBe GETTER(FUNCTION_CALL("xxx", List(REF("yyy"))), "zzz")
+  property("getter on function result") {
+    parseOne("xxx(yyy).zzz") shouldBe GETTER(
+      0,
+      12,
+      FUNCTION_CALL(0, 8, PART.VALID(0, 3, "xxx"), List(REF(4, 7, PART.VALID(4, 7, "yyy")))),
+      PART.VALID(9, 12, "zzz")
+    )
+  }
 
-    parseOne("{xxx(yyy)}.zzz") shouldBe GETTER(FUNCTION_CALL("xxx", List(REF("yyy"))), "zzz")
-    parseOne(
-      """
-        |
-        | {
-        |   xxx(yyy)
-        | }.zzz
-        |
-      """.stripMargin
-    ) shouldBe GETTER(FUNCTION_CALL("xxx", List(REF("yyy"))), "zzz")
+  property("getter on round braces") {
+    parseOne("(xxx(yyy)).zzz") shouldBe GETTER(
+      0,
+      14,
+      FUNCTION_CALL(1, 9, PART.VALID(1, 4, "xxx"), List(REF(5, 8, PART.VALID(5, 8, "yyy")))),
+      PART.VALID(11, 14, "zzz")
+    )
+  }
 
+  property("getter on curly braces") {
+    parseOne("{xxx(yyy)}.zzz") shouldBe GETTER(
+      0,
+      14,
+      FUNCTION_CALL(1, 9, PART.VALID(1, 4, "xxx"), List(REF(5, 8, PART.VALID(5, 8, "yyy")))),
+      PART.VALID(11, 14, "zzz")
+    )
+  }
+
+  property("getter on block") {
     parseOne(
-      """
-        |
-        | {
-        |   let yyy = aaa(bbb)
-        |   xxx(yyy)
-        | }.zzz
-        |
-      """.stripMargin
+      """{
+        |  let yyy = aaa(bbb)
+        |  xxx(yyy)
+        |}.zzz""".stripMargin
     ) shouldBe GETTER(
+      0,
+      39,
       BLOCK(
-        LET("yyy", FUNCTION_CALL("aaa", List(REF("bbb"))), Seq.empty),
-        FUNCTION_CALL("xxx", List(REF("yyy")))
+        4,
+        33,
+        LET(
+          4,
+          22,
+          PART.VALID(8, 11, "yyy"),
+          FUNCTION_CALL(14, 22, PART.VALID(14, 17, "aaa"), List(REF(18, 21, PART.VALID(18, 21, "bbb")))),
+          Seq.empty
+        ),
+        FUNCTION_CALL(25, 33, PART.VALID(25, 28, "xxx"), List(REF(29, 32, PART.VALID(29, 32, "yyy"))))
       ),
-      "zzz"
+      PART.VALID(36, 39, "zzz")
     )
   }
 
-  property("crypto functions") {
-    val hashFunctions = Vector("sha256", "blake2b256", "keccak256")
-    val text          = "❤✓☀★☂♞☯☭☢€☎∞❄♫\u20BD=test message"
-    val encodedText   = ScorexBase58.encode(text.getBytes)
+  // multiple getters
 
-    for (f <- hashFunctions) {
-      parseOne(s"$f(base58'$encodedText')".stripMargin) shouldBe
-        FUNCTION_CALL(
-          f,
-          List(CONST_BYTEVECTOR(ByteVector(text.getBytes)))
-        )
-    }
+  property("crypto functions: sha256") {
+    val text        = "❤✓☀★☂♞☯☭☢€☎∞❄♫\u20BD=test message"
+    val encodedText = ScorexBase58.encode(text.getBytes)
+
+    parseOne(s"sha256(base58'$encodedText')".stripMargin) shouldBe
+      FUNCTION_CALL(0, 96, PART.VALID(0, 6, "sha256"), List(CONST_BYTEVECTOR(7, 95, PART.VALID(15, 94, ByteVector(text.getBytes)))))
+  }
+
+  property("crypto functions: blake2b256") {
+    val text        = "❤✓☀★☂♞☯☭☢€☎∞❄♫\u20BD=test message"
+    val encodedText = ScorexBase58.encode(text.getBytes)
+
+    parseOne(s"blake2b256(base58'$encodedText')".stripMargin) shouldBe
+      FUNCTION_CALL(0, 100, PART.VALID(0, 10, "blake2b256"), List(CONST_BYTEVECTOR(11, 99, PART.VALID(19, 98, ByteVector(text.getBytes)))))
+  }
+
+  property("crypto functions: keccak256") {
+    val text        = "❤✓☀★☂♞☯☭☢€☎∞❄♫\u20BD=test message"
+    val encodedText = ScorexBase58.encode(text.getBytes)
+
+    parseOne(s"keccak256(base58'$encodedText')".stripMargin) shouldBe
+      FUNCTION_CALL(0, 99, PART.VALID(0, 9, "keccak256"), List(CONST_BYTEVECTOR(10, 98, PART.VALID(18, 97, ByteVector(text.getBytes)))))
   }
 
   property("show parse all input including INVALID") {
@@ -308,12 +417,9 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
         |true""".stripMargin
 
     parseAll(script) shouldBe Seq(
-      BLOCK(
-        LET("C", CONST_LONG(1), Seq.empty),
-        REF("foo")
-      ),
-      INVALID("#@", CONST_LONG(2)),
-      TRUE
+      BLOCK(0, 13, LET(0, 9, PART.VALID(4, 5, "C"), CONST_LONG(8, 9, 1), Seq.empty), REF(10, 13, PART.VALID(10, 13, "foo"))),
+      INVALID(14, 16, "#@", Some(CONST_LONG(16, 17, 2))),
+      TRUE(18, 22)
     )
   }
 
@@ -323,8 +429,10 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
         |# /
         |true""".stripMargin
     parseOne(script) shouldBe BLOCK(
-      LET("C", CONST_LONG(1), Seq.empty),
-      INVALID("#/", TRUE)
+      0,
+      18,
+      LET(0, 9, PART.VALID(4, 5, "C"), CONST_LONG(8, 9, 1), Seq.empty),
+      INVALID(10, 14, "# /\n", Some(TRUE(14, 18)))
     )
   }
 
@@ -334,10 +442,16 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
         |let C = 1
         |true""".stripMargin
     parseOne(script) shouldBe INVALID(
-      "#/",
-      BLOCK(
-        LET("C", CONST_LONG(1), Seq.empty),
-        TRUE
+      0,
+      4,
+      "# /\n",
+      Some(
+        BLOCK(
+          4,
+          18,
+          LET(4, 13, PART.VALID(8, 9, "C"), CONST_LONG(12, 13, 1), Seq.empty),
+          TRUE(14, 18)
+        )
       )
     )
   }
@@ -348,67 +462,86 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
         |true
         |# /""".stripMargin
     parseAll(script) shouldBe Seq(
-      BLOCK(
-        LET("C", CONST_LONG(1), Seq.empty),
-        TRUE
-      ),
-      INVALID("#/")
+      BLOCK(0, 14, LET(0, 9, PART.VALID(4, 5, "C"), CONST_LONG(8, 9, 1), Seq.empty), TRUE(10, 14)),
+      INVALID(15, 18, "# /")
     )
   }
 
   property("simple matching") {
     val code =
-      """
-        |
-        | match tx {
-        |    case a: TypeA => 0
-        |    case b: TypeB => 1
-        | }
-        |
-      """.stripMargin
-    parseOne(code) shouldBe MATCH(REF("tx"),
-                                  List(MATCH_CASE(Some("a"), List("TypeA"), CONST_LONG(0)), MATCH_CASE(Some("b"), List("TypeB"), CONST_LONG(1))))
+      """match tx {
+        |  case a: TypeA => 0
+        |  case b: TypeB => 1
+        |}""".stripMargin
+    parseOne(code) shouldBe MATCH(
+      0,
+      54,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
+      List(
+        MATCH_CASE(13, 31, Some(PART.VALID(18, 19, "a")), List(PART.VALID(21, 26, "TypeA")), CONST_LONG(30, 31, 0)),
+        MATCH_CASE(34, 52, Some(PART.VALID(39, 40, "b")), List(PART.VALID(42, 47, "TypeB")), CONST_LONG(51, 52, 1))
+      )
+    )
   }
 
   property("multiple union type matching") {
     val code =
-      """
-        |
-        | match tx {
-        |    case txa: TypeA => 0
-        |    case underscore : TypeB | TypeC => 1
-        | }
-        |
-      """.stripMargin
-    parseOne(code) shouldBe MATCH(REF("tx"),
-                                  List(MATCH_CASE(Some("txa"), List("TypeA"), CONST_LONG(0)),
-                                       MATCH_CASE(Some("underscore"), List("TypeB", "TypeC"), CONST_LONG(1))))
+      """match tx {
+        |  case txa: TypeA => 0
+        |  case underscore : TypeB | TypeC => 1
+        |}""".stripMargin
+    parseOne(code) shouldBe MATCH(
+      0,
+      74,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
+      List(
+        MATCH_CASE(13, 33, Some(PART.VALID(18, 21, "txa")), List(PART.VALID(23, 28, "TypeA")), CONST_LONG(32, 33, 0)),
+        MATCH_CASE(
+          36,
+          72,
+          Some(PART.VALID(41, 51, "underscore")),
+          List(PART.VALID(54, 59, "TypeB"), PART.VALID(62, 67, "TypeC")),
+          CONST_LONG(71, 72, 1)
+        )
+      )
+    )
   }
 
   property("matching expression") {
     val code =
-      """
-        |
-        | match foo(x) + bar {
-        |    case x:TypeA => 0
-        |    case y:TypeB | TypeC => 1
-        | }
-        |
-      """.stripMargin
+      """match foo(x) + bar {
+        |  case x:TypeA => 0
+        |  case y:TypeB | TypeC => 1
+        |}""".stripMargin
     parseOne(code) shouldBe MATCH(
-      BINARY_OP(FUNCTION_CALL("foo", List(REF("x"))), BinaryOperation.SUM_OP, REF("bar")),
-      List(MATCH_CASE(Some("x"), List("TypeA"), CONST_LONG(0)), MATCH_CASE(Some("y"), List("TypeB", "TypeC"), CONST_LONG(1)))
+      0,
+      70,
+      BINARY_OP(
+        6,
+        18,
+        FUNCTION_CALL(6, 12, PART.VALID(6, 9, "foo"), List(REF(10, 11, PART.VALID(10, 11, "x")))),
+        BinaryOperation.SUM_OP,
+        REF(15, 18, PART.VALID(15, 18, "bar"))
+      ),
+      List(
+        MATCH_CASE(23, 40, Some(PART.VALID(28, 29, "x")), List(PART.VALID(30, 35, "TypeA")), CONST_LONG(39, 40, 0)),
+        MATCH_CASE(43, 68, Some(PART.VALID(48, 49, "y")), List(PART.VALID(50, 55, "TypeB"), PART.VALID(58, 63, "TypeC")), CONST_LONG(67, 68, 1))
+      )
     )
   }
 
   property("pattern matching with valid case, but no type is defined") {
     parseOne("match tx { case x => 1 } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      24,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
-          Some(PART.VALID("x")),
+          11,
+          22,
+          Some(PART.VALID(16, 17, "x")),
           List.empty,
-          CONST_LONG(1)
+          CONST_LONG(21, 22, 1)
         )
       )
     )
@@ -416,29 +549,37 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
 
   property("pattern matching with valid case, placeholder instead of variable name") {
     parseOne("match tx { case  _:TypeA => 1 } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      31,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
+          11,
+          29,
           None,
-          List(PART.VALID("TypeA")),
-          CONST_LONG(1)
+          List(PART.VALID(19, 24, "TypeA")),
+          CONST_LONG(28, 29, 1)
         )
       )
     )
   }
 
   property("pattern matching with no cases") {
-    parseOne("match tx { } ") shouldBe INVALID("pattern matching requires case branches")
+    parseOne("match tx { } ") shouldBe INVALID(0, 12, "pattern matching requires case branches")
   }
 
   property("pattern matching with invalid case - no variable, type and expr are defined") {
     parseOne("match tx { case => } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      20,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
-          Some(PART.INVALID("", "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
+          11,
+          18,
+          Some(PART.INVALID(16, 16, "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
           List.empty,
-          INVALID("expected expression")
+          INVALID(16, 18, "expected expression")
         )
       )
     )
@@ -446,12 +587,16 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
 
   property("pattern matching with invalid case - no variable and type are defined") {
     parseOne("match tx { case => 1 } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      22,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
-          Some(PART.INVALID("", "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
+          11,
+          20,
+          Some(PART.INVALID(16, 16, "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
           List.empty,
-          CONST_LONG(1)
+          CONST_LONG(19, 20, 1)
         )
       )
     )
@@ -459,25 +604,27 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
 
   property("pattern matching with invalid case - no expr is defined") {
     parseOne("match tx { case TypeA => } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      26,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
-        MATCH_CASE(
-          Some(PART.VALID("TypeA")),
-          Seq.empty,
-          INVALID("expected expression")
-        )
+        MATCH_CASE(11, 24, Some(PART.VALID(16, 21, "TypeA")), Seq.empty, INVALID(21, 24, "expected expression"))
       )
     )
   }
 
   property("pattern matching with invalid case - no var is defined") {
     parseOne("match tx { case :TypeA => 1 } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      29,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
-          Some(PART.INVALID(":TypeA ", "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
+          11,
+          27,
+          Some(PART.INVALID(16, 23, "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
           Seq.empty,
-          CONST_LONG(1)
+          CONST_LONG(26, 27, 1)
         )
       )
     )
@@ -485,12 +632,16 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
 
   property("pattern matching with invalid case - expression in variable definition") {
     parseOne("match tx { case 1 + 1 => 1 } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      28,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
-          Some(PART.INVALID("1 + 1 ", "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
+          11,
+          26,
+          Some(PART.INVALID(16, 22, "invalid syntax, should be: `case varName: Type => expr` or `case _ => expr`")),
           List.empty,
-          CONST_LONG(1)
+          CONST_LONG(25, 26, 1)
         )
       )
     )
@@ -498,12 +649,16 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
 
   property("pattern matching with default case - no type is defined, one separator") {
     parseOne("match tx { case _: | => 1 } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      27,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
+          11,
+          25,
           None,
-          Seq(PART.INVALID("| ", "the type for variable should be specified: `case varName: Type => expr`")),
-          CONST_LONG(1)
+          Seq(PART.INVALID(19, 21, "the type for variable should be specified: `case varName: Type => expr`")),
+          CONST_LONG(24, 25, 1)
         )
       )
     )
@@ -511,12 +666,16 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
 
   property("pattern matching with default case - no type is defined, multiple separators") {
     parseOne("match tx { case  _: |||| => 1 } ") shouldBe MATCH(
-      REF("tx"),
+      0,
+      31,
+      REF(6, 8, PART.VALID(6, 8, "tx")),
       List(
         MATCH_CASE(
+          11,
+          29,
           None,
-          Seq(PART.INVALID("|||| ", "the type for variable should be specified: `case varName: Type => expr`")),
-          CONST_LONG(1)
+          Seq(PART.INVALID(20, 25, "the type for variable should be specified: `case varName: Type => expr`")),
+          CONST_LONG(28, 29, 1)
         )
       )
     )

--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/typechecker/CompilerV1Test.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/typechecker/CompilerV1Test.scala
@@ -16,28 +16,35 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
 
   property("should infer generic function return type") {
     import com.wavesplatform.lang.v1.parser.Expressions._
-    val Right(v) = CompilerV1(typeCheckerContext, FUNCTION_CALL(idT.name, List(CONST_LONG(1))))
+    val Right(v) = CompilerV1(typeCheckerContext, FUNCTION_CALL(0, 0, PART.VALID(0, 0, idT.name), List(CONST_LONG(0, 0, 1))))
     v.tpe shouldBe LONG
   }
 
   property("should infer inner types") {
     import com.wavesplatform.lang.v1.parser.Expressions._
     val Right(v) =
-      CompilerV1(typeCheckerContext, FUNCTION_CALL(extract.name, List(FUNCTION_CALL(undefinedOptionLong.name, List.empty))))
+      CompilerV1(
+        typeCheckerContext,
+        FUNCTION_CALL(0, 0, PART.VALID(0, 0, extract.name), List(FUNCTION_CALL(0, 0, PART.VALID(0, 0, undefinedOptionLong.name), List.empty)))
+      )
     v.tpe shouldBe LONG
   }
 
   treeTypeTest(s"unitOnNone(NONE)")(
     ctx = typeCheckerContext,
-    expr = Expressions.FUNCTION_CALL(unitOnNone.name, List(Expressions.REF("None"))),
+    expr = Expressions.FUNCTION_CALL(0,
+                                     0,
+                                     Expressions.PART.VALID(0, 0, unitOnNone.name),
+                                     List(Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "None")))),
     expectedResult = Right(FUNCTION_CALL(unitOnNone.header, List(REF("None", OPTION(NOTHING))), UNIT))
   )
 
   property("successful on very deep expressions(stack overflow check)") {
-    val expr =
-      (1 to 100000).foldLeft[Expressions.EXPR](Expressions.CONST_LONG(0))((acc, _) => Expressions.BINARY_OP(acc, SUM_OP, Expressions.CONST_LONG(1)))
-    val expectedResult = Right(LONG)
+    val expr = (1 to 100000).foldLeft[Expressions.EXPR](Expressions.CONST_LONG(0, 0, 0)) { (acc, _) =>
+      Expressions.BINARY_OP(0, 0, acc, SUM_OP, Expressions.CONST_LONG(0, 0, 1))
+    }
 
+    val expectedResult = Right(LONG)
     CompilerV1(typeCheckerContext, expr).map(_.tpe) match {
       case Right(x)    => Right(x) shouldBe expectedResult
       case e @ Left(_) => e shouldBe expectedResult
@@ -47,8 +54,10 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
   treeTypeTest("GETTER")(
     ctx = CompilerContext(predefTypes = Map(pointType.name -> pointType), varDefs = Map("p" -> TYPEREF("Point")), functionDefs = Map.empty),
     expr = Expressions.GETTER(
-      ref = Expressions.REF("p"),
-      field = "x"
+      0,
+      0,
+      ref = Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "p")),
+      field = Expressions.PART.VALID(0, 0, "x")
     ),
     expectedResult = Right(
       GETTER(
@@ -60,31 +69,53 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
 
   treeTypeTest("REF(OBJECT)")(
     ctx = CompilerContext(predefTypes = Map(pointType.name -> pointType), varDefs = Map("p" -> TYPEREF("Point")), functionDefs = Map.empty),
-    expr = Expressions.REF("p"),
+    expr = Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "p")),
     expectedResult = Right(REF("p", TYPEREF("Point")))
   )
 
   treeTypeTest("REF x = y")(
     ctx = CompilerContext(predefTypes = Map(pointType.name -> pointType), varDefs = Map("p" -> TYPEREF("Point")), functionDefs = Map.empty),
-    expr = Expressions.REF("p"),
+    expr = Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "p")),
     expectedResult = Right(REF("p", TYPEREF("Point")))
   )
 
   treeTypeTest("MULTIPLY(1,2)")(
     ctx = typeCheckerContext,
-    expr = Expressions.FUNCTION_CALL(multiplierFunction.name, List(Expressions.CONST_LONG(1), Expressions.CONST_LONG(2))),
+    expr = Expressions.FUNCTION_CALL(
+      0,
+      0,
+      Expressions.PART.VALID(0, 0, multiplierFunction.name),
+      List(Expressions.CONST_LONG(0, 0, 1), Expressions.CONST_LONG(0, 0, 2))
+    ),
     expectedResult = Right(FUNCTION_CALL(multiplierFunction.header, List(CONST_LONG(1), CONST_LONG(2)), LONG))
   )
 
   treeTypeTest(s"idOptionLong(NONE)")(
     ctx = typeCheckerContext,
-    expr = Expressions.FUNCTION_CALL(idOptionLong.name, List(Expressions.REF("None"))),
+    expr = Expressions.FUNCTION_CALL(
+      0,
+      0,
+      Expressions.PART.VALID(0, 0, idOptionLong.name),
+      List(Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "None")))
+    ),
     expectedResult = Right(FUNCTION_CALL(idOptionLong.header, List(REF("None", OPTION(NOTHING))), UNIT))
   )
 
   treeTypeTest(s"idOptionLong(SOME(NONE))")(
     ctx = typeCheckerContext,
-    expr = Expressions.FUNCTION_CALL(idOptionLong.name, List(Expressions.FUNCTION_CALL("Some", List(Expressions.REF("None"))))),
+    expr = Expressions.FUNCTION_CALL(
+      0,
+      0,
+      Expressions.PART.VALID(0, 0, idOptionLong.name),
+      List(
+        Expressions.FUNCTION_CALL(
+          0,
+          0,
+          Expressions.PART.VALID(0, 0, "Some"),
+          List(Expressions.REF(0, 0, Expressions.PART.INVALID(0, 0, "None")))
+        )
+      )
+    ),
     expectedResult =
       Right(FUNCTION_CALL(idOptionLong.header, List(FUNCTION_CALL(some.header, List(REF("None", OPTION(NOTHING))), OPTION(OPTION(NOTHING)))), UNIT))
   )
@@ -92,8 +123,17 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
   treeTypeTest(s"idOptionLong(SOME(CONST_LONG(3)))")(
     ctx = typeCheckerContext,
     expr = Expressions.FUNCTION_CALL(
-      idOptionLong.name,
-      List(Expressions.FUNCTION_CALL("Some", List(Expressions.FUNCTION_CALL("Some", List(Expressions.CONST_LONG(3))))))
+      0,
+      0,
+      Expressions.PART.VALID(0, 0, idOptionLong.name),
+      List(
+        Expressions.FUNCTION_CALL(
+          0,
+          0,
+          Expressions.PART.VALID(0, 0, "Some"),
+          List(Expressions.FUNCTION_CALL(0, 0, Expressions.PART.VALID(0, 0, "Some"), List(Expressions.CONST_LONG(0, 0, 3))))
+        )
+      )
     ),
     expectedResult = Right(
       FUNCTION_CALL(
@@ -106,43 +146,48 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
 
   treeTypeTest("Invalid LET")(
     ctx = typeCheckerContext,
-    expr = Expressions.BLOCK(Expressions.LET(Expressions.PART.INVALID("###", "it is invalid!"), Expressions.TRUE, Seq.empty), Expressions.REF("x")),
+    expr = Expressions.BLOCK(
+      0,
+      0,
+      Expressions.LET(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!"), Expressions.TRUE(0, 0), Seq.empty),
+      Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "x"))
+    ),
     expectedResult = Left("Typecheck failed: it is invalid!: ###")
   )
 
   treeTypeTest("Invalid GETTER")(
     ctx = typeCheckerContext,
-    expr = Expressions.GETTER(Expressions.REF("x"), Expressions.PART.INVALID("###", "it is invalid!")),
+    expr = Expressions.GETTER(0, 0, Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "x")), Expressions.PART.INVALID(0, 0, "it is invalid!")),
     expectedResult = Left("Typecheck failed: it is invalid!: ###")
   )
 
   treeTypeTest("Invalid BYTEVECTOR")(
     ctx = typeCheckerContext,
-    expr = Expressions.CONST_BYTEVECTOR(Expressions.PART.INVALID("foo", "it is invalid!")),
+    expr = Expressions.CONST_BYTEVECTOR(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!")),
     expectedResult = Left("Typecheck failed: it is invalid!: foo")
   )
 
   treeTypeTest("Invalid STRING")(
     ctx = typeCheckerContext,
-    expr = Expressions.CONST_STRING(Expressions.PART.INVALID("\\u1", "it is invalid!")),
+    expr = Expressions.CONST_STRING(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!")),
     expectedResult = Left("Typecheck failed: it is invalid!: \\u1")
   )
 
   treeTypeTest("Invalid REF")(
     ctx = typeCheckerContext,
-    expr = Expressions.REF(Expressions.PART.INVALID("###", "it is invalid!")),
+    expr = Expressions.REF(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!")),
     expectedResult = Left("Typecheck failed: it is invalid!: ###")
   )
 
   treeTypeTest("Invalid FUNCTION_CALL")(
     ctx = typeCheckerContext,
-    expr = Expressions.FUNCTION_CALL(Expressions.PART.INVALID("###", "it is invalid!"), List.empty),
+    expr = Expressions.FUNCTION_CALL(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!"), List.empty),
     expectedResult = Left("Typecheck failed: it is invalid!: ###")
   )
 
   treeTypeTest("INVALID")(
     ctx = typeCheckerContext,
-    expr = Expressions.INVALID("###", None),
+    expr = Expressions.INVALID(0, 0, "###", None),
     expectedResult = Left("Typecheck failed: ###")
   )
 

--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/typechecker/CompilerV1Test.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/typechecker/CompilerV1Test.scala
@@ -30,7 +30,7 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
     v.tpe shouldBe LONG
   }
 
-  treeTypeTest(s"unitOnNone(NONE)")(
+  treeTypeTest("unitOnNone(NONE)")(
     ctx = typeCheckerContext,
     expr = Expressions.FUNCTION_CALL(0,
                                      0,
@@ -90,7 +90,7 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
     expectedResult = Right(FUNCTION_CALL(multiplierFunction.header, List(CONST_LONG(1), CONST_LONG(2)), LONG))
   )
 
-  treeTypeTest(s"idOptionLong(NONE)")(
+  treeTypeTest("idOptionLong(NONE)")(
     ctx = typeCheckerContext,
     expr = Expressions.FUNCTION_CALL(
       0,
@@ -101,7 +101,7 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
     expectedResult = Right(FUNCTION_CALL(idOptionLong.header, List(REF("None", OPTION(NOTHING))), UNIT))
   )
 
-  treeTypeTest(s"idOptionLong(SOME(NONE))")(
+  treeTypeTest("idOptionLong(SOME(NONE))")(
     ctx = typeCheckerContext,
     expr = Expressions.FUNCTION_CALL(
       0,
@@ -112,7 +112,7 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
           0,
           0,
           Expressions.PART.VALID(0, 0, "Some"),
-          List(Expressions.REF(0, 0, Expressions.PART.INVALID(0, 0, "None")))
+          List(Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "None")))
         )
       )
     ),
@@ -120,7 +120,7 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
       Right(FUNCTION_CALL(idOptionLong.header, List(FUNCTION_CALL(some.header, List(REF("None", OPTION(NOTHING))), OPTION(OPTION(NOTHING)))), UNIT))
   )
 
-  treeTypeTest(s"idOptionLong(SOME(CONST_LONG(3)))")(
+  treeTypeTest("idOptionLong(SOME(CONST_LONG(3)))")(
     ctx = typeCheckerContext,
     expr = Expressions.FUNCTION_CALL(
       0,
@@ -149,40 +149,40 @@ class CompilerV1Test extends PropSpec with PropertyChecks with Matchers with Scr
     expr = Expressions.BLOCK(
       0,
       0,
-      Expressions.LET(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!"), Expressions.TRUE(0, 0), Seq.empty),
+      Expressions.LET(0, 0, Expressions.PART.INVALID(0, 1, "can't parse"), Expressions.TRUE(0, 0), Seq.empty),
       Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "x"))
     ),
-    expectedResult = Left("Typecheck failed: it is invalid!: ###")
+    expectedResult = Left("Typecheck failed: Can't compile an invalid instruction: can't parse in 0-1")
   )
 
   treeTypeTest("Invalid GETTER")(
     ctx = typeCheckerContext,
-    expr = Expressions.GETTER(0, 0, Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "x")), Expressions.PART.INVALID(0, 0, "it is invalid!")),
-    expectedResult = Left("Typecheck failed: it is invalid!: ###")
+    expr = Expressions.GETTER(0, 0, Expressions.REF(0, 0, Expressions.PART.VALID(0, 0, "x")), Expressions.PART.INVALID(2, 3, "can't parse")),
+    expectedResult = Left("Typecheck failed: Can't compile an invalid instruction: can't parse in 2-3")
   )
 
   treeTypeTest("Invalid BYTEVECTOR")(
     ctx = typeCheckerContext,
-    expr = Expressions.CONST_BYTEVECTOR(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!")),
-    expectedResult = Left("Typecheck failed: it is invalid!: foo")
+    expr = Expressions.CONST_BYTEVECTOR(0, 0, Expressions.PART.INVALID(0, 0, "can't parse")),
+    expectedResult = Left("Typecheck failed: can't parse in 0-0")
   )
 
   treeTypeTest("Invalid STRING")(
     ctx = typeCheckerContext,
-    expr = Expressions.CONST_STRING(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!")),
-    expectedResult = Left("Typecheck failed: it is invalid!: \\u1")
+    expr = Expressions.CONST_STRING(0, 0, Expressions.PART.INVALID(0, 0, "can't parse")),
+    expectedResult = Left("Typecheck failed: can't parse in 0-0")
   )
 
   treeTypeTest("Invalid REF")(
     ctx = typeCheckerContext,
-    expr = Expressions.REF(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!")),
-    expectedResult = Left("Typecheck failed: it is invalid!: ###")
+    expr = Expressions.REF(0, 0, Expressions.PART.INVALID(0, 0, "can't parse")),
+    expectedResult = Left("Typecheck failed: Can't compile an invalid instruction: can't parse in 0-0")
   )
 
   treeTypeTest("Invalid FUNCTION_CALL")(
     ctx = typeCheckerContext,
-    expr = Expressions.FUNCTION_CALL(0, 0, Expressions.PART.INVALID(0, 0, "it is invalid!"), List.empty),
-    expectedResult = Left("Typecheck failed: it is invalid!: ###")
+    expr = Expressions.FUNCTION_CALL(0, 0, Expressions.PART.INVALID(0, 0, "can't parse"), List.empty),
+    expectedResult = Left("Typecheck failed: Can't compile an invalid instruction: can't parse in 0-0")
   )
 
   treeTypeTest("INVALID")(

--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/typechecker/ErrorTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/typechecker/ErrorTest.scala
@@ -15,24 +15,50 @@ class ErrorTest extends PropSpec with PropertyChecks with Matchers with ScriptGe
 
   errorTests(
     "can't define LET with the same name as already defined in scope" -> "already defined in the scope" -> BLOCK(
-      LET("X", CONST_LONG(1), Seq.empty),
-      BLOCK(LET("X", CONST_LONG(2), Seq.empty), TRUE)),
-    "can't define LET with the same name as predefined constant" -> "already defined in the scope" -> BLOCK(LET("None", CONST_LONG(2), Seq.empty),
-                                                                                                            TRUE),
+      0,
+      0,
+      LET(0, 0, PART.VALID(0, 0, "X"), CONST_LONG(0, 0, 1), Seq.empty),
+      BLOCK(0, 0, LET(0, 0, PART.VALID(0, 0, "X"), CONST_LONG(0, 0, 2), Seq.empty), TRUE(0, 0))
+    ),
+    "can't define LET with the same name as predefined constant" -> "already defined in the scope" -> BLOCK(
+      0,
+      0,
+      LET(0, 0, PART.VALID(0, 0, "None"), CONST_LONG(0, 0, 2), Seq.empty),
+      TRUE(0, 0)
+    ),
     "can't define LET with the same name as predefined function" -> "function with such name is predefined" -> BLOCK(
-      LET("Some", CONST_LONG(2), Seq.empty),
-      TRUE),
-    "BINARY_OP with wrong types"                   -> "Typecheck failed: Can't find a function '+'" -> BINARY_OP(TRUE, SUM_OP, CONST_LONG(1)),
-    "IF can't find common"                         -> "Can't find common type" -> IF(TRUE, TRUE, CONST_LONG(0)),
-    "IF clause must be boolean"                    -> "IF clause is expected to be BOOLEAN" -> IF(CONST_LONG(0), TRUE, FALSE),
-    "FUNCTION_CALL with wrong amount of arguments" -> "requires 2 arguments" -> FUNCTION_CALL(multiplierFunction.name, List(CONST_LONG(0))),
-    "FUNCTION_CALL with upper type"                -> "Non-matching types" -> FUNCTION_CALL(unitOnNone.name, List(FUNCTION_CALL("Some", List(CONST_LONG(3))))),
-    "FUNCTION_CALL with wrong type of argument"    -> "Typecheck failed: Non-matching types: expected: LONG, actual: BOOLEAN" -> FUNCTION_CALL(
-      multiplierFunction.name,
-      List(CONST_LONG(0), FALSE)),
-    "FUNCTION_CALL with uncommon types for parameter T" -> "Can't match inferred types" -> FUNCTION_CALL(functionWithTwoPrarmsOfTheSameType.name,
-                                                                                                         List(CONST_LONG(1),
-                                                                                                              CONST_BYTEVECTOR(ByteVector.empty)))
+      0,
+      0,
+      LET(0, 0, PART.VALID(0, 0, "Some"), CONST_LONG(0, 0, 2), Seq.empty),
+      TRUE(0, 0)
+    ),
+    "BINARY_OP with wrong types"                   -> "Typecheck failed: Can't find a function '+'" -> BINARY_OP(0, 0, TRUE(0, 0), SUM_OP, CONST_LONG(0, 0, 1)),
+    "IF can't find common"                         -> "Can't find common type" -> IF(0, 0, TRUE(0, 0), TRUE(0, 0), CONST_LONG(0, 0, 0)),
+    "IF clause must be boolean"                    -> "IF clause is expected to be BOOLEAN" -> IF(0, 0, CONST_LONG(0, 0, 0), TRUE(0, 0), FALSE(0, 0)),
+    "FUNCTION_CALL with wrong amount of arguments" -> "requires 2 arguments" -> FUNCTION_CALL(
+      0,
+      0,
+      PART.VALID(0, 0, multiplierFunction.name),
+      List(CONST_LONG(0, 0, 0))
+    ),
+    "FUNCTION_CALL with upper type" -> "Non-matching types" -> FUNCTION_CALL(
+      0,
+      0,
+      PART.VALID(0, 0, unitOnNone.name),
+      List(FUNCTION_CALL(0, 0, PART.VALID(0, 0, "Some"), List(CONST_LONG(0, 0, 3))))
+    ),
+    "FUNCTION_CALL with wrong type of argument" -> "Typecheck failed: Non-matching types: expected: LONG, actual: BOOLEAN" -> FUNCTION_CALL(
+      0,
+      0,
+      PART.VALID(0, 0, multiplierFunction.name),
+      List(CONST_LONG(0, 0, 0), FALSE(0, 0))
+    ),
+    "FUNCTION_CALL with uncommon types for parameter T" -> "Can't match inferred types" -> FUNCTION_CALL(
+      0,
+      0,
+      PART.VALID(0, 0, functionWithTwoPrarmsOfTheSameType.name),
+      List(CONST_LONG(0, 0, 1), CONST_BYTEVECTOR(0, 0, PART.VALID(0, 0, ByteVector.empty)))
+    )
   )
 
   private def errorTests(exprs: ((String, String), Expressions.EXPR)*): Unit = exprs.foreach {

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/compiler/CompilerV1.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/compiler/CompilerV1.scala
@@ -264,7 +264,7 @@ object CompilerV1 {
 
   private def handlePart[T](part: PART[T])(f: T => EXPR): SetTypeResult[EXPR] = part match {
     case PART.VALID(_, _, x)               => EitherT.pure(f(x))
-    case PART.INVALID(start, end, message) => EitherT.leftT[Coeval, EXPR](s"$message at $start-$end")
+    case PART.INVALID(start, end, message) => EitherT.leftT[Coeval, EXPR](s"$message in $start-$end")
   }
 
   def apply(c: CompilerContext, expr: Expressions.EXPR): CompilationResult[EXPR] = {

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/BinaryOperation.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/BinaryOperation.scala
@@ -6,8 +6,8 @@ import fastparse.all._
 sealed abstract class BinaryOperation {
   val func: String
   val parser: P[Any] = P(func)
-  def expr(op1: EXPR)(op2: EXPR): EXPR = {
-    BINARY_OP(op1, this, op2)
+  def expr(start: Int, end: Int, op1: EXPR, op2: EXPR): EXPR = {
+    BINARY_OP(start, end, op1, this, op2)
   }
 }
 
@@ -55,15 +55,15 @@ object BinaryOperation {
   case object LE_OP extends BinaryOperation {
     val func            = ">="
     override val parser = P("<=")
-    override def expr(op1: EXPR)(op2: EXPR): EXPR = {
-      BINARY_OP(op2, LE_OP, op1)
+    override def expr(start: Int, end: Int, op1: EXPR, op2: EXPR): EXPR = {
+      BINARY_OP(start, end, op2, LE_OP, op1)
     }
   }
   case object LT_OP extends BinaryOperation {
     val func            = ">"
     override val parser = P("<")
-    override def expr(op1: EXPR)(op2: EXPR): EXPR = {
-      BINARY_OP(op2, LT_OP, op1)
+    override def expr(start: Int, end: Int, op1: EXPR, op2: EXPR): EXPR = {
+      BINARY_OP(start, end, op2, LT_OP, op1)
     }
   }
 

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Expressions.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Expressions.scala
@@ -4,69 +4,42 @@ import scodec.bits.ByteVector
 
 object Expressions {
 
-  sealed trait PART[+T]
+  trait Positioned {
+    def start: Int
+    def end: Int
+  }
+
+  sealed trait PART[+T] extends Positioned
   object PART {
-    case class VALID[T](v: T)                             extends PART[T]
-    case class INVALID(consumed: String, message: String) extends PART[Nothing]
+    case class VALID[T](start: Int, end: Int, v: T)           extends PART[T]
+    case class INVALID(start: Int, end: Int, message: String) extends PART[Nothing]
   }
 
-  case class LET(name: PART[String], value: EXPR, types: Seq[PART[String]])
-  object LET {
-    def apply(name: String, value: EXPR, types: Seq[String]): LET = LET(PART.VALID(name), value, types.map(PART.VALID(_)))
-  }
+  case class LET(start: Int, end: Int, name: PART[String], value: EXPR, types: Seq[PART[String]]) extends Positioned
 
-  sealed trait EXPR
-  case class CONST_LONG(value: Long) extends EXPR
+  sealed trait EXPR                                                                   extends Positioned
+  case class CONST_LONG(start: Int, end: Int, value: Long)                            extends EXPR
+  case class GETTER(start: Int, end: Int, ref: EXPR, field: PART[String])             extends EXPR
+  case class CONST_BYTEVECTOR(start: Int, end: Int, value: PART[ByteVector])          extends EXPR
+  case class CONST_STRING(start: Int, end: Int, value: PART[String])                  extends EXPR
+  case class BINARY_OP(start: Int, end: Int, a: EXPR, kind: BinaryOperation, b: EXPR) extends EXPR
+  case class BLOCK(start: Int, end: Int, let: LET, body: EXPR)                        extends EXPR
+  case class IF(start: Int, end: Int, cond: EXPR, ifTrue: EXPR, ifFalse: EXPR)        extends EXPR
+  case class REF(start: Int, end: Int, key: PART[String])                             extends EXPR
 
-  case class GETTER(ref: EXPR, field: PART[String]) extends EXPR
-  object GETTER {
-    def apply(ref: EXPR, field: String): GETTER = GETTER(ref, PART.VALID(field))
-  }
+  case class TRUE(start: Int, end: Int)  extends EXPR
+  case class FALSE(start: Int, end: Int) extends EXPR
 
-  case class CONST_BYTEVECTOR(value: PART[ByteVector]) extends EXPR
-  object CONST_BYTEVECTOR {
-    def apply(x: ByteVector): CONST_BYTEVECTOR = CONST_BYTEVECTOR(PART.VALID(x))
-  }
+  case class FUNCTION_CALL(start: Int, end: Int, name: PART[String], args: List[EXPR]) extends EXPR
 
-  case class CONST_STRING(value: PART[String]) extends EXPR
-  object CONST_STRING {
-    def apply(x: String): CONST_STRING = CONST_STRING(PART.VALID(x))
-  }
+  case class MATCH_CASE(start: Int, end: Int, newVarName: Option[PART[String]], types: Seq[PART[String]], expr: EXPR)
+  case class MATCH(start: Int, end: Int, expr: EXPR, cases: Seq[MATCH_CASE]) extends EXPR
 
-  case class BINARY_OP(a: EXPR, kind: BinaryOperation, b: EXPR) extends EXPR
-  case class BLOCK(let: LET, body: EXPR)                        extends EXPR
-  case class IF(cond: EXPR, ifTrue: EXPR, ifFalse: EXPR)        extends EXPR
-
-  case class REF(key: PART[String]) extends EXPR
-  object REF {
-    def apply(key: String): REF = REF(PART.VALID(key))
-  }
-
-  case object TRUE  extends EXPR
-  case object FALSE extends EXPR
-
-  case class FUNCTION_CALL(name: PART[String], args: List[EXPR]) extends EXPR
-  object FUNCTION_CALL {
-    def apply(name: String, args: List[EXPR]): FUNCTION_CALL = FUNCTION_CALL(PART.VALID(name), args)
-  }
-
-  case class MATCH_CASE(newVarName: Option[PART[String]], types: Seq[PART[String]], expr: EXPR)
-  object MATCH_CASE {
-    def apply(newVarName: Option[String], types: List[String], expr: EXPR): MATCH_CASE =
-      MATCH_CASE(newVarName.map(PART.VALID(_)), types.map(PART.VALID(_)), expr)
-  }
-
-  case class MATCH(expr: EXPR, cases: Seq[MATCH_CASE]) extends EXPR
-
-  case class INVALID(message: String, next: Option[EXPR] = None) extends EXPR
-  object INVALID {
-    def apply(message: String, next: EXPR): INVALID = INVALID(message, Some(next))
-  }
-
+  case class INVALID(start: Int, end: Int, message: String, next: Option[EXPR] = None) extends EXPR
   implicit class PartOps[T](val self: PART[T]) extends AnyVal {
     def toEither: Either[String, T] = self match {
-      case Expressions.PART.VALID(x)            => Right(x)
-      case Expressions.PART.INVALID(x, message) => Left(s"$message: $x")
+      case Expressions.PART.VALID(_, _, x)         => Right(x)
+      case Expressions.PART.INVALID(_, _, message) => Left(message)
     }
   }
 

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Expressions.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Expressions.scala
@@ -39,7 +39,7 @@ object Expressions {
   implicit class PartOps[T](val self: PART[T]) extends AnyVal {
     def toEither: Either[String, T] = self match {
       case Expressions.PART.VALID(_, _, x)         => Right(x)
-      case Expressions.PART.INVALID(_, _, message) => Left(message)
+      case Expressions.PART.INVALID(s, e, message) => Left(s"Can't compile an invalid instruction: $message in $s-$e")
     }
   }
 

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Parser.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Parser.scala
@@ -184,7 +184,7 @@ object Parser {
                     case REF(_, _, functionName) => FUNCTION_CALL(start, accessEnd, functionName, args.toList)
                     case _                       => FUNCTION_CALL(start, accessEnd, PART.INVALID(start, objEnd, s"'$obj' is not a function name"), args.toList)
                   }
-                case ListIndex(index) => FUNCTION_CALL(start, objEnd, PART.VALID(start, accessStart, "getElement"), List(e, index))
+                case ListIndex(index) => FUNCTION_CALL(start, accessEnd, PART.VALID(accessStart, accessEnd, "getElement"), List(e, index))
               }
           }
       }

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/UnaryOperation.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/UnaryOperation.scala
@@ -3,13 +3,30 @@ package com.wavesplatform.lang.v1.parser
 import com.wavesplatform.lang.v1.parser.Expressions._
 import fastparse.all._
 
+sealed abstract class UnaryOperation {
+  val parser: P[Any]
+  def expr(start: Int, end: Int, op: EXPR): EXPR
+}
+
 object UnaryOperation {
-  val unaryOps = List(
-    P("-" ~ !CharIn('0' to '9')) -> { e: EXPR =>
-      FUNCTION_CALL("-", List(e))
-    },
-    P("!") -> { e: EXPR =>
-      FUNCTION_CALL("!", List(e))
-    }
+
+  val unaryOps: List[UnaryOperation] = List(
+    NEGATIVE_OP,
+    NOT_OP
   )
+
+  case object NEGATIVE_OP extends UnaryOperation {
+    override val parser: P[Any] = P("-" ~ !CharIn('0' to '9'))
+    override def expr(start: Int, end: Int, op: EXPR): EXPR = {
+      FUNCTION_CALL(start, end, PART.VALID(start, end, "-"), List(op))
+    }
+  }
+
+  case object NOT_OP extends UnaryOperation {
+    override val parser: P[Any] = P("!")
+    override def expr(start: Int, end: Int, op: EXPR): EXPR = {
+      FUNCTION_CALL(start, end, PART.VALID(start, end, "!"), List(op))
+    }
+  }
+
 }

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/testing/ScriptGen.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/testing/ScriptGen.scala
@@ -3,7 +3,6 @@ package com.wavesplatform.lang.v1.testing
 import com.wavesplatform.lang.v1.parser.BinaryOperation
 import com.wavesplatform.lang.v1.parser.BinaryOperation._
 import com.wavesplatform.lang.v1.parser.Expressions._
-import com.wavesplatform.lang.v1.parser.Parser.keywords
 import org.scalacheck._
 import scodec.bits.ByteVector
 import scorex.crypto.encode.Base58
@@ -12,12 +11,11 @@ import scala.reflect.ClassTag
 
 trait ScriptGen {
 
-  def CONST_LONGgen: Gen[(EXPR, Long)] = Gen.choose(Long.MinValue, Long.MaxValue).map(v => (CONST_LONG(v), v))
+  def CONST_LONGgen: Gen[(EXPR, Long)] = Gen.choose(Long.MinValue, Long.MaxValue).map(v => (CONST_LONG(0, 0, v), v))
 
   def BOOLgen(gas: Int): Gen[(EXPR, Boolean)] =
-    if (gas > 0)
-      Gen.oneOf(GEgen(gas - 1), GTgen(gas - 1), EQ_INTgen(gas - 1), NE_INTgen(gas - 1), ANDgen(gas - 1), ORgen(gas - 1), IF_BOOLgen(gas - 1))
-    else Gen.const((TRUE, true))
+    if (gas > 0) Gen.oneOf(GEgen(gas - 1), GTgen(gas - 1), EQ_INTgen(gas - 1), ANDgen(gas - 1), ORgen(gas - 1), IF_BOOLgen(gas - 1))
+    else Gen.const((TRUE(0, 0), true))
 
   def SUMgen(gas: Int): Gen[(EXPR, Long)] =
     for {
@@ -25,9 +23,9 @@ trait ScriptGen {
       (i2, v2) <- INTGen((gas - 2) / 2)
     } yield
       if ((BigInt(v1) + BigInt(v2)).isValidLong) {
-        (BINARY_OP(i1, SUM_OP, i2), v1 + v2)
+        (BINARY_OP(0, 0, i1, SUM_OP, i2), v1 + v2)
       } else {
-        (BINARY_OP(i1, SUB_OP, i2), v1 - v2)
+        (BINARY_OP(0, 0, i1, SUB_OP, i2), v1 - v2)
       }
 
   def SUBgen(gas: Int): Gen[(EXPR, Long)] =
@@ -36,9 +34,9 @@ trait ScriptGen {
       (i2, v2) <- INTGen((gas - 2) / 2)
     } yield
       if ((BigInt(v1) - BigInt(v2)).isValidLong) {
-        (BINARY_OP(i1, SUB_OP, i2), v1 - v2)
+        (BINARY_OP(0, 0, i1, SUB_OP, i2), v1 - v2)
       } else {
-        (BINARY_OP(i1, SUM_OP, i2), v1 + v2)
+        (BINARY_OP(0, 0, i1, SUM_OP, i2), v1 + v2)
       }
 
   def INTGen(gas: Int): Gen[(EXPR, Long)] =
@@ -48,89 +46,71 @@ trait ScriptGen {
         SUMgen(gas - 1),
         SUBgen(gas - 1),
         IF_INTgen(gas - 1),
-        INTGen(gas - 1).filter(v => (-BigInt(v._2)).isValidLong).map(e => (FUNCTION_CALL("-", List(e._1)), -e._2))
+        INTGen(gas - 1).filter(v => (-BigInt(v._2)).isValidLong).map(e => (FUNCTION_CALL(0, 0, PART.VALID(0, 0, "-"), List(e._1)), -e._2))
       )
     else CONST_LONGgen
 
   def GEgen(gas: Int): Gen[(EXPR, Boolean)] =
     for {
-      dir      <- Gen.oneOf(true, false)
       (i1, v1) <- INTGen((gas - 2) / 2)
       (i2, v2) <- INTGen((gas - 2) / 2)
-    } yield
-      if (dir) {
-        (BINARY_OP(i1, GE_OP, i2), v1 >= v2)
-      } else {
-        (BINARY_OP(i2, LE_OP, i1), v1 <= v2)
-      }
+    } yield (BINARY_OP(0, 0, i1, GE_OP, i2), v1 >= v2)
 
   def GTgen(gas: Int): Gen[(EXPR, Boolean)] =
     for {
-      dir      <- Gen.oneOf(true, false)
       (i1, v1) <- INTGen((gas - 2) / 2)
       (i2, v2) <- INTGen((gas - 2) / 2)
-    } yield
-      if (dir) {
-        (BINARY_OP(i1, GT_OP, i2), v1 > v2)
-      } else {
-        (BINARY_OP(i2, LT_OP, i1), v1 < v2)
-      }
+    } yield (BINARY_OP(0, 0, i1, GT_OP, i2), v1 > v2)
 
   def EQ_INTgen(gas: Int): Gen[(EXPR, Boolean)] =
     for {
       (i1, v1) <- INTGen((gas - 2) / 2)
       (i2, v2) <- INTGen((gas - 2) / 2)
-    } yield (BINARY_OP(i1, EQ_OP, i2), v1 == v2)
-
-  def NE_INTgen(gas: Int): Gen[(EXPR, Boolean)] =
-    for {
-      (i1, v1) <- INTGen((gas - 2) / 2)
-      (i2, v2) <- INTGen((gas - 2) / 2)
-    } yield (BINARY_OP(i1, NE_OP, i2), v1 != v2)
+    } yield (BINARY_OP(0, 0, i1, EQ_OP, i2), v1 == v2)
 
   def ANDgen(gas: Int): Gen[(EXPR, Boolean)] =
     for {
       (i1, v1) <- BOOLgen((gas - 2) / 2)
       (i2, v2) <- BOOLgen((gas - 2) / 2)
-    } yield (BINARY_OP(i1, AND_OP, i2), v1 && v2)
+    } yield (BINARY_OP(0, 0, i1, AND_OP, i2), v1 && v2)
 
   def ORgen(gas: Int): Gen[(EXPR, Boolean)] =
     for {
       (i1, v1) <- BOOLgen((gas - 2) / 2)
       (i2, v2) <- BOOLgen((gas - 2) / 2)
-    } yield (BINARY_OP(i1, OR_OP, i2), v1 || v2)
+    } yield (BINARY_OP(0, 0, i1, OR_OP, i2), v1 || v2)
 
   def IF_BOOLgen(gas: Int): Gen[(EXPR, Boolean)] =
     for {
       (cnd, vcnd) <- BOOLgen((gas - 3) / 3)
       (t, vt)     <- BOOLgen((gas - 3) / 3)
       (f, vf)     <- BOOLgen((gas - 3) / 3)
-    } yield (IF(cnd, t, f), if (vcnd) vt else vf)
+    } yield (IF(0, 0, cnd, t, f), if (vcnd) { vt } else { vf })
 
   def IF_INTgen(gas: Int): Gen[(EXPR, Long)] =
     for {
       (cnd, vcnd) <- BOOLgen((gas - 3) / 3)
       (t, vt)     <- INTGen((gas - 3) / 3)
       (f, vf)     <- INTGen((gas - 3) / 3)
-    } yield (IF(cnd, t, f), if (vcnd) vt else vf)
+    } yield (IF(0, 0, cnd, t, f), if (vcnd) { vt } else { vf })
 
   def STRgen: Gen[EXPR] =
-    Gen.identifier.map(PART.VALID[String]).map(CONST_STRING(_))
+    Gen.identifier.map(PART.VALID[String](0, 0, _)).map(CONST_STRING(0, 0, _))
 
   def LETgen(gas: Int): Gen[LET] =
     for {
       name       <- Gen.identifier
       (value, _) <- BOOLgen((gas - 3) / 3)
-    } yield LET(PART.VALID(name), value, Seq.empty)
+    } yield LET(0, 0, PART.VALID(0, 0, name), value, Seq.empty)
 
   def REFgen: Gen[EXPR] =
-    Gen.identifier.filter(!keywords(_)).map(PART.VALID[String]).map(REF(_))
+    Gen.identifier.map(PART.VALID[String](0, 0, _)).map(REF(0, 0, _))
 
   def BLOCKgen(gas: Int): Gen[EXPR] =
     for {
       let  <- LETgen((gas - 3) / 3)
       body <- Gen.oneOf(BOOLgen((gas - 3) / 3).map(_._1), BLOCKgen((gas - 3) / 3)) // BLOCKGen wasn't add to BOOLGen since issue: NODE-700
-    } yield BLOCK(let, body)
+    } yield BLOCK(0, 0, let, body)
 
   private val spaceChars: Seq[Char] = " \t\n\r"
 
@@ -144,46 +124,33 @@ trait ScriptGen {
     for {
       pred <- whitespaces
       post <- whitespaces
-    } yield s" $expr " //pred + expr + post
+    } yield pred + expr + post
 
   private def toString[T](part: PART[T])(implicit ct: ClassTag[T]): String = part match {
-    case PART.VALID(x: String)      => x
-    case PART.VALID(xs: ByteVector) => Base58.encode(xs.toArray)
-    case PART.INVALID(consumed, _)  => consumed
-    case _                          => throw new RuntimeException(s"Can't stringify $part")
+    case PART.VALID(_, _, x: String)      => x
+    case PART.VALID(_, _, xs: ByteVector) => Base58.encode(xs.toArray)
+    case _                                => throw new RuntimeException(s"Can't stringify $part")
   }
 
   def toString(expr: EXPR): Gen[String] = expr match {
-    case CONST_LONG(x)                                                 => withWhitespaces(s"$x")
-    case REF(x)                                                        => withWhitespaces(toString(x))
-    case CONST_STRING(x)                                               => withWhitespaces(s"""\"${toString(x)}\"""")
-    case CONST_BYTEVECTOR(x)                                           => withWhitespaces(s"""base58'${toString(x)}'""")
-    case TRUE                                                          => withWhitespaces("true")
-    case FALSE                                                         => withWhitespaces("false")
-    case FUNCTION_CALL(PART.VALID("-"), List(CONST_LONG(v))) if v >= 0 => s"-($v)"
-    case FUNCTION_CALL(op, List(e))                                    => toString(e).map(e => s"${toString(op)}$e")
-    case BINARY_OP(x, LE_OP, y) =>
-      for {
-        arg2 <- toString(x)
-        arg1 <- toString(y)
-      } yield s"($arg1<=$arg2)"
-    case BINARY_OP(x, LT_OP, y) =>
-      for {
-        arg2 <- toString(x)
-        arg1 <- toString(y)
-      } yield s"($arg1<$arg2)"
-    case BINARY_OP(x, op: BinaryOperation, y) =>
+    case CONST_LONG(_, _, x)       => withWhitespaces(s"$x")
+    case REF(_, _, x)              => withWhitespaces(toString(x))
+    case CONST_STRING(_, _, x)     => withWhitespaces(s"""\"${toString(x)}\"""")
+    case CONST_BYTEVECTOR(_, _, x) => withWhitespaces(s"""base58'${toString(x)}'""")
+    case _: TRUE                   => withWhitespaces("true")
+    case _: FALSE                  => withWhitespaces("false")
+    case BINARY_OP(_, _, x, op: BinaryOperation, y) =>
       for {
         arg1 <- toString(x)
         arg2 <- toString(y)
       } yield s"($arg1${opsToFunctions(op)}$arg2)"
-    case IF(cond, x, y) =>
+    case IF(_, _, cond, x, y) =>
       for {
         c <- toString(cond)
         t <- toString(x)
         f <- toString(y)
       } yield s"(if ($c) then $t else $f)"
-    case BLOCK(let, body) =>
+    case BLOCK(_, _, let, body) =>
       for {
         v <- toString(let.value)
         b <- toString(body)
@@ -195,17 +162,8 @@ trait ScriptGen {
 trait ScriptGenParser extends ScriptGen {
   override def BOOLgen(gas: Int): Gen[(EXPR, Boolean)] = {
     if (gas > 0)
-      Gen.oneOf(
-        GEgen(gas - 1),
-        GTgen(gas - 1),
-        EQ_INTgen(gas - 1),
-        ANDgen(gas - 1),
-        ORgen(gas - 1),
-        IF_BOOLgen(gas - 1),
-        REFgen.map(r => (r, false)),
-        BOOLgen(gas - 1).map(e => (FUNCTION_CALL("!", List(e._1)), !e._2))
-      )
-    else Gen.const((TRUE, true))
+      Gen.oneOf(GEgen(gas - 1), GTgen(gas - 1), EQ_INTgen(gas - 1), ANDgen(gas - 1), ORgen(gas - 1), IF_BOOLgen(gas - 1), REFgen.map(r => (r, false)))
+    else Gen.const((TRUE(0, 0), true))
   }
 
   override def INTGen(gas: Int): Gen[(EXPR, Long)] =

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/testing/ScriptGen.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/testing/ScriptGen.scala
@@ -157,7 +157,12 @@ trait ScriptGen {
         isNewLine <- Arbitrary.arbBool.arbitrary
         sep       <- if (isNewLine) Gen.const("\n") else withWhitespaces(";")
       } yield s"let ${toString(let.name)} = $v$sep$b"
-    case _ => ???
+
+    case FUNCTION_CALL(_, _, PART.VALID(_, _, "-"), List(CONST_LONG(_, _, v))) if v >= 0 =>
+      s"-($v)"
+    case FUNCTION_CALL(_, _, op, List(e)) => toString(e).map(e => s"${toString(op)}$e")
+
+    case x => throw new NotImplementedError(s"toString for ${x.getClass.getSimpleName}")
   }
 }
 

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/testing/ScriptGen.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/testing/ScriptGen.scala
@@ -152,9 +152,11 @@ trait ScriptGen {
       } yield s"(if ($c) then $t else $f)"
     case BLOCK(_, _, let, body) =>
       for {
-        v <- toString(let.value)
-        b <- toString(body)
-      } yield s"let ${toString(let.name)} = $v $b\n"
+        v         <- toString(let.value)
+        b         <- toString(body)
+        isNewLine <- Arbitrary.arbBool.arbitrary
+        sep       <- if (isNewLine) Gen.const("\n") else withWhitespaces(";")
+      } yield s"let ${toString(let.name)} = $v$sep$b"
     case _ => ???
   }
 }

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/OracleDataTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/OracleDataTest.scala
@@ -30,18 +30,12 @@ class OracleDataTest extends PropSpec with PropertyChecks with Matchers with Tra
       bin             <- binaryEntryGen(500, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key)
       str             <- stringEntryGen(500, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key && e.key != bin.key)
       dataTransaction <- dataTransactionGenP(oracle, List(long, bool, bin, str))
-      allFieldsRequiredScript = s"""
-                    |
-                    | let oracle = extract(addressFromString("${oracle.address}"))
-                    | let long = extract(getLong(oracle,"${long.key}")) == ${long.value}
-                    | let bool = extract(getBoolean(oracle,"${bool.key}")) == ${bool.value}
-                    | let bin = extract(getByteArray(oracle,"${bin.key}")) == base58'${bin.value.base58}'
-                    | let str = extract(getString(oracle,"${str.key}")) == "${str.value}"
-                    | long && bool && bin && str
-                    |
-                    |
-                    |
-        """.stripMargin
+      allFieldsRequiredScript = s"""let oracle = extract(addressFromString("${oracle.address}"))
+                                   |let long = extract(getLong(oracle,"${long.key}")) == ${long.value}
+                                   |let bool = extract(getBoolean(oracle,"${bool.key}")) == ${bool.value}
+                                   |let bin = extract(getByteArray(oracle,"${bin.key}")) == base58'${bin.value.base58}'
+                                   |let str = extract(getString(oracle,"${str.key}")) == "${str.value}"
+                                   |long && bool && bin && str""".stripMargin
       setScript <- {
         val untypedAllFieldsRequiredScript = Parser(allFieldsRequiredScript).get.value
         assert(untypedAllFieldsRequiredScript.size == 1)


### PR DESCRIPTION
* Offsets in expressions;
* Parser fixes:
  * NODE-700: ; and \n rules in BLOCK;
  * Better accessors parsing: now it treats multiline function calls as invalid: (foo)\n(bar, baz);
  * Better numbers parsing;
  * NoCut for LET;
* ParserTest:
  * Additional tests for BLOCK (NODE-700), tests for multiple accessors;
  * More detailed information about failure.