### PR TITLE
NODE-1072 New RIDE functions: toBytes, toString, data accessors

### DIFF
--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/FunctionIds.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/FunctionIds.scala
@@ -26,6 +26,11 @@ object FunctionIds {
 
   val SIZE_LIST: Short = 400
   val GET_LIST: Short  = 401
+  val LONG_TO_BYTES: Short = 410
+  val STRING_TO_BYTES: Short = 411
+  val BOOLEAN_TO_BYTES: Short = 412
+  val LONG_TO_STRING: Short = 420
+  val BOOLEAN_TO_STRING: Short = 421
 
   // Crypto
   val SIGVERIFY: Short = 500
@@ -42,10 +47,17 @@ object FunctionIds {
   val GETTRANSACTIONBYID: Short    = 1000
   val TRANSACTIONHEIGHTBYID: Short = 1001
   val ACCOUNTASSETBALANCE: Short   = 1003
-  val DATA_LONG: Short             = 1050
-  val DATA_BOOLEAN: Short          = 1051
-  val DATA_BYTES: Short            = 1052
-  val DATA_STRING: Short           = 1053
+
+  val DATA_LONG_FROM_ARRAY: Short = 1040
+  val DATA_BOOLEAN_FROM_ARRAY: Short = 1041
+  val DATA_BYTES_FROM_ARRAY: Short = 1042
+  val DATA_STRING_FROM_ARRAY: Short = 1043
+
+  val DATA_LONG_FROM_STATE: Short             = 1050
+  val DATA_BOOLEAN_FROM_STATE: Short          = 1051
+  val DATA_BYTES_FROM_STATE: Short            = 1052
+  val DATA_STRING_FROM_STATE: Short           = 1053
+
   val ADDRESSFROMRECIPIENT: Short  = 1060
 
 }

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/waves/WavesContext.scala
@@ -20,16 +20,53 @@ object WavesContext {
   def build(env: Environment): CTX = {
     val environmentFunctions = new EnvironmentFunctions(env)
 
-    def getdataF(name: String, internalName: Short, dataType: DataType): BaseFunction =
+    def getDataFromStateF(name: String, internalName: Short, dataType: DataType): BaseFunction =
       NativeFunction(name, 100, internalName, UNION(dataType.innerType, UNIT), "addressOrAlias" -> addressOrAliasType, "key" -> STRING) {
         case (addressOrAlias: CaseObj) :: (k: String) :: Nil => environmentFunctions.getData(addressOrAlias, k, dataType).map(fromOption)
         case _                                               => ???
       }
 
-    val getIntegerF: BaseFunction = getdataF("getInteger", DATA_LONG, DataType.Long)
-    val getBooleanF: BaseFunction = getdataF("getBoolean", DATA_BOOLEAN, DataType.Boolean)
-    val getBinaryF: BaseFunction  = getdataF("getBinary", DATA_BYTES, DataType.ByteArray)
-    val getStringF: BaseFunction  = getdataF("getString", DATA_STRING, DataType.String)
+    val getIntegerFromStateF: BaseFunction = getDataFromStateF("getInteger", DATA_LONG_FROM_STATE, DataType.Long)
+    val getBooleanFromStateF: BaseFunction = getDataFromStateF("getBoolean", DATA_BOOLEAN_FROM_STATE, DataType.Boolean)
+    val getBinaryFromStateF: BaseFunction  = getDataFromStateF("getBinary", DATA_BYTES_FROM_STATE, DataType.ByteArray)
+    val getStringFromStateF: BaseFunction  = getDataFromStateF("getString", DATA_STRING_FROM_STATE, DataType.String)
+
+    def getDataFromArrayF(name: String, internalName: Short, dataType: DataType): BaseFunction =
+      NativeFunction(name, 10, internalName, UNION(dataType.innerType, UNIT), "data" -> LIST(dataEntryType.typeRef), "key" -> STRING) {
+        case (data: IndexedSeq[CaseObj] @unchecked) :: (key: String) :: Nil =>
+          val x = data.find(_.fields("key") == key).map(_.fields("value"))
+          val y = x match {
+            case Some(n: Long) if dataType == DataType.Long => Right(n)
+            case Some(b: Boolean) if dataType == DataType.Boolean => Right(b)
+            case Some(b: ByteVector) if dataType == DataType.ByteArray => Right(b)
+            case Some(s: String) if dataType == DataType.String => Right(s)
+            case _ => Right(())
+          }
+          println(s"data-from-array(type $dataType) ($x) -> $y")///
+          y
+        case _ => ???
+      }
+
+    val getIntegerFromArrayF: BaseFunction = getDataFromArrayF("getInteger", DATA_LONG_FROM_ARRAY, DataType.Long)
+    val getBooleanFromArrayF: BaseFunction = getDataFromArrayF("getBoolean", DATA_BOOLEAN_FROM_ARRAY, DataType.Boolean)
+    val getBinaryFromArrayF: BaseFunction = getDataFromArrayF("getBinary", DATA_BYTES_FROM_ARRAY, DataType.ByteArray)
+    val getStringFromArrayF: BaseFunction = getDataFromArrayF("getString", DATA_STRING_FROM_ARRAY, DataType.String)
+
+    def getDataByIndexF(name: String, dataType: DataType): BaseFunction =
+      UserFunction(name, UNION(dataType.innerType, UNIT), "data" -> LIST(dataEntryType.typeRef), "index" -> LONG) {
+        case data :: index :: Nil =>
+          BLOCK(
+            LET("@val", GETTER(FUNCTION_CALL(PureContext.getElement, List(data, index)), "value")),
+            IF(FUNCTION_CALL(PureContext._isInstanceOf, List(REF("@val"), CONST_STRING(dataType.innerType.name))),
+              REF("@val"),
+              REF("unit")))
+        case _ => ???
+      }
+
+    val getIntegerByIndexF: BaseFunction = getDataByIndexF("getInteger", DataType.Long)
+    val getBooleanByIndexF: BaseFunction = getDataByIndexF("getBoolean", DataType.Boolean)
+    val getBinaryByIndexF: BaseFunction = getDataByIndexF("getBinary", DataType.ByteArray)
+    val getStringByIndexF: BaseFunction = getDataByIndexF("getString", DataType.String)
 
     def secureHashExpr(xs: EXPR): EXPR = FUNCTION_CALL(
       FunctionHeader.Native(KECCAK256),
@@ -218,10 +255,18 @@ object WavesContext {
     val functions = Seq(
       txByIdF,
       txHeightByIdF,
-      getIntegerF,
-      getBooleanF,
-      getBinaryF,
-      getStringF,
+      getIntegerFromStateF,
+      getBooleanFromStateF,
+      getBinaryFromStateF,
+      getStringFromStateF,
+      getIntegerFromArrayF,
+      getBooleanFromArrayF,
+      getBinaryFromArrayF,
+      getStringFromArrayF,
+      getIntegerByIndexF,
+      getBooleanByIndexF,
+      getBinaryByIndexF,
+      getStringByIndexF,
       addressFromPublicKeyF,
       addressFromStringF,
       addressFromRecipientF,

--- a/src/test/scala/com/wavesplatform/state/diffs/smart/predef/ContextFunctionsTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/smart/predef/ContextFunctionsTest.scala
@@ -1,31 +1,38 @@
 package com.wavesplatform.state.diffs.smart.predef
 
-import com.wavesplatform.lang.Global.MaxBase58Bytes
+import com.wavesplatform.account.PrivateKeyAccount
 import com.wavesplatform.lang.v1.compiler.CompilerV1
 import com.wavesplatform.lang.v1.parser.Parser
 import com.wavesplatform.state._
 import com.wavesplatform.state.diffs.smart.smartEnabledFS
 import com.wavesplatform.state.diffs.{ENOUGH_AMT, assertDiffAndState}
-import com.wavesplatform.utils.dummyCompilerContext
+import com.wavesplatform.utils.{Base58, dummyCompilerContext}
 import com.wavesplatform.{NoShrink, TransactionGen}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import com.wavesplatform.transaction.smart.SetScriptTransaction
 import com.wavesplatform.transaction.smart.script.v1.ScriptV1
 import com.wavesplatform.transaction.GenesisTransaction
+import org.scalacheck.Gen
 
 class ContextFunctionsTest extends PropSpec with PropertyChecks with Matchers with TransactionGen with NoShrink {
+
+  def compactDataTransactionGen(sender: PrivateKeyAccount) =
+    for {
+      long <- longEntryGen(dataAsciiKeyGen)
+      bool <- booleanEntryGen(dataAsciiKeyGen).filter(_.key != long.key)
+      bin  <- binaryEntryGen(40, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key)
+      str  <- stringEntryGen(40, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key && e.key != bin.key)
+      tx   <- dataTransactionGenP(sender, List(long, bool, bin, str))
+    } yield tx
+
   val preconditionsAndPayments = for {
     master    <- accountGen
     recipient <- accountGen
     ts        <- positiveIntGen
     genesis1 = GenesisTransaction.create(master, ENOUGH_AMT * 3, ts).explicitGet()
     genesis2 = GenesisTransaction.create(recipient, ENOUGH_AMT * 3, ts).explicitGet()
-    long            <- longEntryGen(dataAsciiKeyGen)
-    bool            <- booleanEntryGen(dataAsciiKeyGen).filter(_.key != long.key)
-    bin             <- binaryEntryGen(MaxBase58Bytes, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key)
-    str             <- stringEntryGen(500, dataAsciiKeyGen).filter(e => e.key != long.key && e.key != bool.key && e.key != bin.key)
-    dataTransaction <- dataTransactionGenP(recipient, List(long, bool, bin, str))
+    dataTransaction <- compactDataTransactionGen(recipient)
     transfer        <- transferGeneratorP(ts, master, recipient.toAddress, 100000000L)
 
     untypedScript = {
@@ -53,4 +60,98 @@ class ContextFunctionsTest extends PropSpec with PropertyChecks with Matchers wi
     }
   }
 
+  property("reading from data transaction array by key") {
+    forAll(preconditionsAndPayments) {
+      case ((_, _, tx, _)) =>
+        val int  = tx.data(0)
+        val bool = tx.data(1)
+        val bin  = tx.data(2)
+        val str  = tx.data(3)
+        val result = runScript[Boolean](
+          s"""
+               |match tx {
+               | case tx: DataTransaction => {
+               |  let d = tx.data
+               |
+               |  let int  = extract(getInteger(d, "${int.key}"))
+               |  let bool = extract(getBoolean(d, "${bool.key}"))
+               |  let bin  = extract(getBinary(d, "${bin.key}"))
+               |  let str  = extract(getString(d, "${str.key}"))
+               |
+               |  let okInt  = int  == ${int.value}
+               |  let okBool = bool == ${bool.value}
+               |  let okBin  = bin  == base58'${Base58.encode(bin.asInstanceOf[BinaryDataEntry].value.arr)}'
+               |  let okStr  = str  == "${str.value}"
+               |
+               |  let badInt  = isDefined(getInteger(d, "${bool.key}"))
+               |  let badBool = isDefined(getBoolean(d, "${bin.key}"))
+               |  let badBin  = isDefined(getBinary(d, "${str.key}"))
+               |  let badStr  = isDefined(getString(d, "${int.key}"))
+               |
+               |  let noSuchKey = isDefined(getInteger(d, "\u00a0"))
+               |
+               |  let positives = okInt && okBool && okBin && okStr
+               |  let negatives = badInt || badBool || badBin || badStr || noSuchKey
+               |  positives && ! negatives
+               | }
+               | case _ => throw
+               |}
+               |""".stripMargin,
+          tx
+        )
+        result shouldBe Right(true)
+    }
+  }
+
+  property("reading from data transaction array by index") {
+    forAll(preconditionsAndPayments, Gen.choose(4, 40)) {
+      case ((_, _, tx, _), badIndex) =>
+        val int  = tx.data(0)
+        val bool = tx.data(1)
+        val bin  = tx.data(2)
+        val str  = tx.data(3)
+        val ok = runScript[Boolean](
+          s"""
+               |match tx {
+               | case tx: DataTransaction => {
+               |  let d = tx.data
+               |
+               |  let int  = extract(getInteger(d, 0))
+               |  let bool = extract(getBoolean(d, 1))
+               |  let bin  = extract(getBinary(d, 2))
+               |  let str  = extract(getString(d, 3))
+               |
+               |  let okInt  = int  == ${int.value}
+               |  let okBool = bool == ${bool.value}
+               |  let okBin  = bin  == base58'${Base58.encode(bin.asInstanceOf[BinaryDataEntry].value.arr)}'
+               |  let okStr  = str  == "${str.value}"
+               |
+               |  let badInt  = isDefined(getInteger(d, 1))
+               |  let badBool = isDefined(getBoolean(d, 2))
+               |  let badBin  = isDefined(getBinary(d, 3))
+               |  let badStr  = isDefined(getString(d, 0))
+               |
+               |  let positives = okInt && okBool && okBin && okStr
+               |  let negatives = badInt || badBool || badBin || badStr
+               |  positives && ! negatives
+               | }
+               | case _ => throw
+               |}
+               |""".stripMargin,
+          tx
+        )
+        ok shouldBe Right(true)
+
+        val outOfBounds = runScript[Boolean](
+          s"""
+             |match tx {
+             | case tx: DataTransaction => isDefined(getInteger(tx.data, $badIndex))
+             | case _ => false
+             |}
+             |""".stripMargin,
+          tx
+        )
+        outOfBounds shouldBe Left(s"java.lang.IndexOutOfBoundsException: $badIndex")
+    }
+  }
 }


### PR DESCRIPTION
This addresses two issues:
https://wavesplatform.atlassian.net/browse/NODE-1072
https://wavesplatform.atlassian.net/browse/NODE-1073

Functions added:
```
toString(integer | boolean)
toBytes(integer | boolean | string)
get{Integer | Boolean | Binary | String}(dataentry[], string) // retrieve by key
get{Integer | Boolean | Binary | String}(dataentry[], integer) // retrieve by array index
```