### PR TITLE
NODE-736 Allow new lease/leasecancel possibility to have AssetId field

### DIFF
--- a/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseTransaction.scala
@@ -47,7 +47,7 @@ object LeaseTransaction {
     } else Right(())
 
   def parseBase(bytes: Array[Byte], start: Int) = {
-    val sender = PublicKeyAccount(bytes.slice(start, KeyLength))
+    val sender = PublicKeyAccount(bytes.slice(start, start + KeyLength))
     for {
       recRes <- AddressOrAlias.fromBytes(bytes, start + KeyLength)
       (recipient, recipientEnd) = recRes

--- a/src/main/scala/scorex/transaction/lease/LeaseTransactionV2.scala
+++ b/src/main/scala/scorex/transaction/lease/LeaseTransactionV2.scala
@@ -5,6 +5,7 @@ import com.wavesplatform.crypto
 import com.wavesplatform.state.ByteStr
 import monix.eval.Coeval
 import scorex.account.{AddressOrAlias, PrivateKeyAccount, PublicKeyAccount}
+import scorex.serialization.Deser
 import scorex.transaction.ValidationError.UnsupportedVersion
 import scorex.transaction._
 
@@ -21,11 +22,10 @@ case class LeaseTransactionV2 private (version: Byte,
     with FastHashId {
 
   override val builder: TransactionParser = LeaseTransactionV2
-  val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce(
-    Bytes.concat(
-      Array(builder.typeId, version),
-      bytesBase()
-    ))
+  val bodyBytes: Coeval[Array[Byte]] = Coeval.evalOnce {
+    val assetId: Option[AssetId] = None // placeholder for future enhancement
+    Bytes.concat(Array(builder.typeId, version), assetId.map(a => (1: Byte) +: a.arr).getOrElse(Array(0: Byte)), bytesBase())
+  }
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 }
 
@@ -36,8 +36,10 @@ object LeaseTransactionV2 extends TransactionParserFor[LeaseTransactionV2] with 
 
   override protected def parseTail(version: Byte, bytes: Array[Byte]): Try[TransactionT] =
     Try {
+      val (assetIdOpt, s0) = Deser.parseByteArrayOption(bytes, 0, AssetIdLength)
       (for {
-        parsed <- LeaseTransaction.parseBase(bytes, 0)
+        _      <- Either.cond(assetIdOpt.isEmpty, (), ValidationError.GenericError("Leasing assets is not supported yet"))
+        parsed <- LeaseTransaction.parseBase(bytes, s0)
         (sender, recipient, quantity, fee, timestamp, end) = parsed
         proofs <- Proofs.fromBytes(bytes.drop(end))
         lt     <- LeaseTransactionV2.create(version, sender, quantity, fee, timestamp, recipient, proofs)


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-736
Added an `assetId` field to binary representation. Currently the only valid value is None.
Field order is unnatural, but see NODE-784