### PR TITLE
NODE-766 DataTransactionSpecification fails sometimes

### DIFF
--- a/src/test/scala/scorex/transaction/DataTransactionSpecification.scala
+++ b/src/test/scala/scorex/transaction/DataTransactionSpecification.scala
@@ -41,7 +41,7 @@ class DataTransactionSpecification extends PropSpec with PropertyChecks with Mat
   }
 
   property("unknown type handing") {
-    val badTypeIdGen = Gen.choose[Byte](3, Byte.MaxValue)
+    val badTypeIdGen = Gen.choose[Int](DataEntry.Type.maxId + 1, Byte.MaxValue)
     forAll(dataTransactionGen, badTypeIdGen) {
       case (tx, badTypeId) =>
         val bytes      = tx.bytes()
@@ -49,7 +49,7 @@ class DataTransactionSpecification extends PropSpec with PropertyChecks with Mat
         if (entryCount > 0) {
           val key1Length = Shorts.fromByteArray(bytes.drop(37))
           val p          = 39 + key1Length
-          bytes(p) = badTypeId
+          bytes(p) = badTypeId.toByte
           val parsed = DataTransaction.parseBytes(bytes)
           parsed.isFailure shouldBe true
           parsed.failed.get.getMessage shouldBe s"Unknown type $badTypeId"


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-766

Max valid DataEntry type value is hardcoded as 3, which is wrong now as we've added String type. I'm fixing the code to use `maxId`