### PR TITLE
NODE-847 Implement ADDRESSFROMSTRING in RIDE

### DIFF
--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/Common.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/Common.scala
@@ -71,9 +71,9 @@ object Common {
     override def accountBalanceOf(addressOrAlias: Array[Byte], assetId: Option[Array[Byte]]): Either[String, Long] = ???
   }
 
-  def addressFromPublicKey(networkByte: Byte, pk: Array[Byte]): Array[Byte] = {
+  def addressFromPublicKey(networkByte: Byte, pk: Array[Byte], addressVersion: Byte = EnvironmentFunctions.AddressVersion): Array[Byte] = {
     val publicKeyHash   = Global.secureHash(pk).take(EnvironmentFunctions.HashLength)
-    val withoutChecksum = EnvironmentFunctions.AddressVersion +: networkByte +: publicKeyHash
+    val withoutChecksum = addressVersion +: networkByte +: publicKeyHash
     withoutChecksum ++ Global.secureHash(withoutChecksum).take(EnvironmentFunctions.ChecksumLength)
   }
 

--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/EvaluatorV1Test.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/EvaluatorV1Test.scala
@@ -331,6 +331,24 @@ class EvaluatorV1Test extends PropSpec with PropertyChecks with Matchers with Sc
     }
   }
 
+  property("dropRightBytes(ByteVector, Long) works as the native one") {
+    forAll(genBytesAndNumber) {
+      case (xs, number) =>
+        val expr   = FUNCTION_CALL(FunctionHeader.User("dropRightBytes"), List(CONST_BYTEVECTOR(xs), CONST_LONG(number)))
+        val actual = ev[ByteVector](PureContext.ctx.evaluationContext, expr)._2
+        actual shouldBe Right(xs.dropRight(number))
+    }
+  }
+
+  property("takeRightBytes(ByteVector, Long) works as the native one") {
+    forAll(genBytesAndNumber) {
+      case (xs, number) =>
+        val expr   = FUNCTION_CALL(FunctionHeader.User("takeRightBytes"), List(CONST_BYTEVECTOR(xs), CONST_LONG(number)))
+        val actual = ev[ByteVector](PureContext.ctx.evaluationContext, expr)._2
+        actual shouldBe Right(xs.takeRight(number))
+    }
+  }
+
   private val genStringAndNumber = for {
     xs     <- Arbitrary.arbString.arbitrary
     number <- Arbitrary.arbInt.arbitrary
@@ -340,7 +358,7 @@ class EvaluatorV1Test extends PropSpec with PropertyChecks with Matchers with Sc
     forAll(genStringAndNumber) {
       case (xs, number) =>
         val expr   = FUNCTION_CALL(FunctionHeader.Native(DROP_STRING), List(CONST_STRING(xs), CONST_LONG(number)))
-        val actual = ev[ByteVector](PureContext.ctx.evaluationContext, expr)._2
+        val actual = ev[String](PureContext.ctx.evaluationContext, expr)._2
         actual shouldBe Right(xs.drop(number))
     }
   }
