### PR TITLE
NODE-764  Use base64 to encode scripts

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/async/SmartTransactionsConstraintsSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/async/SmartTransactionsConstraintsSuite.scala
@@ -93,7 +93,7 @@ class SmartTransactionsConstraintsSuite extends FreeSpec with Matchers with Tran
   private def toRequest(tx: SetScriptTransaction): SignedSetScriptRequest = SignedSetScriptRequest(
     version = tx.version,
     senderPublicKey = Base58.encode(tx.sender.publicKey),
-    script = tx.script.map(_.bytes().base58),
+    script = tx.script.map(_.bytes().base64),
     fee = tx.fee,
     timestamp = tx.timestamp,
     proofs = tx.proofs.proofs.map(_.base58)(collection.breakOut)

--- a/it/src/test/scala/com/wavesplatform/it/sync/DataTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/DataTransactionSuite.scala
@@ -144,6 +144,9 @@ class DataTransactionSuite extends BaseTransactionSuite {
     sender.getData(secondAddress).equals(dataAllTypes)
 
     notMiner.assertBalances(secondAddress, balance2 - fee, eff2 - fee)
+
+    val json = Json.parse(sender.get(s"/transactions/info/$txId").getResponseBody)
+    ((json \ "data")(2) \ "value").as[String].startsWith("base64:") shouldBe true
   }
 
   test("queries for nonexistent data") {
@@ -218,7 +221,7 @@ class DataTransactionSuite extends BaseTransactionSuite {
                                 "Illegal base64 character")
 
     assertBadRequestAndResponse(sender.postJson("/addresses/data", request(notValidBlobValue + ("value" -> JsString("yomp")))),
-                                "Base64 encoding expected")
+                                "base64:chars expected")
   }
 
   test("transaction requires a valid proof") {

--- a/it/src/test/scala/com/wavesplatform/it/sync/SetScriptTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/SetScriptTransactionSuite.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.lang.v1.parser.Parser
 import com.wavesplatform.state._
 import com.wavesplatform.utils.dummyTypeCheckerContext
 import org.scalatest.CancelAfterFailure
-import play.api.libs.json.JsNumber
+import play.api.libs.json.{JsNumber, Json}
 import scorex.account.PrivateKeyAccount
 import scorex.transaction.Proofs
 import scorex.transaction.transfer._
@@ -85,6 +85,10 @@ class SetScriptTransactionSuite extends BaseTransactionSuite with CancelAfterFai
 
     acc0ScriptInfo.script.isEmpty shouldBe false
     acc0ScriptInfo.scriptText.isEmpty shouldBe false
+    acc0ScriptInfo.script.get.startsWith("base64:") shouldBe true
+
+    val json = Json.parse(sender.get(s"/transactions/info/$setScriptId").getResponseBody)
+    (json \ "script").as[String].startsWith("base64:") shouldBe true
   }
 
   test("can't send from acc0 using old pk") {

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/SignAndBroadcastApiSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/SignAndBroadcastApiSuite.scala
@@ -202,6 +202,19 @@ class SignAndBroadcastApiSuite extends BaseTransactionSuite {
     )
   }
 
