### PR TITLE
NODE-814-reorder-comparation-priority

### DIFF
--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
@@ -1380,5 +1380,12 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
                                          BINARY_OP(0, 3, REF(0, 1, PART.VALID(0, 1, "a")), DIV_OP, REF(2, 3, PART.VALID(2, 3, "b"))),
                                          MUL_OP,
                                          REF(4, 5, PART.VALID(4, 5, "c")))
+    parseOne("a<b==c>=d") shouldBe BINARY_OP(
+      0,
+      9,
+      BINARY_OP(0, 3, REF(2, 3, PART.VALID(2, 3, "b")), LT_OP, REF(0, 1, PART.VALID(0, 1, "a"))),
+      EQ_OP,
+      BINARY_OP(5, 9, REF(5, 6, PART.VALID(5, 6, "c")), GE_OP, REF(8, 9, PART.VALID(8, 9, "d")))
+    )
   }
 }

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/BinaryOperation.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/BinaryOperation.scala
@@ -15,7 +15,8 @@ object BinaryOperation {
 
   val opsByPriority: List[List[BinaryOperation]] = List(
     List(OR_OP, AND_OP),
-    List(EQ_OP, NE_OP, GT_OP, GE_OP, LT_OP, LE_OP),
+    List(EQ_OP, NE_OP),
+    List(GT_OP, GE_OP, LT_OP, LE_OP),
     List(SUM_OP, SUB_OP),
     List(MUL_OP, DIV_OP, MOD_OP)
   )


### PR DESCRIPTION
make prioority of '<', '>', '<=', '>=' greter then priority of '==' and '!='