### PR TITLE
NODE-927 Not all orders are cancelled with "Cancel All" operation

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherTestSuite.scala
@@ -23,8 +23,10 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
   override protected def nodeConfigs: Seq[Config] = Configs
 
   private def matcherNode = nodes.head
-  private def aliceNode   = nodes(1)
-  private def bobNode     = nodes(2)
+
+  private def aliceNode = nodes(1)
+
+  private def bobNode = nodes(2)
 
   private val aliceSellAmount = 500
 
@@ -71,9 +73,9 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       }
 
       "and should match with buy order" in {
-        val bobBalance     = bobNode.accountBalances(bobNode.address)._1
+        val bobBalance = bobNode.accountBalances(bobNode.address)._1
         val matcherBalance = matcherNode.accountBalances(matcherNode.address)._1
-        val aliceBalance   = aliceNode.accountBalances(aliceNode.address)._1
+        val aliceBalance = aliceNode.accountBalances(aliceNode.address)._1
 
         // Bob places a buy order
         val order2 = matcherNode.placeOrder(bobNode, aliceWavesPair, OrderType.BUY, 2.waves * Order.PriceConstant, 200)
@@ -131,8 +133,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
 
       "buy order should match on few price levels" in {
         val matcherBalance = matcherNode.accountBalances(matcherNode.address)._1
-        val aliceBalance   = aliceNode.accountBalances(aliceNode.address)._1
-        val bobBalance     = bobNode.accountBalances(bobNode.address)._1
+        val aliceBalance = aliceNode.accountBalances(aliceNode.address)._1
+        val bobBalance = bobNode.accountBalances(bobNode.address)._1
 
         // Alice places a buy order
         val order4 = matcherNode.placeOrder(aliceNode, aliceWavesPair, OrderType.BUY, (21.waves / 10.0 * Order.PriceConstant).toLong, 350)
@@ -180,8 +182,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
 
       "buy order should execute all open orders and put remaining in order book" in {
         val matcherBalance = matcherNode.accountBalances(matcherNode.address)._1
-        val aliceBalance   = aliceNode.accountBalances(aliceNode.address)._1
-        val bobBalance     = bobNode.accountBalances(bobNode.address)._1
+        val aliceBalance = aliceNode.accountBalances(aliceNode.address)._1
+        val bobBalance = bobNode.accountBalances(bobNode.address)._1
 
         // Bob places buy order on amount bigger then left in sell orders
         val order5 = matcherNode.placeOrder(bobNode, aliceWavesPair, OrderType.BUY, 2.waves * Order.PriceConstant, 130)
@@ -217,8 +219,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       "should consider UTX pool when checking the balance" in {
         // Bob issues new asset
         val bobAssetQuantity = 10000
-        val bobAssetName     = "BobCoin"
-        val bobAsset         = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
+        val bobAssetName = "BobCoin"
+        val bobAsset = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
         nodes.waitForHeightAriseAndTxPresent(bobAsset)
 
         aliceNode.assertAssetBalance(aliceNode.address, bobAsset, 0)
@@ -243,8 +245,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       "trader can buy waves for assets with order without having waves" in {
         // Bob issues new asset
         val bobAssetQuantity = 10000
-        val bobAssetName     = "BobCoin2"
-        val bobAsset         = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
+        val bobAssetName = "BobCoin2"
+        val bobAsset = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
         nodes.waitForHeightAriseAndTxPresent(bobAsset)
 
         val bobWavesPair = AssetPair(
@@ -263,9 +265,9 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
         matcherNode.waitOrderStatus(bobWavesPair, order8.message.id, "Accepted")
 
         // Bob moves all waves to Alice
-        val h1              = matcherNode.height
-        val bobBalance      = matcherNode.accountBalances(bobNode.address)._1
-        val transferAmount  = bobBalance - TransactionFee
+        val h1 = matcherNode.height
+        val bobBalance = matcherNode.accountBalances(bobNode.address)._1
+        val transferAmount = bobBalance - TransactionFee
         val transferAliceId = bobNode.transfer(bobNode.address, aliceNode.address, transferAmount, TransactionFee, None, None).id
         nodes.waitForHeightAriseAndTxPresent(transferAliceId)
 
@@ -286,6 +288,7 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
     }
 
     "batch cancel" - {
+      val ordersNum = 5
       def fileOrders(n: Int, pair: AssetPair): Seq[String] = 0 until n map { _ =>
         val o = matcherNode.placeOrder(matcherNode.prepareOrder(aliceNode, pair, OrderType.BUY, 1.waves * Order.PriceConstant, 100))
         o.status should be("OrderAccepted")
@@ -298,7 +301,7 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       val aliceWavesPair2 = AssetPair(ByteStr.decodeBase58(asset2).toOption, None)
 
       "canceling an order doesn't affect other orders for the same pair" in {
-        val orders                          = fileOrders(5, aliceWavesPair)
+        val orders = fileOrders(ordersNum, aliceWavesPair)
         val (orderToCancel, ordersToRetain) = (orders.head, orders.tail)
 
         val cancel = matcherNode.cancelOrder(aliceNode, aliceWavesPair, Some(orderToCancel))
@@ -310,15 +313,19 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       }
 
       "cancel orders by pair" in {
-        val ordersToCancel = fileOrders(25, aliceWavesPair)
-        val ordersToRetain = fileOrders(5, aliceWavesPair2)
-        val ts             = Some(System.currentTimeMillis)
+        val ordersToCancel = fileOrders(orderLimit + ordersNum, aliceWavesPair)
+        val ordersToRetain = fileOrders(ordersNum, aliceWavesPair2)
+        val ts = Some(System.currentTimeMillis)
 
         val cancel = matcherNode.cancelOrder(aliceNode, aliceWavesPair, None, ts)
         cancel.status should be("Cancelled")
 
-        ordersToCancel foreach { matcherNode.orderStatus(_, aliceWavesPair).status should be("Cancelled") }
-        ordersToRetain foreach { matcherNode.orderStatus(_, aliceWavesPair2).status should be("Accepted") }
+        ordersToCancel foreach {
+          matcherNode.orderStatus(_, aliceWavesPair).status should be("Cancelled")
+        }
+        ordersToRetain foreach {
+          matcherNode.orderStatus(_, aliceWavesPair2).status should be("Accepted")
+        }
 
         // signed timestamp is mandatory
         assertBadRequestAndMessage(matcherNode.cancelOrder(aliceNode, aliceWavesPair, None, None), "invalid signature")
@@ -328,15 +335,19 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       }
 
       "cancel all orders" in {
-        val orders1 = fileOrders(25, aliceWavesPair)
-        val orders2 = fileOrders(25, aliceWavesPair2)
-        val ts      = Some(System.currentTimeMillis)
+        val orders1 = fileOrders(orderLimit + ordersNum, aliceWavesPair)
+        val orders2 = fileOrders(orderLimit + ordersNum, aliceWavesPair2)
+        val ts = Some(System.currentTimeMillis)
 
         val cancel = matcherNode.cancelAllOrders(aliceNode, ts)
         cancel.status should be("Cancelled")
 
-        orders1 foreach { matcherNode.orderStatus(_, aliceWavesPair).status should be("Cancelled") }
-        orders2 foreach { matcherNode.orderStatus(_, aliceWavesPair2).status should be("Cancelled") }
+        orders1 foreach {
+          matcherNode.orderStatus(_, aliceWavesPair).status should be("Cancelled")
+        }
+        orders2 foreach {
+          matcherNode.orderStatus(_, aliceWavesPair2).status should be("Cancelled")
+        }
 
         // signed timestamp is mandatory
         assertBadRequestAndMessage(matcherNode.cancelAllOrders(aliceNode, None), "invalid signature")
@@ -354,13 +365,14 @@ object MatcherTestSuite {
   import com.wavesplatform.it.NodeConfigs._
 
   private val ForbiddenAssetId = "FdbnAsset"
-  private val AssetQuantity    = 1000
-  private val MatcherFee       = 300000
-  private val TransactionFee   = 300000
-  private val orderLimit       = 20
+  private val AssetQuantity = 1000
+  private val MatcherFee = 300000
+  private val TransactionFee = 300000
+  private val orderLimit = 20
 
   private val minerDisabled = parseString("waves.miner.enable = no")
-  private val matcherConfig = parseString(s"""
+  private val matcherConfig = parseString(
+    s"""
        |waves.matcher {
        |  enable = yes
        |  account = 3HmFkAoQRs4Y3PE2uR6ohN7wS4VqPBGKv7k

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherTestSuite.scala
@@ -73,9 +73,9 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       }
 
       "and should match with buy order" in {
-        val bobBalance = bobNode.accountBalances(bobNode.address)._1
+        val bobBalance     = bobNode.accountBalances(bobNode.address)._1
         val matcherBalance = matcherNode.accountBalances(matcherNode.address)._1
-        val aliceBalance = aliceNode.accountBalances(aliceNode.address)._1
+        val aliceBalance   = aliceNode.accountBalances(aliceNode.address)._1
 
         // Bob places a buy order
         val order2 = matcherNode.placeOrder(bobNode, aliceWavesPair, OrderType.BUY, 2.waves * Order.PriceConstant, 200)
@@ -133,8 +133,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
 
       "buy order should match on few price levels" in {
         val matcherBalance = matcherNode.accountBalances(matcherNode.address)._1
-        val aliceBalance = aliceNode.accountBalances(aliceNode.address)._1
-        val bobBalance = bobNode.accountBalances(bobNode.address)._1
+        val aliceBalance   = aliceNode.accountBalances(aliceNode.address)._1
+        val bobBalance     = bobNode.accountBalances(bobNode.address)._1
 
         // Alice places a buy order
         val order4 = matcherNode.placeOrder(aliceNode, aliceWavesPair, OrderType.BUY, (21.waves / 10.0 * Order.PriceConstant).toLong, 350)
@@ -182,8 +182,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
 
       "buy order should execute all open orders and put remaining in order book" in {
         val matcherBalance = matcherNode.accountBalances(matcherNode.address)._1
-        val aliceBalance = aliceNode.accountBalances(aliceNode.address)._1
-        val bobBalance = bobNode.accountBalances(bobNode.address)._1
+        val aliceBalance   = aliceNode.accountBalances(aliceNode.address)._1
+        val bobBalance     = bobNode.accountBalances(bobNode.address)._1
 
         // Bob places buy order on amount bigger then left in sell orders
         val order5 = matcherNode.placeOrder(bobNode, aliceWavesPair, OrderType.BUY, 2.waves * Order.PriceConstant, 130)
@@ -219,8 +219,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       "should consider UTX pool when checking the balance" in {
         // Bob issues new asset
         val bobAssetQuantity = 10000
-        val bobAssetName = "BobCoin"
-        val bobAsset = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
+        val bobAssetName     = "BobCoin"
+        val bobAsset         = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
         nodes.waitForHeightAriseAndTxPresent(bobAsset)
 
         aliceNode.assertAssetBalance(aliceNode.address, bobAsset, 0)
@@ -245,8 +245,8 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       "trader can buy waves for assets with order without having waves" in {
         // Bob issues new asset
         val bobAssetQuantity = 10000
-        val bobAssetName = "BobCoin2"
-        val bobAsset = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
+        val bobAssetName     = "BobCoin2"
+        val bobAsset         = bobNode.issue(bobNode.address, bobAssetName, "Bob's asset", bobAssetQuantity, 0, false, 100000000L).id
         nodes.waitForHeightAriseAndTxPresent(bobAsset)
 
         val bobWavesPair = AssetPair(
@@ -265,9 +265,9 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
         matcherNode.waitOrderStatus(bobWavesPair, order8.message.id, "Accepted")
 
         // Bob moves all waves to Alice
-        val h1 = matcherNode.height
-        val bobBalance = matcherNode.accountBalances(bobNode.address)._1
-        val transferAmount = bobBalance - TransactionFee
+        val h1              = matcherNode.height
+        val bobBalance      = matcherNode.accountBalances(bobNode.address)._1
+        val transferAmount  = bobBalance - TransactionFee
         val transferAliceId = bobNode.transfer(bobNode.address, aliceNode.address, transferAmount, TransactionFee, None, None).id
         nodes.waitForHeightAriseAndTxPresent(transferAliceId)
 
@@ -301,7 +301,7 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       val aliceWavesPair2 = AssetPair(ByteStr.decodeBase58(asset2).toOption, None)
 
       "canceling an order doesn't affect other orders for the same pair" in {
-        val orders = fileOrders(ordersNum, aliceWavesPair)
+        val orders                          = fileOrders(ordersNum, aliceWavesPair)
         val (orderToCancel, ordersToRetain) = (orders.head, orders.tail)
 
         val cancel = matcherNode.cancelOrder(aliceNode, aliceWavesPair, Some(orderToCancel))
@@ -315,7 +315,7 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       "cancel orders by pair" in {
         val ordersToCancel = fileOrders(orderLimit + ordersNum, aliceWavesPair)
         val ordersToRetain = fileOrders(ordersNum, aliceWavesPair2)
-        val ts = Some(System.currentTimeMillis)
+        val ts             = Some(System.currentTimeMillis)
 
         val cancel = matcherNode.cancelOrder(aliceNode, aliceWavesPair, None, ts)
         cancel.status should be("Cancelled")
@@ -337,7 +337,7 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
       "cancel all orders" in {
         val orders1 = fileOrders(orderLimit + ordersNum, aliceWavesPair)
         val orders2 = fileOrders(orderLimit + ordersNum, aliceWavesPair2)
-        val ts = Some(System.currentTimeMillis)
+        val ts      = Some(System.currentTimeMillis)
 
         val cancel = matcherNode.cancelAllOrders(aliceNode, ts)
         cancel.status should be("Cancelled")
@@ -365,14 +365,13 @@ object MatcherTestSuite {
   import com.wavesplatform.it.NodeConfigs._
 
   private val ForbiddenAssetId = "FdbnAsset"
-  private val AssetQuantity = 1000
-  private val MatcherFee = 300000
-  private val TransactionFee = 300000
-  private val orderLimit = 20
+  private val AssetQuantity    = 1000
+  private val MatcherFee       = 300000
+  private val TransactionFee   = 300000
+  private val orderLimit       = 20
 
   private val minerDisabled = parseString("waves.miner.enable = no")
-  private val matcherConfig = parseString(
-    s"""
+  private val matcherConfig = parseString(s"""
        |waves.matcher {
        |  enable = yes
        |  account = 3HmFkAoQRs4Y3PE2uR6ohN7wS4VqPBGKv7k

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -237,8 +237,8 @@ class MatcherApiRoute(wallet: Wallet,
                 .map(r => r.code -> r.json)
             case None =>
               implicit val ec = MatcherApiRoute.cancelExecutor
-              val timestamp = req.timestamp.get
-              val address   = req.senderPublicKey.address
+              val timestamp   = req.timestamp.get
+              val address     = req.senderPublicKey.address
               MatcherApiRoute.checkTimestamp(address, timestamp.millis) {
                 (orderHistory ? GetOrderHistory(pair, address, timestamp))
                   .mapTo[GetOrderHistoryResponse]

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -187,12 +187,12 @@ class MatcherApiRoute(wallet: Wallet,
           case Some(timestamp) =>
             val address = req.senderPublicKey.address
             MatcherApiRoute.checkTimestamp(address, timestamp.millis) {
-              (orderHistory ? GetAllOrderHistory(address, true, timestamp))
+              (orderHistory ? GetAllOrderHistory(address, activeOnly = true, timestamp, internal = true))
                 .mapTo[GetOrderHistoryResponse]
                 .flatMap { res: GetOrderHistoryResponse =>
                   Future
                     .sequence(res.history map {
-                      case (id, info, Some(order)) =>
+                      case (id, _, Some(order)) =>
                         matcher ? CancelOrder(order.assetPair, req.senderPublicKey, id)
                       case _ => Future.successful(())
                     })
@@ -240,7 +240,7 @@ class MatcherApiRoute(wallet: Wallet,
               val timestamp   = req.timestamp.get
               val address     = req.senderPublicKey.address
               MatcherApiRoute.checkTimestamp(address, timestamp.millis) {
-                (orderHistory ? GetOrderHistory(pair, address, timestamp))
+                (orderHistory ? GetOrderHistory(pair, address, timestamp, internal = true))
                   .mapTo[GetOrderHistoryResponse]
                   .flatMap { res =>
                     Future
@@ -316,7 +316,7 @@ class MatcherApiRoute(wallet: Wallet,
         case Success(address) =>
           withAssetPair(a1, a2) { pair =>
             complete(
-              (orderHistory ? GetOrderHistory(pair, address, NTP.correctedTime()))
+              (orderHistory ? GetOrderHistory(pair, address, NTP.correctedTime(), internal = false))
                 .mapTo[MatcherResponse]
                 .map(r => r.code -> r.json))
           }
@@ -352,7 +352,7 @@ class MatcherApiRoute(wallet: Wallet,
         checkGetSignature(publicKey, ts, sig) match {
           case Success(address) =>
             complete(
-              (orderHistory ? GetAllOrderHistory(address, activeOnly.getOrElse(false), NTP.correctedTime()))
+              (orderHistory ? GetAllOrderHistory(address, activeOnly.getOrElse(false), NTP.correctedTime(), internal = false))
                 .mapTo[MatcherResponse]
                 .map(r => r.code -> r.json))
           case Failure(ex) =>
@@ -401,7 +401,7 @@ class MatcherApiRoute(wallet: Wallet,
   def getAllOrderHistory: Route = (path("orders" / Segment) & get & withAuth) { addr =>
     implicit val timeout: Timeout = Timeout(10.seconds)
     complete(
-      (orderHistory ? GetAllOrderHistory(addr, activeOnly = true, NTP.correctedTime()))
+      (orderHistory ? GetAllOrderHistory(addr, activeOnly = true, NTP.correctedTime(), internal = false))
         .mapTo[MatcherResponse]
         .map(r => r.code -> r.json))
   }

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderHistory.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderHistory.scala
@@ -217,25 +217,28 @@ case class OrderHistoryImpl(db: DB, settings: MatcherSettings) extends SubStorag
     val orders = allOrderIdsByAddress(address).toSeq
       .map(id => (id, orderInfo(id), order(id)))
       .filter(_._3.exists(_.assetPair == assetPair))
-    if (internal) orders
-    else
+    if (internal) {
+      orders
+    } else {
       orders
         .sorted(OrderHistoryOrdering)
         .take(settings.maxOrdersPerRequest)
+    }
   }
 
   override def fetchAllActiveOrderHistory(address: String, internal: Boolean): Seq[(String, OrderInfo, Option[Order])] = {
     import OrderInfo.orderStatusOrdering
     val orders = activeOrderIdsByAddress(address).toSeq
-    if (internal)
-      orders
-        .map { case (_, id) => (id, orderInfo(id), order(id)) } else
+    if (internal) {
+      orders.map { case (_, id) => (id, orderInfo(id), order(id)) }
+    } else {
       orders
         .map(o => (o._2, orderInfo(o._2)))
         .sortBy(_._2.status)
         .take(settings.maxOrdersPerRequest)
         .map(p => (p._1, p._2, order(p._1)))
         .sorted(OrderHistoryOrdering)
+    }
   }
 
   override def fetchAllOrderHistory(address: String): Seq[(String, OrderInfo, Option[Order])] = {

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderHistoryActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderHistoryActorSpecification.scala
@@ -47,7 +47,7 @@ class OrderHistoryActorSpecification
   "OrderHistoryActor" should {
 
     "not process expirable messages" in {
-      val r = GetOrderHistory(pair, "address", NTP.correctedTime() - OrderHistoryActor.RequestTTL - 1)
+      val r = GetOrderHistory(pair, "address", NTP.correctedTime() - OrderHistoryActor.RequestTTL - 1, internal = false)
       actor ! r
       expectNoMsg()
     }

--- a/src/test/scala/com/wavesplatform/matcher/model/OrderHistorySpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/model/OrderHistorySpecification.scala
@@ -302,7 +302,7 @@ class OrderHistorySpecification
     oh.fetchAllOrderHistory(ord1.senderPublicKey.address).map(_._1) shouldBe
       Seq(ord5.idStr(), ord4.idStr(), ord2.idStr(), ord3.idStr(), ord1.idStr())
 
-    oh.fetchAllActiveOrderHistory(ord1.senderPublicKey.address).map(_._1) shouldBe
+    oh.fetchAllActiveOrderHistory(ord1.senderPublicKey.address, internal = false).map(_._1) shouldBe
       Seq(ord5.idStr(), ord4.idStr(), ord2.idStr())
   }
 


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-927

The actor from which we were asking active orders was limiting the number of orders it returned. I'm fixing that by adding an 'internal' mode where it skips some unnecessary steps such as limiting, sorting etc