+  test("/transactions/sign should produce script transaction that is good for /transactions/broadcast") {
+    signAndBroadcast(
+      Json.obj(
+        "type"    -> 13,
+        "version" -> 1,
+        "sender"  -> firstAddress,
+        "script"  -> None,
+        "fee"     -> 100000
+      ),
+      usesProofs = true
+    )
+  }
+
   test("/transactions/sign should produce sponsor transactions that are good for /transactions/broadcast") {
     for (v <- supportedVersions) {
       val isProof = Option(v).nonEmpty

--- a/lang/jvm/src/main/scala/com/wavesplatform/utils/Base64.scala
+++ b/lang/jvm/src/main/scala/com/wavesplatform/utils/Base64.scala
@@ -1,0 +1,9 @@
+package com.wavesplatform.utils
+
+import scala.util.Try
+
+object Base64 {
+  def encode(input: Array[Byte]): String = "base64:" + new String(java.util.Base64.getEncoder.encode(input))
+
+  def decode(input: String): Try[Array[Byte]] = Try(java.util.Base64.getDecoder.decode(input.substring(7)))
+}

--- a/lang/jvm/src/main/scala/com/wavesplatform/utils/Base64.scala
+++ b/lang/jvm/src/main/scala/com/wavesplatform/utils/Base64.scala
@@ -5,5 +5,8 @@ import scala.util.Try
 object Base64 {
   def encode(input: Array[Byte]): String = "base64:" + new String(java.util.Base64.getEncoder.encode(input))
 
-  def decode(input: String): Try[Array[Byte]] = Try(java.util.Base64.getDecoder.decode(input.substring(7)))
+  def decode(input: String): Try[Array[Byte]] = Try {
+    if (input.length < 7) throw new IllegalArgumentException("String of the form base64:chars expected")
+    else java.util.Base64.getDecoder.decode(input.substring(7))
+  }
 }

--- a/lang/jvm/src/test/scala/com/wavesplatform/utils/Base64Test.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/utils/Base64Test.scala
@@ -1,0 +1,36 @@
+package com.wavesplatform.utils
+
+import org.scalacheck.Gen
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.PropertyChecks
+
+class Base64Test extends PropSpec with PropertyChecks with Matchers {
+
+  private val Base64Chars  = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/"
+  private val IllegalChars = "!@#$%^&*()_-?/.,<>|\';:`~"
+
+  val illegalGen: Gen[String] =
+    for {
+      length <- Gen.chooseNum(100, 1024)
+      chars <- Gen
+        .listOfN(length, Gen.oneOf(Base64Chars ++ IllegalChars))
+        .filter(_.toSet.intersect(IllegalChars.toSet).nonEmpty)
+    } yield chars.mkString
+
+  property("handles empty sequences") {
+    Base64.encode(Array.emptyByteArray) shouldBe "base64:"
+    val d = Base64.decode("base64:")
+    d.isSuccess shouldBe true
+    d.get.length shouldBe 0
+  }
+
+  property("decoding fails on illegal characters") {
+    forAll(illegalGen) { s =>
+      Base64.decode(s).isSuccess shouldBe false
+    }
+  }
+
+  property("decoding fails on null") {
+    Base64.decode(null).isSuccess shouldBe false
+  }
+}

--- a/src/main/scala/com/wavesplatform/state/ByteStr.scala
+++ b/src/main/scala/com/wavesplatform/state/ByteStr.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.state
 
 import play.api.libs.json._
-import com.wavesplatform.utils.Base58
+import com.wavesplatform.utils.{Base58, Base64}
 
 import scala.util.Try
 
@@ -14,6 +14,8 @@ case class ByteStr(arr: Array[Byte]) {
   override def hashCode(): Int = java.util.Arrays.hashCode(arr)
 
   lazy val base58: String = Base58.encode(arr)
+
+  lazy val base64: String = Base64.encode(arr)
 
   lazy val trim: String = base58.toString.take(7) + "..."
 

--- a/src/main/scala/com/wavesplatform/state/DataEntry.scala
+++ b/src/main/scala/com/wavesplatform/state/DataEntry.scala
@@ -104,7 +104,7 @@ case class BooleanDataEntry(override val key: String, override val value: Boolea
 case class BinaryDataEntry(override val key: String, override val value: ByteStr) extends DataEntry[ByteStr](key, value) {
   override def valueBytes: Array[Byte] = Type.Binary.id.toByte +: Deser.serializeArray(value.arr)
 
-  override def toJson: JsObject = super.toJson + ("type" -> JsString("binary")) + ("value" -> JsString(Base64.encode(value.arr)))
+  override def toJson: JsObject = super.toJson + ("type" -> JsString("binary")) + ("value" -> JsString(value.base64))
 
   override def valid: Boolean = super.valid && value.arr.length <= MaxValueSize
 }

--- a/src/main/scala/com/wavesplatform/utils/JsonFileStorage.scala
+++ b/src/main/scala/com/wavesplatform/utils/JsonFileStorage.scala
@@ -41,7 +41,7 @@ object JsonFileStorage {
   private def encrypt(key: SecretKeySpec, value: String): String = {
     val cipher: Cipher = Cipher.getInstance(algorithm)
     cipher.init(Cipher.ENCRYPT_MODE, key)
-    Base64.encode(cipher.doFinal(value.getBytes(encoding)))
+    ScorexBase64.encode(cipher.doFinal(value.getBytes(encoding)))
   }
 
   private def decrypt(key: SecretKeySpec, encryptedValue: String): String = {

--- a/src/main/scala/com/wavesplatform/utils/JsonFileStorage.scala
+++ b/src/main/scala/com/wavesplatform/utils/JsonFileStorage.scala
@@ -5,7 +5,7 @@ import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
 
 import play.api.libs.json.{Json, Reads, Writes}
-import scorex.crypto.encode.Base64
+import scorex.crypto.encode.{Base64 => ScorexBase64}
 
 import scala.io.{BufferedSource, Source}
 
@@ -47,7 +47,7 @@ object JsonFileStorage {
   private def decrypt(key: SecretKeySpec, encryptedValue: String): String = {
     val cipher: Cipher = Cipher.getInstance(algorithm)
     cipher.init(Cipher.DECRYPT_MODE, key)
-    new String(cipher.doFinal(Base64.decode(encryptedValue)))
+    new String(cipher.doFinal(ScorexBase64.decode(encryptedValue)))
   }
 
   def save[T](value: T, path: String, key: Option[SecretKeySpec])(implicit w: Writes[T]): Unit = {

--- a/src/main/scala/scorex/api/http/AddressApiRoute.scala
+++ b/src/main/scala/scorex/api/http/AddressApiRoute.scala
@@ -12,10 +12,11 @@ import com.wavesplatform.utx.UtxPool
 import io.netty.channel.group.ChannelGroup
 import io.swagger.annotations._
 import javax.ws.rs.Path
+
 import play.api.libs.json._
 import scorex.BroadcastRoute
 import scorex.account.{Address, PublicKeyAccount}
-import com.wavesplatform.utils.Base58
+import com.wavesplatform.utils.{Base58, Base64}
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction.smart.script.ScriptCompiler
 import scorex.transaction.{PoSCalc, TransactionFactory, ValidationError}
@@ -371,7 +372,7 @@ case class AddressApiRoute(settings: RestAPISettings,
     } yield
       AddressScriptInfo(
         address = account.address,
-        script = script.map(_.bytes().base58),
+        script = script.map(s => Base64.encode(s.bytes().arr)),
         scriptText = script.map(_.text),
         complexity = complexity,
         extraFee = if (script.isEmpty) 0 else CommonValidation.ScriptExtraFee

--- a/src/main/scala/scorex/api/http/AddressApiRoute.scala
+++ b/src/main/scala/scorex/api/http/AddressApiRoute.scala
@@ -1,6 +1,7 @@
 package scorex.api.http
 
 import java.nio.charset.StandardCharsets
+import javax.ws.rs.Path
 
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.server.Route
@@ -8,15 +9,13 @@ import com.wavesplatform.crypto
 import com.wavesplatform.settings.{FunctionalitySettings, RestAPISettings}
 import com.wavesplatform.state.Blockchain
 import com.wavesplatform.state.diffs.CommonValidation
+import com.wavesplatform.utils.Base58
 import com.wavesplatform.utx.UtxPool
 import io.netty.channel.group.ChannelGroup
 import io.swagger.annotations._
-import javax.ws.rs.Path
-
 import play.api.libs.json._
 import scorex.BroadcastRoute
 import scorex.account.{Address, PublicKeyAccount}
-import com.wavesplatform.utils.{Base58, Base64}
 import scorex.transaction.ValidationError.GenericError
 import scorex.transaction.smart.script.ScriptCompiler
 import scorex.transaction.{PoSCalc, TransactionFactory, ValidationError}
@@ -372,7 +371,7 @@ case class AddressApiRoute(settings: RestAPISettings,
     } yield
       AddressScriptInfo(
         address = account.address,
-        script = script.map(s => Base64.encode(s.bytes().arr)),
+        script = script.map(_.bytes().base64),
         scriptText = script.map(_.text),
         complexity = complexity,
         extraFee = if (script.isEmpty) 0 else CommonValidation.ScriptExtraFee

--- a/src/main/scala/scorex/api/http/UtilsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/UtilsApiRoute.scala
@@ -1,16 +1,15 @@
 package scorex.api.http
 
 import java.security.SecureRandom
+import javax.ws.rs.Path
 
 import akka.http.scaladsl.server.Route
 import com.wavesplatform.crypto
 import com.wavesplatform.settings.RestAPISettings
 import com.wavesplatform.state.diffs.CommonValidation
+import com.wavesplatform.utils.Base58
 import io.swagger.annotations._
-import javax.ws.rs.Path
-
 import play.api.libs.json.Json
-import com.wavesplatform.utils.{Base58, Base64}
 import scorex.transaction.smart.script.{Script, ScriptCompiler}
 import scorex.utils.Time
 
@@ -47,7 +46,7 @@ case class UtilsApiRoute(timeService: Time, settings: RestAPISettings) extends A
           e => Json.obj("error" -> e), {
             case (script, complexity) =>
               Json.obj(
-                "script"     -> Base64.encode(script.bytes().arr),
+                "script"     -> script.bytes().base64,
                 "complexity" -> complexity,
                 "extraFee"   -> CommonValidation.ScriptExtraFee
               )

--- a/src/main/scala/scorex/api/http/assets/SignedIssueV2Request.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedIssueV2Request.scala
@@ -44,7 +44,7 @@ case class SignedIssueV2Request(@ApiModelProperty(required = true)
       _proofs     <- Proofs.create(_proofBytes)
       _script <- script match {
         case None    => Right(None)
-        case Some(s) => Script.fromBase58String(s).map(Some(_))
+        case Some(s) => Script.fromBase64String(s).map(Some(_))
       }
       t <- IssueTransactionV2.create(
         version,

--- a/src/main/scala/scorex/api/http/assets/SignedSetScriptRequest.scala
+++ b/src/main/scala/scorex/api/http/assets/SignedSetScriptRequest.scala
@@ -32,7 +32,7 @@ case class SignedSetScriptRequest(@ApiModelProperty(required = true)
       _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
       _script <- script match {
         case None    => Right(None)
-        case Some(s) => Script.fromBase58String(s).map(Some(_))
+        case Some(s) => Script.fromBase64String(s).map(Some(_))
       }
       _proofBytes <- proofs.traverse(s => parseBase58(s, "invalid proof", Proofs.MaxProofStringSize))
       _proofs     <- Proofs.create(_proofBytes)

--- a/src/main/scala/scorex/transaction/TransactionFactory.scala
+++ b/src/main/scala/scorex/transaction/TransactionFactory.scala
@@ -94,7 +94,7 @@ object TransactionFactory {
       signer <- if (request.sender == signerAddress) Right(sender) else wallet.findPrivateKey(signerAddress)
       script <- request.script match {
         case None    => Right(None)
-        case Some(s) => Script.fromBase58String(s).map(Some(_))
+        case Some(s) => Script.fromBase64String(s).map(Some(_))
       }
       tx <- SetScriptTransaction.signed(
         request.version,
@@ -115,7 +115,7 @@ object TransactionFactory {
       signer <- if (request.sender == signerAddress) Right(sender) else wallet.findPrivateKey(signerAddress)
       s <- request.script match {
         case None    => Right(None)
-        case Some(s) => Script.fromBase58String(s).map(Some(_))
+        case Some(s) => Script.fromBase64String(s).map(Some(_))
       }
       tx <- IssueTransactionV2.signed(
         version = request.version,

--- a/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
+++ b/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
@@ -3,6 +3,7 @@ package scorex.transaction.smart
 import com.google.common.primitives.{Bytes, Longs}
 import com.wavesplatform.crypto
 import com.wavesplatform.state._
+import com.wavesplatform.utils.Base64
 import monix.eval.Coeval
 import play.api.libs.json.Json
 import scorex.account._
@@ -36,7 +37,7 @@ case class SetScriptTransaction private (version: Byte,
     ))
 
   override val assetFee = (None, fee)
-  override val json     = Coeval.evalOnce(jsonBase() ++ Json.obj("version" -> version, "script" -> script.map(_.bytes())))
+  override val json     = Coeval.evalOnce(jsonBase() ++ Json.obj("version" -> version, "script" -> script.map(s => Base64.encode(s.bytes().arr))))
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 }

--- a/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
+++ b/src/main/scala/scorex/transaction/smart/SetScriptTransaction.scala
@@ -3,7 +3,6 @@ package scorex.transaction.smart
 import com.google.common.primitives.{Bytes, Longs}
 import com.wavesplatform.crypto
 import com.wavesplatform.state._
-import com.wavesplatform.utils.Base64
 import monix.eval.Coeval
 import play.api.libs.json.Json
 import scorex.account._
@@ -37,7 +36,7 @@ case class SetScriptTransaction private (version: Byte,
     ))
 
   override val assetFee = (None, fee)
-  override val json     = Coeval.evalOnce(jsonBase() ++ Json.obj("version" -> version, "script" -> script.map(s => Base64.encode(s.bytes().arr))))
+  override val json     = Coeval.evalOnce(jsonBase() ++ Json.obj("version" -> version, "script" -> script.map(_.bytes().base64)))
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 }

--- a/src/main/scala/scorex/transaction/smart/script/Script.scala
+++ b/src/main/scala/scorex/transaction/smart/script/Script.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.lang.Versioned
 import com.wavesplatform.lang.v1.compiler.Terms
 import com.wavesplatform.state.ByteStr
 import monix.eval.Coeval
-import com.wavesplatform.utils.Base58
+import com.wavesplatform.utils.Base64
 import scorex.transaction.ValidationError.ScriptParseError
 
 trait Script extends Versioned {
@@ -25,9 +25,9 @@ object Script {
 
   val checksumLength = 4
 
-  def fromBase58String(str: String): Either[ScriptParseError, Script] =
+  def fromBase64String(str: String): Either[ScriptParseError, Script] =
     for {
-      bytes  <- Base58.decode(str).toEither.left.map(ex => ScriptParseError(s"Unable to decode base58: ${ex.getMessage}"))
+      bytes  <- Base64.decode(str).toEither.left.map(ex => ScriptParseError(s"Unable to decode base64: ${ex.getMessage}"))
       script <- ScriptReader.fromBytes(bytes)
     } yield script
 

--- a/src/test/scala/com/wavesplatform/http/AddressRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AddressRouteSpec.scala
@@ -152,7 +152,7 @@ class AddressRouteSpec
     Get(routePath(s"/scriptInfo/${allAddresses(1)}")) ~> route ~> check {
       val response = responseAs[JsObject]
       (response \ "address").as[String] shouldBe allAddresses(1)
-      (response \ "script").as[String] shouldBe "We8Dksx"
+      (response \ "script").as[String] shouldBe "base64:AQa3b8tH"
       (response \ "scriptText").as[String] shouldBe "TRUE"
       (response \ "complexity").as[Long] shouldBe 1
       (response \ "extraFee").as[Long] shouldBe CommonValidation.ScriptExtraFee

--- a/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.{JsObject, JsValue}
 import scorex.api.http.{TooBigArrayAllocation, UtilsApiRoute}
-import com.wavesplatform.utils.Base58
+import com.wavesplatform.utils.{Base58, Base64}
 import scorex.transaction.smart.script.Script
 import scorex.transaction.smart.script.v1.ScriptV1
 import scorex.utils.Time
@@ -35,18 +35,18 @@ class UtilsRouteSpec extends RouteSpec("/utils") with RestAPISettingsHelper with
       val json           = responseAs[JsValue]
       val expectedScript = ScriptV1(script).explicitGet()
 
-      Script.fromBase58String((json \ "script").as[String]) shouldBe Right(expectedScript)
+      Script.fromBase64String((json \ "script").as[String]) shouldBe Right(expectedScript)
       (json \ "complexity").as[Long] shouldBe 3
       (json \ "extraFee").as[Long] shouldBe CommonValidation.ScriptExtraFee
     }
   }
 
   routePath("/script/estimate") in {
-    val base58 = ScriptV1(script).explicitGet().bytes().base58
+    val base64 = Base64.encode(ScriptV1(script).explicitGet().bytes().arr)
 
-    Post(routePath("/script/estimate"), base58) ~> route ~> check {
+    Post(routePath("/script/estimate"), base64) ~> route ~> check {
       val json = responseAs[JsValue]
-      (json \ "script").as[String] shouldBe base58
+      (json \ "script").as[String] shouldBe base64
       (json \ "scriptText").as[String] shouldBe "FUNCTION_CALL(FunctionHeader(==,List(LONG, LONG)),List(CONST_LONG(1), CONST_LONG(2)),BOOLEAN)"
       (json \ "complexity").as[Long] shouldBe 3
       (json \ "extraFee").as[Long] shouldBe CommonValidation.ScriptExtraFee

--- a/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.{JsObject, JsValue}
 import scorex.api.http.{TooBigArrayAllocation, UtilsApiRoute}
-import com.wavesplatform.utils.{Base58, Base64}
+import com.wavesplatform.utils.Base58
 import scorex.transaction.smart.script.Script
 import scorex.transaction.smart.script.v1.ScriptV1
 import scorex.utils.Time
@@ -42,7 +42,7 @@ class UtilsRouteSpec extends RouteSpec("/utils") with RestAPISettingsHelper with
   }
 
   routePath("/script/estimate") in {
-    val base64 = Base64.encode(ScriptV1(script).explicitGet().bytes().arr)
+    val base64 = ScriptV1(script).explicitGet().bytes().base64
 
     Post(routePath("/script/estimate"), base64) ~> route ~> check {
       val json = responseAs[JsValue]


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-764

Changes:
- SetScript and Issue transactions accept base64-encoded scripts only
- REST API returns scripts as base64 strings
- Base64 strings must have "base64:" prefix to tell them from base58