### PR TITLE
NODE-829 Updated Estimator to handle data constructors

### DIFF
--- a/benchmark/src/test/scala/com/wavesplatform/lang/v1/ScriptEstimatorBenchmark.scala
+++ b/benchmark/src/test/scala/com/wavesplatform/lang/v1/ScriptEstimatorBenchmark.scala
@@ -3,7 +3,6 @@ package com.wavesplatform.lang.v1
 import java.util.concurrent.TimeUnit
 
 import com.wavesplatform.lang.v1.ScriptEstimatorBenchmark.St
-import com.wavesplatform.lang.v1.evaluator.ctx.EvaluationContext
 import com.wavesplatform.utils
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
@@ -22,7 +21,7 @@ class ScriptEstimatorBenchmark {
 object ScriptEstimatorBenchmark {
 
   class St extends BigSum {
-    val functionCosts: Map[FunctionHeader, Long] = EvaluationContext.functionCosts(utils.dummyEvaluationContext.functions.values)
+    val functionCosts: Map[FunctionHeader, Long] = utils.dummyEvaluationContext.functionCosts
   }
 
 }

--- a/it/src/test/scala/com/wavesplatform/it/sync/AtomicSwapSmartContractSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/AtomicSwapSmartContractSuite.scala
@@ -49,8 +49,8 @@ class AtomicSwapSmartContractSuite extends BaseTransactionSuite with CancelAfter
     val beforeHeight = sender.height
     val sc1 = {
       val untyped = Parser(s"""
-    let Bob = extract(addressFromString("$BobBC1")).bytes
-    let Alice = extract(addressFromString("$AliceBC1")).bytes
+    let Bob = Address(base58'$BobBC1').bytes
+    let Alice = Address(base58'$AliceBC1').bytes
     let AlicesPK = base58'${ByteStr(AlicesPK.publicKey)}'
     match tx {
       case ttx: TransferTransaction =>

--- a/src/main/scala/scorex/transaction/smart/script/ScriptCompiler.scala
+++ b/src/main/scala/scorex/transaction/smart/script/ScriptCompiler.scala
@@ -4,18 +4,17 @@ import cats.implicits._
 import com.wavesplatform.lang.ScriptVersion
 import com.wavesplatform.lang.ScriptVersion.Versions.V1
 import com.wavesplatform.lang.directives.{Directive, DirectiveKey, DirectiveParser}
-import com.wavesplatform.lang.v1.evaluator.ctx.EvaluationContext
 import com.wavesplatform.lang.v1.ScriptEstimator
 import com.wavesplatform.lang.v1.compiler.CompilerV1
 import com.wavesplatform.utils
+import com.wavesplatform.utils.dummyEvaluationContext.functionCosts
 import scorex.transaction.smart.script.v1.ScriptV1
 
 import scala.util.{Failure, Success, Try}
 
 object ScriptCompiler {
 
-  private val v1Compiler    = new CompilerV1(utils.dummyCompilerContext)
-  private val functionCosts = EvaluationContext.functionCosts(utils.dummyEvaluationContext.functions.values)
+  private val v1Compiler = new CompilerV1(utils.dummyCompilerContext)
 
   def apply(scriptText: String): Either[String, (Script, Long)] = {
     val directives = DirectiveParser(scriptText)
@@ -30,7 +29,7 @@ object ScriptCompiler {
       expr <- v match {
         case V1 => v1Compiler.compile(scriptWithoutDirectives, directives)
       }
-      script     <- ScriptV1(expr)
+      script <- ScriptV1(expr)
       complexity <- ScriptEstimator(functionCosts, expr)
     } yield (script, complexity)
   }

--- a/src/main/scala/scorex/transaction/smart/script/v1/ScriptV1.scala
+++ b/src/main/scala/scorex/transaction/smart/script/v1/ScriptV1.scala
@@ -4,16 +4,13 @@ import com.wavesplatform.crypto
 import com.wavesplatform.lang.ScriptVersion.Versions.V1
 import com.wavesplatform.lang.v1.compiler.Terms._
 import com.wavesplatform.lang.v1.evaluator.FunctionIds._
-import com.wavesplatform.lang.v1.evaluator.ctx.EvaluationContext
 import com.wavesplatform.lang.v1.{FunctionHeader, ScriptEstimator, Serde}
 import com.wavesplatform.state.ByteStr
+import com.wavesplatform.utils.dummyEvaluationContext.functionCosts
 import monix.eval.Coeval
 import scorex.transaction.smart.script.Script
 
 object ScriptV1 {
-  private val functionCosts: Map[FunctionHeader, Long] =
-    EvaluationContext.functionCosts(com.wavesplatform.utils.dummyEvaluationContext.functions.values)
-
   private val checksumLength = 4
   private val maxComplexity  = 20 * functionCosts(FunctionHeader.Native(SIGVERIFY))
   private val maxSizeInBytes = 8 * 1024

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/NotaryControlledTransferScenartioTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/NotaryControlledTransferScenartioTest.scala
@@ -41,8 +41,8 @@ class NotaryControlledTransferScenartioTest extends PropSpec with PropertyChecks
                     |
                     | match tx {
                     |   case ttx: TransferTransaction =>
-                    |      let king = extract(addressFromString("${king.address}"))
-                    |      let company = extract(addressFromString("${company.address}"))
+                    |      let king = Address(base58'${king.address}')
+                    |      let company = Address(base58'${company.address}')
                     |      let notary1 = addressFromPublicKey(extract(getByteArray(king,"notary1PK")))
                     |      let txIdBase58String = toBase58String(ttx.id)
                     |      let notary1Agreement = getBoolean(notary1,txIdBase58String)

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/OracleDataTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/scenarios/OracleDataTest.scala
@@ -31,7 +31,7 @@ class OracleDataTest extends PropSpec with PropertyChecks with Matchers with Tra
       bin             <- binaryEntryGen(MaxBase58Bytes, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key)
       str             <- stringEntryGen(500, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key && e.key != bin.key)
       dataTransaction <- dataTransactionGenP(oracle, List(long, bool, bin, str))
-      allFieldsRequiredScript = s"""let oracle = extract(addressFromString("${oracle.address}"))
+      allFieldsRequiredScript = s"""let oracle = Address(base58'${oracle.address}')
                                    |let long = extract(getLong(oracle,"${long.key}")) == ${long.value}
                                    |let bool = extract(getBoolean(oracle,"${bool.key}")) == ${bool.value}
                                    |let bin = extract(getByteArray(oracle,"${bin.key}")) == base58'${bin.value.base58}'


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-829

Changes:
- `functionCosts` was moved inside `EvaluationContext` case class where it can access type definitions
- Cost of a data constructor is just the number of its parameters
- The rest of the changes is to tests