@@ -349,8 +367,26 @@ class EvaluatorV1Test extends PropSpec with PropertyChecks with Matchers with Sc
     forAll(genStringAndNumber) {
       case (xs, number) =>
         val expr   = FUNCTION_CALL(FunctionHeader.Native(TAKE_STRING), List(CONST_STRING(xs), CONST_LONG(number)))
-        val actual = ev[ByteVector](PureContext.ctx.evaluationContext, expr)._2
+        val actual = ev[String](PureContext.ctx.evaluationContext, expr)._2
         actual shouldBe Right(xs.take(number))
+    }
+  }
+
+  property("dropRight(String, Long) works as the native one") {
+    forAll(genStringAndNumber) {
+      case (xs, number) =>
+        val expr   = FUNCTION_CALL(FunctionHeader.User("dropRight"), List(CONST_STRING(xs), CONST_LONG(number)))
+        val actual = ev[String](PureContext.ctx.evaluationContext, expr)._2
+        actual shouldBe Right(xs.dropRight(number))
+    }
+  }
+
+  property("takeRight(String, Long) works as the native one") {
+    forAll(genStringAndNumber) {
+      case (xs, number) =>
+        val expr   = FUNCTION_CALL(FunctionHeader.User("takeRight"), List(CONST_STRING(xs), CONST_LONG(number)))
+        val actual = ev[String](PureContext.ctx.evaluationContext, expr)._2
+        actual shouldBe Right(xs.takeRight(number))
     }
   }
 

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/FunctionIds.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/FunctionIds.scala
@@ -6,11 +6,12 @@ object FunctionIds {
   val GT_LONG: Short  = 4
   val GE_LONG: Short  = 5
 
-  val SUM_STRING: Short = 50
-  val GT_STRING: Short  = 51
-  val GE_STRING: Short  = 52
-
-  val SUM_BYTES: Short = 100
+  val SUM_STRING: Short  = 50
+  val GT_STRING: Short   = 51
+  val GE_STRING: Short   = 52
+  val TAKE_STRING: Short = 53
+  val DROP_STRING: Short = 54
+  val SIZE_STRING: Short = 55
 
   val EQ: Short = 150
 
@@ -26,6 +27,8 @@ object FunctionIds {
 
   val SIZE_BYTES: Short = 350
   val TAKE_BYTES: Short = 351
+  val DROP_BYTES: Short = 352
+  val SUM_BYTES: Short  = 353
 
   val SOME: Short      = 400
   val ISDEFINED: Short = 401
@@ -41,8 +44,10 @@ object FunctionIds {
   val BLAKE256: Short  = 552
   val SHA256: Short    = 553
 
-  val TOBASE58: Short = 600
-  val TOBASE64: Short = 601
+  val TOBASE58: Short   = 600
+  val FROMBASE58: Short = 601
+  val TOBASE64: Short   = 602
+  val FROMBASE64: Short = 603
 
   // Waves
   val DATA_LONG: Short    = 650
@@ -50,10 +55,8 @@ object FunctionIds {
   val DATA_BYTES: Short   = 652
   val DATA_STRING: Short  = 653
 
-  val ADDRESSFROMPUBKEY: Short    = 700
-  val ADDRESSFROMSTRING: Short    = 701
-  val ADDRESSFROMRECIPIENT: Short = 702
-  val ADDRESSFROMBYTES: Short     = 703
+  val ADDRESSFROMRECIPIENT: Short = 700
+  val ADDRESSFROMBYTES: Short     = 701
 
   val GETTRANSACTIONBYID: Short    = 750
   val ACCOUNTBALANCE: Short        = 751

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/CryptoContext.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/CryptoContext.scala
@@ -29,15 +29,29 @@ object CryptoContext {
 
     def toBase58StringF: BaseFunction = NativeFunction("toBase58String", 10, TOBASE58, STRING, "bytes" -> BYTEVECTOR) {
       case (bytes: ByteVector) :: Nil => global.base58Encode(bytes.toArray)
-      case _                          => ???
+      case xs                         => notImplemented("toBase58String(bytes: byte[])", xs)
+    }
+
+    def fromBase58StringF: BaseFunction = NativeFunction("fromBase58String", 10, FROMBASE58, BYTEVECTOR, "str" -> STRING) {
+      case (str: String) :: Nil => global.base58Decode(str).map(ByteVector(_))
+      case xs                   => notImplemented("fromBase58String(str: String)", xs)
     }
 
     def toBase64StringF: BaseFunction = NativeFunction("toBase64String", 10, TOBASE64, STRING, "bytes" -> BYTEVECTOR) {
       case (bytes: ByteVector) :: Nil => global.base64Encode(bytes.toArray)
-      case _                          => ???
+      case xs                         => notImplemented("toBase64String(bytes: byte[])", xs)
     }
 
-    CTX(Seq.empty, Map.empty, Seq(keccak256F, blake2b256F, sha256F, sigVerifyF, toBase58StringF, toBase64StringF))
+    def fromBase64StringF: BaseFunction = NativeFunction("fromBase64String", 10, FROMBASE64, BYTEVECTOR, "str" -> STRING) {
+      case (str: String) :: Nil => global.base64Decode(str).map(ByteVector(_))
+      case xs                   => notImplemented("fromBase64String(str: String)", xs)
+    }
+
+    CTX(
+      Seq.empty,
+      Map.empty,
+      Seq(keccak256F, blake2b256F, sha256F, sigVerifyF, toBase58StringF, fromBase58StringF, toBase64StringF, fromBase64StringF)
+    )
   }
 
   def evalContext(global: BaseGlobal): EvaluationContext   = build(global).evaluationContext

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/EnvironmentFunctions.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/EnvironmentFunctions.scala
@@ -12,7 +12,7 @@ class EnvironmentFunctions(environment: Environment) {
   private val Global = com.wavesplatform.lang.hacks.Global // Hack for IDEA
 
   def addressFromString(str: String): Either[String, Option[ByteVector]] = {
-    val base58String = if (str.startsWith(Prefix)) str.drop(Prefix.length) else str
+    val base58String = if (str.startsWith(AddressPrefix)) str.drop(AddressPrefix.length) else str
     Global.base58Decode(base58String, Global.MaxAddressLength) match {
       case Left(e) => Left(e)
       case Right(addressBytes) =>
@@ -41,9 +41,9 @@ class EnvironmentFunctions(environment: Environment) {
 }
 
 object EnvironmentFunctions {
-  val ChecksumLength        = 4
-  val HashLength            = 20
-  val AddressVersion: Byte  = 1
-  private val AddressLength = 1 + 1 + ChecksumLength + HashLength
-  private val Prefix        = "address:"
+  val ChecksumLength       = 4
+  val HashLength           = 20
+  val AddressVersion: Byte = 1
+  val AddressLength: Int   = 1 + 1 + ChecksumLength + HashLength
+  val AddressPrefix        = "address:"
 }

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/PureContext.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/PureContext.scala
@@ -61,7 +61,7 @@ object PureContext {
   }
 
   val sizeString: BaseFunction = NativeFunction("size", 1, SIZE_STRING, LONG, "xs" -> STRING) {
-    case (bv: String) :: Nil => Right(bv.length)
+    case (bv: String) :: Nil => Right(bv.length.toLong)
     case xs                  => notImplemented("size(String)", xs)
   }
 
@@ -115,13 +115,15 @@ object PureContext {
     case xs => notImplemented("dropRight(xs: byte[], number: Long)", xs)
   }
 
+  private def trimLongToInt(x: Long): Int = Math.toIntExact(Math.max(Math.min(x, Int.MaxValue), Int.MinValue))
+
   val takeString: BaseFunction = NativeFunction("take", 1, TAKE_STRING, STRING, "xs" -> STRING, "number" -> LONG) {
-    case (xs: String) :: (number: Long) :: Nil => Right(xs.take(Math.toIntExact(number)))
+    case (xs: String) :: (number: Long) :: Nil => Right(xs.take(trimLongToInt(number)))
     case xs                                    => notImplemented("take(xs: String, number: Long)", xs)
   }
 
   val dropString: BaseFunction = NativeFunction("drop", 1, DROP_STRING, STRING, "xs" -> STRING, "number" -> LONG) {
-    case (xs: String) :: (number: Long) :: Nil => Right(xs.drop(Math.toIntExact(number)))
+    case (xs: String) :: (number: Long) :: Nil => Right(xs.drop(trimLongToInt(number)))
     case xs                                    => notImplemented("drop(xs: String, number: Long)", xs)
   }
 

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/package.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/package.scala
@@ -1,0 +1,7 @@
+package com.wavesplatform.lang.v1.evaluator.ctx
+
+package object impl {
+  def notImplemented(funcName: String, args: List[Any]): Either[String, Nothing] = Left(
+    s"Can't apply (${args.map(_.getClass.getSimpleName).mkString(", ")}) to '$funcName'"
+  )
+}

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
@@ -160,18 +160,19 @@ object WavesContext {
                 )
               ),
               IF(
+                // version
                 FUNCTION_CALL(
                   FunctionHeader.Native(EQ),
                   List(
-                    FUNCTION_CALL(FunctionHeader.Native(TAKE_BYTES), List(REF("@afs_addrBytes"), CONST_LONG(1))), // version
+                    FUNCTION_CALL(FunctionHeader.Native(TAKE_BYTES), List(REF("@afs_addrBytes"), CONST_LONG(1))),
                     CONST_BYTEVECTOR(ByteVector(EnvironmentFunctions.AddressVersion))
                   )
                 ),
                 IF(
+                  // networkByte
                   FUNCTION_CALL(
                     FunctionHeader.Native(EQ),
                     List(
-                      // networkByte
                       FUNCTION_CALL(
                         FunctionHeader.Native(TAKE_BYTES),
                         List(

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
@@ -102,44 +102,16 @@ object WavesContext {
       str
     )
 
-    def dropRightExpr(xs: EXPR, number: Long): EXPR = FUNCTION_CALL(
-      FunctionHeader.Native(TAKE_BYTES),
-      List(
-        xs,
-        FUNCTION_CALL(
-          FunctionHeader.Native(SUB_LONG),
-          List(
-            FUNCTION_CALL(FunctionHeader.Native(SIZE_BYTES), List(xs)),
-            CONST_LONG(number)
-          )
-        )
-      )
-    )
-
-    def takeRightExpr(xs: EXPR, number: Long): EXPR = FUNCTION_CALL(
-      FunctionHeader.Native(DROP_BYTES),
-      List(
-        xs,
-        FUNCTION_CALL(
-          FunctionHeader.Native(SUB_LONG),
-          List(
-            FUNCTION_CALL(FunctionHeader.Native(SIZE_BYTES), List(xs)),
-            CONST_LONG(number)
-          )
-        )
-      )
-    )
-
     def verifyAddressChecksumExpr(addressBytes: EXPR): EXPR = FUNCTION_CALL(
       FunctionHeader.Native(EQ),
       List(
         // actual checksum
-        takeRightExpr(addressBytes, EnvironmentFunctions.ChecksumLength),
+        FUNCTION_CALL(FunctionHeader.User("takeRightBytes"), List(addressBytes, CONST_LONG(EnvironmentFunctions.ChecksumLength))),
         // generated checksum
         FUNCTION_CALL(
           FunctionHeader.Native(TAKE_BYTES),
           List(
-            secureHashExpr(dropRightExpr(addressBytes, EnvironmentFunctions.ChecksumLength)),
+            secureHashExpr(FUNCTION_CALL(FunctionHeader.User("dropRightBytes"), List(addressBytes, CONST_LONG(EnvironmentFunctions.ChecksumLength)))),
             CONST_LONG(EnvironmentFunctions.ChecksumLength)
           )
         )

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
@@ -90,10 +90,86 @@ object WavesContext {
       case _ => ???
     }
 
-    val addressFromStringF: BaseFunction = NativeFunction("addressFromString", 100, ADDRESSFROMSTRING, optionAddress, "string" -> STRING) {
-      case (addressString: String) :: Nil =>
-        val r = environmentFunctions.addressFromString(addressString)
-        r.map(_.map(x => CaseObj(addressType.typeRef, Map("bytes" -> x))))
+    /*
+  def addressFromString(str: String): Either[String, Option[ByteVector]] = {
+    val base58String = if (str.startsWith(Prefix)) str.drop(Prefix.length) else str
+    Global.base58Decode(base58String, Global.MaxAddressLength) match {
+      case Left(e) => Left(e)
+      case Right(addressBytes) =>
+        val version = addressBytes.head
+        val network = addressBytes.tail.head
+        lazy val checksumCorrect = {
+          val checkSum          = addressBytes.takeRight(ChecksumLength)
+          val checkSumGenerated = Global.secureHash(addressBytes.dropRight(ChecksumLength)).take(ChecksumLength)
+          checkSum sameElements checkSumGenerated
+        }
+
+        if (version == AddressVersion && network == environment.networkByte && addressBytes.length == AddressLength && checksumCorrect)
+          Right(Some(ByteVector(addressBytes)))
+        else Right(None)
+    }
+  }
+     */
+    def removePrefix(str: EXPR, prefix: String): EXPR = IF(
+      FUNCTION_CALL(
+        FunctionHeader.Native(EQ),
+        List(
+          FUNCTION_CALL(FunctionHeader.Native(TAKE_STRING), List(str, CONST_LONG(prefix.length))),
+          CONST_STRING(prefix)
+        )
+      ),
+      FUNCTION_CALL(FunctionHeader.Native(DROP_STRING), List(str, CONST_LONG(prefix.length))),
+      str
+    )
+
+    val addressFromStringF: BaseFunction = UserFunction("addressFromString", 100, optionAddress, "string" -> STRING) {
+      case (str: EXPR) :: Nil =>
+        Right(
+          BLOCK(
+            LET("@afs_addrBytes", FUNCTION_CALL(FunctionHeader.Native(FROMBASE58), List(removePrefix(str, EnvironmentFunctions.AddressPrefix)))),
+            IF(
+              FUNCTION_CALL(
+                FunctionHeader.Native(EQ),
+                List(
+                  FUNCTION_CALL(FunctionHeader.Native(SIZE_BYTES), List(REF("@afs_addrBytes"))),
+                  CONST_LONG(EnvironmentFunctions.AddressLength)
+                )
+              ),
+              IF(
+                FUNCTION_CALL(
+                  FunctionHeader.Native(EQ),
+                  List(
+                    FUNCTION_CALL(FunctionHeader.Native(TAKE_BYTES), List(REF("@afs_addrBytes"), CONST_LONG(1))), // version
+                    CONST_BYTEVECTOR(ByteVector(EnvironmentFunctions.AddressVersion))
+                  )
+                ),
+                IF(
+                  FUNCTION_CALL(
+                    FunctionHeader.Native(EQ),
+                    List(
+                      // networkByte
+                      FUNCTION_CALL(
+                        FunctionHeader.Native(TAKE_BYTES),
+                        List(
+                          FUNCTION_CALL(FunctionHeader.Native(DROP_BYTES), List(REF("@afs_addrBytes"), CONST_LONG(1))),
+                          CONST_LONG(1)
+                        )
+                      ),
+                      CONST_BYTEVECTOR(ByteVector(env.networkByte))
+                    )
+                  ),
+                  FUNCTION_CALL(
+                    FunctionHeader.Native(SOME),
+                    List(FUNCTION_CALL(FunctionHeader.Native(ADDRESSFROMBYTES), List(REF("@afs_addrBytes"))))
+                  ),
+                  REF("None")
+                ),
+                REF("None")
+              ),
+              REF("None")
+            )
+          )
+        )
       case _ => ???
     }
 

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/NotaryControlledTransferScenartioTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/NotaryControlledTransferScenartioTest.scala
@@ -127,12 +127,10 @@ class NotaryControlledTransferScenartioTest extends PropSpec with PropertyChecks
     eval[Boolean](s"""toBase64String(base64'$s') == \"$s\"""").explicitGet() shouldBe true
   }
 
-  property("addressFromString() fails when address is too long") {
+  property("addressFromString() returns None when address is too long") {
     import Global.MaxAddressLength
     val longAddress = "A" * (MaxAddressLength + 1)
-    val r           = eval[ByteVector](s"""addressFromString("$longAddress")""")
-    r.isLeft shouldBe true
-    r.left.get shouldBe s"base58Decode input exceeds $MaxAddressLength"
+    eval[ByteVector](s"""addressFromString("$longAddress")""") shouldBe Right(None)
   }
 
   property("Scenario") {


### PR DESCRIPTION
* [x] Implemented system functions:
  * [x] drop(ByteVector, Long)
  * [x] tests for drop(ByteVector, Long)
  * [x] size(String)
  * [x] tests for size(String)
  * [x] take(String, Long)
  * [x] tests for take(String, Long)
  * [x] drop(String, Long)
  * [x] tests for drop(String, Long)
  * [x] fromBase58String(String)
  * [x] tests for fromBase58String(String)
  * [x] fromBase64String(String)
  * [x] tests for fromBase64String(String)
* [x] Implemented user functions:
  * [x] dropRight(ByteVector, Long)
  * [x] tests for dropRight(ByteVector, Long)
  * [x] takeRight(ByteVector, Long)
  * [x] tests for takeRight(ByteVector, Long)
  * [x] dropRight(String, Long)
  * [x] tests for dropRight(String, Long)
  * [x] takeRight(String, Long)
  * [x] tests for takeRight(String, Long)
* [x] addressFromString now is user function:
  * [x] base implementation
  * [x] check checksums
  * [x] Tests:
    * [x] sunny day
    * [x] with prefix
    * [x] wrong address version
    * [x] from other network
    * [x] wrong length
    * [x] wrong checksum
  * [x] Simplify tests
* [x] Better errors when function is not implemented for such arguments (not for all functions)