### PR TITLE
NODE-814-group-operations-by-priority

### DIFF
--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
@@ -938,7 +938,7 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
         |  case b => 1
         |}""".stripMargin
 
-    parseAll(script) shouldBe List(
+    parseAll(script)(0) shouldBe
       MATCH(
         0,
         46,
@@ -949,12 +949,11 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
             30,
             Some(PART.VALID(18, 19, "a")),
             List(),
-            BINARY_OP(23, 30, TRUE(23, 27), AND_OP, INVALID(33, 33, "expected a second operator", None))
+            BINARY_OP(23, 33, TRUE(23, 27), AND_OP, INVALID(33, 33, "expected a second operator", None))
           ),
           MATCH_CASE(33, 44, Some(PART.VALID(38, 39, "b")), List(), CONST_LONG(43, 44, 1))
         )
       )
-    )
   }
 
   property("if expressions") {
@@ -1074,7 +1073,7 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
     parseOne(code) shouldBe IF(
       0,
       38,
-      BINARY_OP(3, 17, CONST_LONG(8, 10, 15), LT_OP, CONST_LONG(3, 5, 10)),
+      BINARY_OP(3, 10, CONST_LONG(8, 10, 15), LT_OP, CONST_LONG(3, 5, 10)),
       TRUE(23, 27),
       FALSE(33, 38)
     )
@@ -1353,5 +1352,33 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
       PART.VALID(2, 22, "getElement"),
       List(REF(0, 2, PART.VALID(0, 2, "xs")), CONST_LONG(12, 13, 1))
     )
+  }
+
+  property("operations priority") {
+    parseOne("a-b+c") shouldBe BINARY_OP(0,
+                                         5,
+                                         BINARY_OP(0, 3, REF(0, 1, PART.VALID(0, 1, "a")), SUB_OP, REF(2, 3, PART.VALID(2, 3, "b"))),
+                                         SUM_OP,
+                                         REF(4, 5, PART.VALID(4, 5, "c")))
+    parseOne("a+b-c") shouldBe BINARY_OP(0,
+                                         5,
+                                         BINARY_OP(0, 3, REF(0, 1, PART.VALID(0, 1, "a")), SUM_OP, REF(2, 3, PART.VALID(2, 3, "b"))),
+                                         SUB_OP,
+                                         REF(4, 5, PART.VALID(4, 5, "c")))
+    parseOne("a+b*c") shouldBe BINARY_OP(0,
+                                         5,
+                                         REF(0, 1, PART.VALID(0, 1, "a")),
+                                         SUM_OP,
+                                         BINARY_OP(2, 5, REF(2, 3, PART.VALID(2, 3, "b")), MUL_OP, REF(4, 5, PART.VALID(4, 5, "c"))))
+    parseOne("a*b-c") shouldBe BINARY_OP(0,
+                                         5,
+                                         BINARY_OP(0, 3, REF(0, 1, PART.VALID(0, 1, "a")), MUL_OP, REF(2, 3, PART.VALID(2, 3, "b"))),
+                                         SUB_OP,
+                                         REF(4, 5, PART.VALID(4, 5, "c")))
+    parseOne("a/b*c") shouldBe BINARY_OP(0,
+                                         5,
+                                         BINARY_OP(0, 3, REF(0, 1, PART.VALID(0, 1, "a")), DIV_OP, REF(2, 3, PART.VALID(2, 3, "b"))),
+                                         MUL_OP,
+                                         REF(4, 5, PART.VALID(4, 5, "c")))
   }
 }

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/BinaryOperation.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/BinaryOperation.scala
@@ -5,7 +5,7 @@ import fastparse.all._
 
 sealed abstract class BinaryOperation {
   val func: String
-  val parser: P[Any] = P(func)
+  val parser: P[BinaryOperation] = P(func).map(_ => this)
   def expr(start: Int, end: Int, op1: EXPR, op2: EXPR): EXPR = {
     BINARY_OP(start, end, op1, this, op2)
   }
@@ -13,20 +13,11 @@ sealed abstract class BinaryOperation {
 
 object BinaryOperation {
 
-  val opsByPriority: List[BinaryOperation] = List[BinaryOperation](
-    OR_OP,
-    AND_OP,
-    EQ_OP,
-    NE_OP,
-    GT_OP,
-    GE_OP,
-    LT_OP,
-    LE_OP,
-    MUL_OP,
-    DIV_OP,
-    MOD_OP,
-    SUM_OP,
-    SUB_OP
+  val opsByPriority: List[List[BinaryOperation]] = List(
+    List(OR_OP, AND_OP),
+    List(EQ_OP, NE_OP, GT_OP, GE_OP, LT_OP, LE_OP),
+    List(SUM_OP, SUB_OP),
+    List(MUL_OP, DIV_OP, MOD_OP)
   )
 
   def opsToFunctions(op: BinaryOperation): String = op.func
@@ -48,6 +39,7 @@ object BinaryOperation {
   }
   case object GT_OP extends BinaryOperation {
     val func = ">"
+    override val parser = P(">" ~ !P("=")).map(_ => this)
   }
   case object SUM_OP extends BinaryOperation {
     val func = "+"
@@ -66,14 +58,14 @@ object BinaryOperation {
   }
   case object LE_OP extends BinaryOperation {
     val func            = ">="
-    override val parser = P("<=")
+    override val parser = P("<=").map(_ => this)
     override def expr(start: Int, end: Int, op1: EXPR, op2: EXPR): EXPR = {
       BINARY_OP(start, end, op2, LE_OP, op1)
     }
   }
   case object LT_OP extends BinaryOperation {
     val func            = ">"
-    override val parser = P("<")
+    override val parser = P("<" ~ !P("=")).map(_ => this)
     override def expr(start: Int, end: Int, op1: EXPR, op2: EXPR): EXPR = {
       BINARY_OP(start, end, op2, LT_OP, op1)
     }


### PR DESCRIPTION
Several operations (like '+' and '-', '*' and '/') have identical priority.