### PR TITLE
NODE-955 DataTransaction fee should not depend on proofs

### DIFF
--- a/src/main/scala/com/wavesplatform/state/diffs/CommonValidation.scala
+++ b/src/main/scala/com/wavesplatform/state/diffs/CommonValidation.scala
@@ -145,10 +145,12 @@ object CommonValidation {
       case _: LeaseCancelTransaction   => Right(1)
       case _: ExchangeTransaction      => Right(3)
       case _: CreateAliasTransaction   => Right(1)
-      case tx: DataTransaction         => Right(1 + (tx.bytes().length - 1) / 1024)
-      case _: SetScriptTransaction     => Right(1)
-      case _: SponsorFeeTransaction    => Right(1000)
-      case _                           => Left(UnsupportedTransactionType)
+      case tx: DataTransaction =>
+        val base = if (blockchain.isFeatureActivated(BlockchainFeatures.SmartAccounts, height)) tx.bodyBytes() else tx.bytes()
+        Right(1 + (base.length - 1) / 1024)
+      case _: SetScriptTransaction  => Right(1)
+      case _: SponsorFeeTransaction => Right(1000)
+      case _                        => Left(UnsupportedTransactionType)
     }
 
     def restFeeAfterSponsorship(inputFee: (Option[AssetId], Long)): Either[ValidationError, (Option[AssetId], Long)] =


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-955
Replaced bytes() with bodyBytes() but only after SmartAccounts have been activated.

Unit tests fail because of some Travis internal glitch