### PR TITLE
NODE-772 Improve error reports in REST APIs that expect base64

### DIFF
--- a/lang/jvm/src/main/scala/com/wavesplatform/utils/Base64.scala
+++ b/lang/jvm/src/main/scala/com/wavesplatform/utils/Base64.scala
@@ -6,7 +6,7 @@ object Base64 {
   def encode(input: Array[Byte]): String = "base64:" + new String(java.util.Base64.getEncoder.encode(input))
 
   def decode(input: String): Try[Array[Byte]] = Try {
-    if (input.length < 7) throw new IllegalArgumentException("String of the form base64:chars expected")
+    if (!input.startsWith("base64:")) throw new IllegalArgumentException("String of the form base64:chars expected")
     else java.util.Base64.getDecoder.decode(input.substring(7))
   }
 }


### PR DESCRIPTION
Explicitly check for the "base64:" prefix