### PR TITLE
NODE-605-special-symbols

### DIFF
--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/ParserTest.scala
@@ -210,15 +210,11 @@ class ParserTest extends PropSpec with PropertyChecks with Matchers with ScriptG
   }
 
   property("string literal with special symbols") {
-    parseOne("\"\\t\"") shouldBe CONST_STRING(AnyPos, PART.VALID(AnyPos, "\t"))
+    parseOne("\"\\t\\n\\r\\\\\\\"\"") shouldBe CONST_STRING(AnyPos, PART.VALID(AnyPos, "\t\n\r\\\""))
   }
 
   property("should parse invalid special symbols") {
     parseOne("\"\\ test\"") shouldBe CONST_STRING(AnyPos, PART.INVALID(AnyPos, "unknown escaped symbol: '\\ '. The valid are \b, \f, \n, \r, \t"))
-  }
-
-  property("should parse incomplete special symbols") {
-    parseOne("\"foo \\\"") shouldBe CONST_STRING(AnyPos, PART.INVALID(AnyPos, "invalid escaped symbol: '\\'. The valid are \b, \f, \n, \r, \t"))
   }
 
   property("block: multiline without ;") {

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Parser.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/parser/Parser.scala
@@ -26,7 +26,7 @@ object Parser {
   private val digit          = CharIn('0' to '9')
   private val unicodeSymbolP = P("\\u" ~/ Pass ~~ (char | digit).repX(min = 0, max = 4))
   private val notEndOfString = CharPred(_ != '\"')
-  private val specialSymbols = P("\\" ~~ notEndOfString.?)
+  private val specialSymbols = P("\\" ~~ AnyChar)
   private val comment        = P("#" ~~ CharPred(_ != '\n').repX).rep
 
   private val escapedUnicodeSymbolP: P[(Int, String, Int)] = P(Index ~~ (NoCut(unicodeSymbolP) | specialSymbols).! ~~ Index)
@@ -64,6 +64,8 @@ object Parser {
                 case 'n' => "\n"
                 case 'r' => "\r"
                 case 't' => "\t"
+                case '\\' => "\\"
+                case '"' => "\""
                 case _ =>
                   errors :+= s"""unknown escaped symbol: '$x'. The valid are \b, \f, \n, \r, \t"""
                   x

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/predef/TransactionBindingsTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/predef/TransactionBindingsTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.prop.PropertyChecks
 import scorex.account.{Address, Alias}
 import scorex.transaction.ProvenTransaction
 import scorex.transaction.assets.exchange.Order
+import play.api.libs.json.Json // For string escapes.
 
 class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers with TransactionGen with NoShrink {
   def provenPart(t: ProvenTransaction): String = {
@@ -44,7 +45,7 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
            |      else isDefined(t.transferAssetId) == false
            |   let recipient = match (t.recipient) {
            |       case a: Address => a.bytes == base58'${t.recipient.cast[Address].map(_.bytes.base58).getOrElse("")}'
-           |       case a: Alias => a.alias == "${t.recipient.cast[Alias].map(_.name).getOrElse("")}"
+           |       case a: Alias => a.alias == ${Json.toJson(t.recipient.cast[Alias].map(_.name).getOrElse(""))}
            |      }
            |    let attachment = t.attachment == base58'${ByteStr(t.attachment).base58}'
            |   $assertProvenPart && amount && feeAssetId && transferAssetId && recipient && attachment
@@ -134,7 +135,7 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           |match tx {
           | case t : CreateAliasTransaction =>
           |   ${provenPart(t)}
-          |   let alias = t.alias == "${t.alias.name}"
+          |   let alias = t.alias == ${Json.toJson(t.alias.name)}
           |   $assertProvenPart && alias
           | case other => throw
           | }
@@ -156,7 +157,7 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           |   let amount = t.amount == ${t.amount}
           |   let recipient = match (t.recipient) {
           |       case a: Address => a.bytes == base58'${t.recipient.cast[Address].map(_.bytes.base58).getOrElse("")}'
-          |       case a: Alias => a.alias == "${t.recipient.cast[Alias].map(_.name).getOrElse("")}"
+          |       case a: Alias => a.alias == ${Json.toJson(t.recipient.cast[Alias].map(_.name).getOrElse(""))}
           |      }
           |   $assertProvenPart && amount && recipient
           | case other => throw
@@ -237,10 +238,10 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
           case x: LongDataEntry    => s"case a: LongDataEntry => a.value == ${x.value}"
           case x: BooleanDataEntry => s"case a: BoolDataEntry => a.value == ${x.value}"
           case x: BinaryDataEntry  => s"case a: ByteVectorDataEntry => a.value == base64'${x.value.base64}'"
-          case x: StringDataEntry  => s"""case a: StrDataEntry => a.value == "${x.value}""""
+          case x: StringDataEntry  => s"""case a: StrDataEntry => a.value == ${Json.toJson(x.value)}"""
         }
 
-        s"""let key$i = t.data[$i].key == "${t.data(i).key}"
+        s"""let key$i = t.data[$i].key == ${Json.toJson(t.data(i).key)}
            |let value$i = match (t.data[$i]) {
            | $v
            | case other => true
@@ -275,7 +276,7 @@ class TransactionBindingsTest extends PropSpec with PropertyChecks with Matchers
       def pg(i: Int) =
         s"""let recipient$i = match (t.transfers[$i].recipient) {
            |case a: Address => a.bytes == base58'${t.transfers(i).address.cast[Address].map(_.bytes.base58).getOrElse("")}'
-           |case a: Alias => a.alias == "${t.transfers(i).address.cast[Alias].map(_.name).getOrElse("")}"
+           |case a: Alias => a.alias == ${Json.toJson(t.transfers(i).address.cast[Alias].map(_.name).getOrElse(""))}
            |}
            |let amount$i = t.transfers[$i].amount == ${t.transfers(i).amount}
          """.stripMargin


### PR DESCRIPTION
Allow \\ and \" symbols in strings.