### PR TITLE
NODE-785 Compatibility with testnet addresses

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/AtomicSwapSmartContractSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/AtomicSwapSmartContractSuite.scala
@@ -55,7 +55,7 @@ class AtomicSwapSmartContractSuite extends BaseTransactionSuite with CancelAfter
     match tx {
       case ttx: TransferTransaction =>
         let txRecipient = addressFromRecipient(ttx.recipient).bytes
-        let txSender = addressFromPublicKey(ttx.senderPk).bytes
+        let txSender = addressFromPublicKey(ttx.senderPublicKey).bytes
 
         let txToBob = (txRecipient == Bob) && (sha256(ttx.proofs[0]) == base58'$shaSecret') && ((20 + $beforeHeight) >= height)
         let backToAliceAfterHeight = ((height >= (21 + $beforeHeight)) && (txRecipient == Alice))

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/Types.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/Types.scala
@@ -24,10 +24,10 @@ object Types {
     "version"   -> LONG,
   )
   val proven = List(
-    "sender"    -> addressType.typeRef,
-    "senderPk"  -> BYTEVECTOR,
-    "bodyBytes" -> BYTEVECTOR,
-    "proofs"    -> listByteVector
+    "sender"          -> addressType.typeRef,
+    "senderPublicKey" -> BYTEVECTOR,
+    "bodyBytes"       -> BYTEVECTOR,
+    "proofs"          -> listByteVector
   )
 
   val genesisTransactionType = CaseType(
@@ -121,6 +121,7 @@ object Types {
   val orderType = CaseType(
     "Order",
     List(
+      "sender"           -> addressType.typeRef,
       "senderPublicKey"  -> BYTEVECTOR,
       "matcherPublicKey" -> BYTEVECTOR,
       "assetPair"        -> assetPairType.typeRef,

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/traits/Domain.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/traits/Domain.scala
@@ -29,7 +29,8 @@ object DataItem {
   case class Str(k: String, v: String)     extends DataItem
 }
 
-case class Ord(senderPublicKey: ByteVector,
+case class Ord(sender: Recipient.Address,
+               senderPublicKey: ByteVector,
                matcherPublicKey: ByteVector,
                assetPair: APair,
                orderType: OrdType,

--- a/src/main/scala/scorex/transaction/smart/RealTransactionWrapper.scala
+++ b/src/main/scala/scorex/transaction/smart/RealTransactionWrapper.scala
@@ -28,6 +28,7 @@ object RealTransactionWrapper {
   implicit def assetPair(a: AssetPair): APair = APair(a.amountAsset.map(toByteVector), a.priceAsset.map(toByteVector))
   implicit def ord(o: Order): Ord =
     Ord(
+      sender = Recipient.Address(ByteVector(o.sender.bytes.arr)),
       senderPublicKey = o.senderPublicKey.toAddress.bytes,
       matcherPublicKey = o.matcherPublicKey.toAddress.bytes,
       assetPair = o.assetPair,

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/predef/TransactionBindingsTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/predef/TransactionBindingsTest.scala
@@ -9,7 +9,6 @@ import scorex.account.{Address, Alias}
 import scorex.transaction.ProvenTransaction
 
 class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers with TransactionGen with NoShrink {
-
   def provenPart(t: ProvenTransaction): String = {
     def pg(i: Int) = s"let proof$i = t.proofs[$i] == base58'${t.proofs.proofs.applyOrElse(i, (_: Int) => ByteStr.empty).base58}'"
     s"""
@@ -17,14 +16,14 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
        |   let fee = t.fee == ${t.assetFee._2}
        |   let timestamp = t.timestamp == ${t.timestamp}
        |   let bodyBytes = t.bodyBytes == base58'${ByteStr(t.bodyBytes.apply()).base58}'
-       |   let sender = t.sender == addressFromPublicKey(base58'${t.sender.bytes.base58}')
-       |   let senderPk = t.senderPk == base58'${ByteStr(t.sender.publicKey).base58}'
+       |   let sender = t.sender == addressFromPublicKey(base58'${ByteStr(t.sender.publicKey).base58}')
+       |   let senderPublicKey = t.senderPublicKey == base58'${ByteStr(t.sender.publicKey).base58}'
        |   ${Range(0, 8).map(pg).mkString("\n")}
      """.stripMargin
   }
 
   val assertProvenPart =
-    "id && fee && timestamp && senderPk && proof0 && proof1 && proof2 && proof3 && proof4 && proof5 && proof6 && proof7 && bodyBytes"
+    "id && fee && timestamp && sender && senderPublicKey && proof0 && proof1 && proof2 && proof3 && proof4 && proof5 && proof6 && proof7 && bodyBytes"
 
   property("TransferTransaction binding") {
     forAll(Gen.oneOf(transferV1Gen, transferV2Gen)) { t =>
@@ -51,7 +50,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
            | case other => throw
            | }
            |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -78,7 +78,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
 
       val result = runScript[Boolean](
         s,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -97,7 +98,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           | case other => throw
           | }
           |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -117,7 +119,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           | case other => throw
           | }
           |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -135,7 +138,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           | case other => throw
           | }
           |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -157,7 +161,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           | case other => throw
           | }
           |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -175,7 +180,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           | case other => throw
           | }
           |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -195,7 +201,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           | case other => throw
           | }
           |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -215,7 +222,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
            | case other => throw
            | }
            |""".stripMargin,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -254,7 +262,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
 
       val result = runScript[Boolean](
         s,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }
@@ -296,7 +305,8 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
 
       val result = runScript[Boolean](
         script,
-        t
+        t,
+        'T'
       )
       result shouldBe Right(true)
     }

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/predef/package.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/predef/package.scala
@@ -12,7 +12,7 @@ import scorex.transaction.smart.BlockchainContext
 package object predef {
   val networkByte: Byte = 'u'
 
-  def runScript[T](script: String, tx: Transaction = null): Either[String, T] = {
+  def runScript[T](script: String, tx: Transaction = null, networkByte: Byte = networkByte): Either[String, T] = {
     val Success(expr, _) = Parser(script)
     if (expr.size == 1) {
       val Right((typedExpr, tpe)) = CompilerV1(dummyCompilerContext, expr.head)

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/NotaryControlledTransferScenartioTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/NotaryControlledTransferScenartioTest.scala
@@ -50,7 +50,7 @@ class NotaryControlledTransferScenartioTest extends PropSpec with PropertyChecks
                     |      let recipientAddress = addressFromRecipient(ttx.recipient)
                     |      let recipientAgreement = getBoolean(recipientAddress,txIdBase58String)
                     |      let isRecipientAgreed = if(isDefined(recipientAgreement)) then extract(recipientAgreement) else false
-                    |      let senderAddress = addressFromPublicKey(ttx.senderPk)
+                    |      let senderAddress = addressFromPublicKey(ttx.senderPublicKey)
                     |      senderAddress.bytes == company.bytes || (isNotary1Agreed && isRecipientAgreed)
                     |   case other => throw
                     | }

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/OnlyTransferIsAllowedTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/OnlyTransferIsAllowedTest.scala
@@ -20,7 +20,7 @@ class OnlyTransferIsAllowedTest extends PropSpec with PropertyChecks with Matche
          |
          | match tx {
          |  case ttx: TransferTransaction | MassTransferTransaction =>
-         |     sigVerify(ttx.bodyBytes,ttx.proofs[0],ttx.senderPk)
+         |     sigVerify(ttx.bodyBytes,ttx.proofs[0],ttx.senderPublicKey)
          |  case other =>
          |     false
          | }


### PR DESCRIPTION
- renamed senderPk to senderPublicKey (need careful review)