### PR TITLE
NODE-773 API incompatibilities in v0.13.0

### DIFF
--- a/src/main/scala/scorex/api/http/assets/AssetsApiRoute.scala
+++ b/src/main/scala/scorex/api/http/assets/AssetsApiRoute.scala
@@ -273,8 +273,8 @@ case class AssetsApiRoute(settings: RestAPISettings, wallet: Wallet, utx: UtxPoo
           "decimals"       -> JsNumber(tx.decimals.toInt),
           "reissuable"     -> JsBoolean(description.reissuable),
           "quantity"       -> JsNumber(BigDecimal(description.totalVolume)),
-          "script"         -> JsString(description.script.fold("")(_.bytes().base58)),
-          "scriptText"     -> JsString(description.script.fold("")(_.text)),
+          "script"         -> Json.toJson(description.script.map(_.bytes().base58)),
+          "scriptText"     -> Json.toJson(description.script.map(_.text)),
           "complexity"     -> JsNumber(complexity),
           "extraFee"       -> JsNumber(if (description.script.isEmpty) 0 else CommonValidation.ScriptExtraFee),
           "minSponsoredAssetFee" -> (description.sponsorship match {

--- a/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
+++ b/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
@@ -29,6 +29,7 @@ trait IssueTransaction extends ProvenTransaction {
   override val json = Coeval.evalOnce(
     jsonBase() ++ Json.obj(
       "version"     -> version,
+      "assetId"     -> assetId().base58,
       "name"        -> new String(name, StandardCharsets.UTF_8),
       "quantity"    -> quantity,
       "reissuable"  -> reissuable,

--- a/src/main/scala/scorex/transaction/transfer/TransferTransaction.scala
+++ b/src/main/scala/scorex/transaction/transfer/TransferTransaction.scala
@@ -29,6 +29,7 @@ trait TransferTransaction extends ProvenTransaction {
       "recipient"  -> recipient.stringRepr,
       "assetId"    -> assetId.map(_.base58),
       "feeAssetId" -> feeAssetId.map(_.base58),
+      "feeAsset"   -> feeAssetId.map(_.base58), // legacy v0.11.1 compat
       "amount"     -> amount,
       "attachment" -> Base58.encode(attachment)
     ))

--- a/src/test/scala/scorex/api/http/AssetsApiRouteSpec.scala
+++ b/src/test/scala/scorex/api/http/AssetsApiRouteSpec.scala
@@ -92,8 +92,8 @@ class AssetsApiRouteSpec
       (response \ "decimals").as[Int] shouldBe sillyAssetTx.decimals
       (response \ "reissuable").as[Boolean] shouldBe sillyAssetTx.reissuable
       (response \ "quantity").as[BigDecimal] shouldBe sillyAssetDesc.totalVolume
-      (response \ "script").as[String] shouldBe sillyAssetDesc.script.fold("")(_.bytes().base58)
-      (response \ "scriptText").as[String] shouldBe ""
+      (response \ "script").asOpt[String] shouldBe None
+      (response \ "scriptText").asOpt[String] shouldBe None
       (response \ "complexity").as[Long] shouldBe 0L
       (response \ "extraFee").as[Long] shouldBe 0
       (response \ "minSponsoredAssetFee").asOpt[Long] shouldBe empty

--- a/src/test/scala/scorex/transaction/IssueTransactionV1Specification.scala
+++ b/src/test/scala/scorex/transaction/IssueTransactionV1Specification.scala
@@ -34,6 +34,7 @@ class IssueTransactionV1Specification extends PropSpec with PropertyChecks with 
                        "timestamp": 1526287561757,
                        "version": 1,
                        "signature": "28kE1uN1pX2bwhzr9UHw5UuB9meTFEDFgeunNgy6nZWpHX4pzkGYotu8DhQ88AdqUG6Yy5wcXgHseKPBUygSgRMJ",
+                       "assetId": "9ekQuYn92natMnMq8KqeGK3Nn7cpKd3BvPEGgD6fFyyz",
                        "name": "Gigacoin",
                        "quantity": 10000000000,
                        "reissuable": true,
@@ -58,7 +59,7 @@ class IssueTransactionV1Specification extends PropSpec with PropertyChecks with 
       .right
       .get
 
-    js shouldEqual tx.json()
+    tx.json() shouldEqual js
   }
 
 }

--- a/src/test/scala/scorex/transaction/IssueTransactionV2Specification.scala
+++ b/src/test/scala/scorex/transaction/IssueTransactionV2Specification.scala
@@ -39,6 +39,7 @@ class IssueTransactionV2Specification extends PropSpec with PropertyChecks with 
                        "43TCfWBa6t2o2ggsD4bU9FpvH3kmDbSBWKE1Z6B5i5Ax5wJaGT2zAvBihSbnSS3AikZLcicVWhUk1bQAMWVzTG5g"
                        ],
                        "version": 2,
+                       "assetId": "2ykNAo5JrvNCcL8PtCmc9pTcNtKUy2PjJkrFdRvTfUf4",
                        "name": "Gigacoin",
                        "quantity": 10000000000,
                        "reissuable": true,
@@ -66,7 +67,7 @@ class IssueTransactionV2Specification extends PropSpec with PropertyChecks with 
       .right
       .get
 
-    js shouldEqual tx.json()
+    tx.json() shouldEqual js
   }
 
 }

--- a/src/test/scala/scorex/transaction/TransferTransactionV1Specification.scala
+++ b/src/test/scala/scorex/transaction/TransferTransactionV1Specification.scala
@@ -47,6 +47,7 @@ class TransferTransactionV1Specification extends PropSpec with PropertyChecks wi
                         "recipient": "3My3KZgFQ3CrVHgz6vGRt8687sH4oAA1qp8",
                         "assetId": null,
                         "feeAssetId": null,
+                        "feeAsset": null,
                         "amount": 1900000,
                         "attachment": "4t2Xazb2SX"
                         }
@@ -67,6 +68,6 @@ class TransferTransactionV1Specification extends PropSpec with PropertyChecks wi
       .right
       .get
 
-    js shouldEqual tx.json()
+    tx.json() shouldEqual js
   }
 }

--- a/src/test/scala/scorex/transaction/TransferTransactionV2Specification.scala
+++ b/src/test/scala/scorex/transaction/TransferTransactionV2Specification.scala
@@ -65,6 +65,7 @@ class TransferTransactionV2Specification extends PropSpec with PropertyChecks wi
                        "recipient": "3My3KZgFQ3CrVHgz6vGRt8687sH4oAA1qp8",
                        "assetId": null,
                        "feeAssetId": null,
+                       "feeAsset": null,
                        "amount": 100000000,
                        "attachment": "4t2Xazb2SX"}
     """)
@@ -85,6 +86,6 @@ class TransferTransactionV2Specification extends PropSpec with PropertyChecks wi
       .right
       .get
 
-    js shouldEqual tx.json()
+    tx.json() shouldEqual js
   }
 }


### PR DESCRIPTION
Changes:
- Restored `assetId` in IssueTransaction
- Added `feeAsset` to TransferTransaction so that both `feeAssetId` are returned. The former is for compatibility, the latter just looks better
- Changed `script` and `scriptText` in `/assets/details` from `String` to `Option[String]`. If there's no script, the API now returns `null`, not `""` as before