### PR TITLE
NODE-1075 Make order books responses faster

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherTestSuite.scala
@@ -64,7 +64,6 @@ class MatcherTestSuite extends FreeSpec with Matchers with BeforeAndAfterAll wit
     }
 
     "sell order could be placed correctly" - {
-      // Alice places sell order
       "alice places sell order" in {
         order1.status shouldBe "OrderAccepted"
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -292,6 +292,15 @@ waves {
 
     # Blacklisted addresses
     blacklisted-addresses: []
+
+    # Cache for /matcher/orderbook/{amountAsset}/{priceAsset}?depth=N
+    order-book-snapshot-http-cache {
+      # A timeout to store cache
+      cache-timeout = 5s
+
+      # Cache for these depths. When ?depth=3 is requested, returned a cache for depth of 10
+      depth-ranges = [10, 100]
+    }
   }
 
   # New blocks generator settings

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -93,6 +93,7 @@ class Matcher(actorSystem: ActorSystem,
 
   def shutdownMatcher(): Unit = {
     val stopMatcherTimeout = 5.minutes
+    orderBooksSnapshotCache.close()
     Await.result(gracefulStop(matcher, stopMatcherTimeout, MatcherActor.Shutdown), stopMatcherTimeout)
     db.close()
     Await.result(matcherServerBinding.unbind(), 10.seconds)

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.Http.ServerBinding
 import akka.pattern.gracefulStop
 import akka.stream.ActorMaterializer
 import com.wavesplatform.db._
-import com.wavesplatform.matcher.api.MatcherApiRoute
+import com.wavesplatform.matcher.api.{MatcherApiRoute, OrderBookSnapshotHttpCache}
 import com.wavesplatform.matcher.market.{MatcherActor, MatcherTransactionWriter, OrderHistoryActor}
 import com.wavesplatform.matcher.model.OrderBook
 import com.wavesplatform.settings.{BlockchainSettings, RestAPISettings}
@@ -38,9 +38,17 @@ class Matcher(actorSystem: ActorSystem,
 
   private val pairBuilder    = new AssetPairBuilder(matcherSettings, blockchain)
   private val orderBookCache = new ConcurrentHashMap[AssetPair, OrderBook](1000, 0.9f, 10)
-  private val orderBooks     = new AtomicReference(Map.empty[AssetPair, ActorRef])
 
-  private def updateOrderBookCache(assetPair: AssetPair)(newSnapshot: OrderBook): Unit = orderBookCache.put(assetPair, newSnapshot)
+  private val orderBooks = new AtomicReference(Map.empty[AssetPair, ActorRef])
+  private val orderBooksSnapshotCache = new OrderBookSnapshotHttpCache(
+    OrderBookSnapshotHttpCache.Settings(5.seconds, List(1, 10, 100)),
+    p => Option(orderBookCache.get(p))
+  )
+
+  private def updateOrderBookCache(assetPair: AssetPair)(newSnapshot: OrderBook): Unit = {
+    orderBookCache.put(assetPair, newSnapshot)
+    orderBooksSnapshotCache.invalidate(assetPair)
+  }
 
   lazy val matcherApiRoutes = Seq(
     MatcherApiRoute(
@@ -49,7 +57,7 @@ class Matcher(actorSystem: ActorSystem,
       matcher,
       orderHistory,
       p => Option(orderBooks.get()).flatMap(_.get(p)),
-      p => Option(orderBookCache.get(p)),
+      orderBooksSnapshotCache,
       txWriter,
       restAPISettings,
       matcherSettings,

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -41,7 +41,7 @@ class Matcher(actorSystem: ActorSystem,
 
   private val orderBooks = new AtomicReference(Map.empty[AssetPair, ActorRef])
   private val orderBooksSnapshotCache = new OrderBookSnapshotHttpCache(
-    OrderBookSnapshotHttpCache.Settings(5.seconds, List(1, 10, 100)),
+    matcherSettings.orderBookSnapshotHttpCache,
     p => Option(orderBookCache.get(p))
   )
 

--- a/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
+++ b/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
@@ -3,7 +3,9 @@ package com.wavesplatform.matcher
 import java.io.File
 
 import com.typesafe.config.Config
+import com.wavesplatform.matcher.api.OrderBookSnapshotHttpCache
 import net.ceedubs.ficus.Ficus._
+import net.ceedubs.ficus.readers.ArbitraryTypeReader.arbitraryTypeValueReader
 import net.ceedubs.ficus.readers.NameMapper
 import scorex.transaction.assets.exchange.AssetPair
 
@@ -31,7 +33,8 @@ case class MatcherSettings(enable: Boolean,
                            blacklistedNames: Seq[Regex],
                            validationTimeout: FiniteDuration,
                            maxOrdersPerRequest: Int,
-                           blacklistedAddresses: Set[String])
+                           blacklistedAddresses: Set[String],
+                           orderBookSnapshotHttpCache: OrderBookSnapshotHttpCache.Settings)
 
 object MatcherSettings {
 
@@ -62,7 +65,8 @@ object MatcherSettings {
     val validationTimeout = config.as[FiniteDuration](s"$configPath.validation-timeout")
     val blacklistedNames  = config.as[List[String]](s"$configPath.blacklisted-names").map(_.r)
 
-    val blacklistedAddresses = config.as[List[String]](s"$configPath.blacklisted-addresses")
+    val blacklistedAddresses       = config.as[List[String]](s"$configPath.blacklisted-addresses")
+    val orderBookSnapshotHttpCache = config.as[OrderBookSnapshotHttpCache.Settings](s"$configPath.order-book-snapshot-http-cache")
 
     val isMigrateToNewOrderHistoryStorage = !new File(dataDirectory).exists()
 
@@ -88,6 +92,7 @@ object MatcherSettings {
       validationTimeout,
       maxOrdersPerRequest,
       blacklistedAddresses.toSet,
+      orderBookSnapshotHttpCache
     )
   }
 }

--- a/src/main/scala/com/wavesplatform/matcher/api/JsonSerializer.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/JsonSerializer.scala
@@ -1,14 +1,35 @@
 package com.wavesplatform.matcher.api
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.{DeserializationContext, JsonNode, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.wavesplatform.state.ByteStr
+import scorex.transaction.assets.exchange.AssetPair
 
 object JsonSerializer {
 
+  private val coreTypeSerializers = new SimpleModule()
+  coreTypeSerializers.addDeserializer(classOf[AssetPair], new AssetPairSerializer)
+
   private val mapper = new ObjectMapper() with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)
+  mapper.registerModule(coreTypeSerializers)
 
   def serialize(value: Any): String                             = mapper.writeValueAsString(value)
   def deserialize[T](value: String)(implicit m: Manifest[T]): T = mapper.readValue(value)
+
+  private class AssetPairSerializer extends StdDeserializer[AssetPair](classOf[AssetPair]) {
+    override def deserialize(p: JsonParser, ctxt: DeserializationContext): AssetPair = {
+      val node = p.getCodec.readTree[JsonNode](p)
+      def readAsset(fieldName: String) = {
+        val x = node.get(fieldName).asText(AssetPair.WavesName)
+        if (x == AssetPair.WavesName) None else Some(ByteStr.decodeBase58(x).get)
+      }
+
+      AssetPair(readAsset("amountAsset"), readAsset("priceAsset"))
+    }
+  }
 
 }

--- a/src/main/scala/com/wavesplatform/matcher/api/JsonSerializer.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/JsonSerializer.scala
@@ -1,0 +1,14 @@
+package com.wavesplatform.matcher.api
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+
+object JsonSerializer {
+
+  private val mapper = new ObjectMapper() with ScalaObjectMapper
+  mapper.registerModule(DefaultScalaModule)
+
+  def serialize(value: Any): String                             = mapper.writeValueAsString(value)
+  def deserialize[T](value: String)(implicit m: Manifest[T]): T = mapper.readValue(value)
+
+}

--- a/src/main/scala/com/wavesplatform/matcher/api/JsonSerializer.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/JsonSerializer.scala
@@ -11,7 +11,7 @@ import scorex.transaction.assets.exchange.AssetPair
 object JsonSerializer {
 
   private val coreTypeSerializers = new SimpleModule()
-  coreTypeSerializers.addDeserializer(classOf[AssetPair], new AssetPairSerializer)
+  coreTypeSerializers.addDeserializer(classOf[AssetPair], new AssetPairDeserializer)
 
   private val mapper = new ObjectMapper() with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)
@@ -20,15 +20,15 @@ object JsonSerializer {
   def serialize(value: Any): String                             = mapper.writeValueAsString(value)
   def deserialize[T](value: String)(implicit m: Manifest[T]): T = mapper.readValue(value)
 
-  private class AssetPairSerializer extends StdDeserializer[AssetPair](classOf[AssetPair]) {
+  private class AssetPairDeserializer extends StdDeserializer[AssetPair](classOf[AssetPair]) {
     override def deserialize(p: JsonParser, ctxt: DeserializationContext): AssetPair = {
       val node = p.getCodec.readTree[JsonNode](p)
-      def readAsset(fieldName: String) = {
+      def readAssetId(fieldName: String) = {
         val x = node.get(fieldName).asText(AssetPair.WavesName)
         if (x == AssetPair.WavesName) None else Some(ByteStr.decodeBase58(x).get)
       }
 
-      AssetPair(readAsset("amountAsset"), readAsset("priceAsset"))
+      AssetPair(readAssetId("amountAsset"), readAssetId("priceAsset"))
     }
   }
 

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.matcher.api
 
 import akka.actor.ActorRef
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.{Directive1, Route}
 import akka.pattern.ask
 import akka.util.Timeout
@@ -12,7 +12,7 @@ import com.wavesplatform.matcher.market.MatcherTransactionWriter.GetTransactions
 import com.wavesplatform.matcher.market.OrderBookActor._
 import com.wavesplatform.matcher.market.OrderHistoryActor._
 import com.wavesplatform.matcher.model.MatcherModel.{Level, Price}
-import com.wavesplatform.matcher.model.{LevelAgg, LimitOrder, OrderBook, OrderInfo}
+import com.wavesplatform.matcher.model._
 import com.wavesplatform.matcher.{AssetPairBuilder, MatcherSettings}
 import com.wavesplatform.metrics.TimerExt
 import com.wavesplatform.settings.RestAPISettings
@@ -100,7 +100,11 @@ case class MatcherApiRoute(wallet: Wallet,
   def getOrderBook: Route = (path("orderbook" / AssetPairPM) & get) { p =>
     parameters('depth.as[Int].?) { depth =>
       withAssetPair(p, redirectToInverse = true) { pair =>
-        complete(StatusCodes.OK -> orderBookSnapshot(pair).fold(GetOrderBookResponse.empty(pair))(handleGetOrderBook(pair, _, depth)).json)
+        complete(
+          orderBookSnapshot(pair)
+            .fold(GetOrderBookResponse.empty(pair))(handleGetOrderBook(pair, _, depth))
+            .toHttpResponse
+        )
       }
     }
   }
@@ -125,7 +129,7 @@ case class MatcherApiRoute(wallet: Wallet,
     (pathEndOrSingleSlash & post) {
       json[Order] { order =>
         placeTimer.measure {
-          (matcher ? order).mapTo[MatcherResponse].map(r => r.code -> r.json)
+          (matcher ? order).mapTo[MatcherResponse].map(_.toHttpResponse)
         }
       }
     }
@@ -156,11 +160,9 @@ case class MatcherApiRoute(wallet: Wallet,
       orderBook(pair).fold[Route](complete(StatusCodes.NotFound -> Json.obj("message" -> "Invalid asset pair"))) { oba =>
         json[CancelOrderRequest] { req =>
           if (req.isSignatureValid()) cancelTimer.measure {
-            (oba ? CancelOrder(pair, req))
-              .mapTo[MatcherResponse]
-              .map(r => r.code -> r.json)
+            (oba ? CancelOrder(pair, req)).mapTo[MatcherResponse].map(_.toHttpResponse)
           } else {
-            OrderCancelRejected("Invalid signature").json
+            OrderCancelRejected("Invalid signature").toHttpResponse
           }
         }
       }
@@ -193,9 +195,9 @@ case class MatcherApiRoute(wallet: Wallet,
         if (req.isSignatureValid()) {
           (orderHistory ? DeleteOrderFromHistory(pair, req.senderPublicKey, req.orderId, NTP.correctedTime()))
             .mapTo[MatcherResponse]
-            .map(r => r.code -> r.json)
+            .map(_.toHttpResponse)
         } else {
-          StatusCodes.BadRequest -> Json.obj("message" -> "Incorrect signature")
+          StatusCodeMatcherResponse(StatusCodes.BadRequest, "Incorrect signature").toHttpResponse
         }
       }
     }
@@ -222,7 +224,7 @@ case class MatcherApiRoute(wallet: Wallet,
       checkGetSignature(publicKey, ts, sig) match {
         case Success(address) =>
           withAssetPair(p, redirectToInverse = true, s"/publicKey/$publicKey") { pair =>
-            complete(StatusCodes.OK -> DBUtils.ordersByAddressAndPair(db, address, pair, false).map {
+            complete(StatusCodes.OK -> DBUtils.ordersByAddressAndPair(db, address, pair, activeOnly = false).map {
               case (order, orderInfo) =>
                 orderJson(order, orderInfo)
             })
@@ -296,7 +298,7 @@ case class MatcherApiRoute(wallet: Wallet,
         }
     }
 
-    complete(resp.map(r => r.code -> r.json))
+    complete(resp.map(_.toHttpResponse))
   }
 
   @Path("/orders/{address}")
@@ -328,7 +330,7 @@ case class MatcherApiRoute(wallet: Wallet,
       complete(
         (orderHistory ? GetTradableBalance(pair, address, NTP.correctedTime()))
           .mapTo[MatcherResponse]
-          .map(r => r.code -> r.json))
+          .map(_.toHttpResponse))
     }
   }
 
@@ -378,10 +380,7 @@ case class MatcherApiRoute(wallet: Wallet,
   @ApiOperation(value = "Get the open trading markets", notes = "Get the open trading markets along with trading pairs meta data", httpMethod = "GET")
   def orderbooks: Route = path("orderbook") {
     (pathEndOrSingleSlash & get) {
-      complete(
-        (matcher ? GetMarkets)
-          .mapTo[GetMarketsResponse]
-          .map(r => r.json))
+      complete((matcher ? GetMarkets).mapTo[GetMarketsResponse].map(_.toHttpResponse))
     }
   }
 
@@ -394,10 +393,7 @@ case class MatcherApiRoute(wallet: Wallet,
     ))
   def orderBookDelete: Route = (path("orderbook" / AssetPairPM) & delete & withAuth) { p =>
     withAssetPair(p) { pair =>
-      complete(
-        (matcher ? DeleteOrderBookRequest(pair))
-          .mapTo[MatcherResponse]
-          .map(r => r.code -> r.json))
+      complete((matcher ? DeleteOrderBookRequest(pair)).mapTo[MatcherResponse].map(_.toHttpResponse))
     }
   }
 
@@ -410,10 +406,7 @@ case class MatcherApiRoute(wallet: Wallet,
       new ApiImplicitParam(name = "orderId", value = "Order Id", dataType = "string", paramType = "path")
     ))
   def getTransactionsByOrder: Route = (path("transactions" / ByteStrPM) & get) { orderId =>
-    complete(
-      (txWriter ? GetTransactionsByOrder(orderId))
-        .mapTo[MatcherResponse]
-        .map(r => r.code -> r.json))
+    complete((txWriter ? GetTransactionsByOrder(orderId)).mapTo[MatcherResponse].map(_.toHttpResponse))
   }
 }
 
@@ -424,7 +417,12 @@ object MatcherApiRoute {
     def aggregateLevel(l: (Price, Level[LimitOrder])) = LevelAgg(l._1, l._2.foldLeft(0L)((b, o) => b + o.amount))
 
     val d = Math.min(depth.getOrElse(MaxDepth), MaxDepth)
-    GetOrderBookResponse(pair, orderBook.bids.take(d).map(aggregateLevel).toSeq, orderBook.asks.take(d).map(aggregateLevel).toSeq)
+    GetOrderBookResponse(
+      NTP.correctedTime(),
+      pair,
+      orderBook.bids.take(d).map(aggregateLevel).toSeq,
+      orderBook.asks.take(d).map(aggregateLevel).toSeq
+    )
   }
 
   def orderJson(order: Order, orderInfo: OrderInfo): JsObject =

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
@@ -8,6 +8,7 @@ trait MatcherResponse {
   def toHttpResponse: HttpResponse
 
   protected def httpJsonResponse(entity: JsValue, status: StatusCode = StatusCodes.OK) = HttpResponse(
+    status = status,
     headers = collection.immutable.Seq(`Content-Type`(MediaTypes.`application/json`)),
     entity = Json.stringify(entity)
   )

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
@@ -1,7 +1,6 @@
 package com.wavesplatform.matcher.api
 
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.`Content-Type`
 import play.api.libs.json.{JsNull, JsValue, Json}
 
 trait MatcherResponse {
@@ -9,8 +8,10 @@ trait MatcherResponse {
 
   protected def httpJsonResponse(entity: JsValue, status: StatusCode = StatusCodes.OK) = HttpResponse(
     status = status,
-    headers = collection.immutable.Seq(`Content-Type`(MediaTypes.`application/json`)),
-    entity = Json.stringify(entity)
+    entity = HttpEntity(
+      ContentTypes.`application/json`,
+      Json.stringify(entity)
+    )
   )
 }
 

--- a/src/main/scala/com/wavesplatform/matcher/api/OrderBookSnapshotHttpCache.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/OrderBookSnapshotHttpCache.scala
@@ -1,0 +1,55 @@
+package com.wavesplatform.matcher.api
+
+import akka.http.scaladsl.model.HttpResponse
+import com.google.common.cache.{CacheBuilder, CacheLoader}
+import com.wavesplatform.matcher.api.OrderBookSnapshotHttpCache.Settings
+import com.wavesplatform.matcher.market.OrderBookActor.GetOrderBookResponse
+import com.wavesplatform.matcher.model.MatcherModel.{Level, Price}
+import com.wavesplatform.matcher.model.{LevelAgg, LimitOrder, OrderBook}
+import scorex.transaction.assets.exchange.AssetPair
+import scorex.utils.NTP
+
+import scala.concurrent.duration.FiniteDuration
+
+class OrderBookSnapshotHttpCache(settings: Settings, orderBookSnapshot: AssetPair => Option[OrderBook]) {
+  import OrderBookSnapshotHttpCache._
+
+  private val depthRanges = settings.depthRanges.sorted
+  private val maxDepth    = depthRanges.max
+
+  private val orderBookSnapshotCache = CacheBuilder
+    .newBuilder()
+    .expireAfterAccess(settings.cacheTimeout.length, settings.cacheTimeout.unit)
+    .build[Key, HttpResponse](new CacheLoader[Key, HttpResponse] {
+      override def load(key: Key): HttpResponse = {
+        def aggregateLevel(l: (Price, Level[LimitOrder])) = LevelAgg(l._1, l._2.foldLeft(0L)((b, o) => b + o.amount))
+
+        val orderBook = orderBookSnapshot(key.pair).getOrElse(OrderBook.empty)
+        GetOrderBookResponse(
+          NTP.correctedTime(),
+          key.pair,
+          orderBook.bids.view.take(key.depth).map(aggregateLevel).toSeq,
+          orderBook.asks.view.take(key.depth).map(aggregateLevel).toSeq
+        ).toHttpResponse
+      }
+    })
+
+  def get(pair: AssetPair, depth: Option[Int]): HttpResponse = {
+    val nearestDepth = depth
+      .flatMap(desiredDepth => depthRanges.find(_ >= desiredDepth))
+      .getOrElse(maxDepth)
+
+    orderBookSnapshotCache.get(Key(pair, nearestDepth))
+  }
+
+  def invalidate(pair: AssetPair): Unit = {
+    import scala.collection.JavaConverters._
+    orderBookSnapshotCache.invalidateAll(depthRanges.map(Key(pair, _)).asJava)
+  }
+}
+
+object OrderBookSnapshotHttpCache {
+  case class Settings(cacheTimeout: FiniteDuration, depthRanges: List[Int])
+
+  private case class Key(pair: AssetPair, depth: Int)
+}

--- a/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
@@ -3,10 +3,10 @@ package com.wavesplatform.matcher.market
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.actor.{Actor, ActorRef, Props, Terminated}
-import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.model._
 import akka.persistence.{PersistentActor, RecoveryCompleted, _}
 import com.google.common.base.Charsets
-import com.wavesplatform.matcher.api.{BadMatcherResponse, MatcherResponse, StatusCodeMatcherResponse}
+import com.wavesplatform.matcher.api.{MatcherResponse, StatusCodeMatcherResponse}
 import com.wavesplatform.matcher.market.OrderBookActor._
 import com.wavesplatform.matcher.model.OrderBook
 import com.wavesplatform.matcher.{AssetPairBuilder, MatcherSettings}
@@ -254,7 +254,7 @@ class MatcherActor(orderHistory: ActorRef,
       shutdownStatus = shutdownStatus.copy(orderBooksStopped = true)
       shutdownStatus.tryComplete()
 
-    case _ if shutdownStatus.initiated => sender() ! BadMatcherResponse(StatusCodes.ServiceUnavailable, "System is going shutdown")
+    case _ if shutdownStatus.initiated => sender() ! StatusCodeMatcherResponse(StatusCodes.ServiceUnavailable, "System is going shutdown")
   }
 
   override def receiveCommand: Receive = forwardToOrderBook orElse snapshotsCommands
@@ -315,25 +315,21 @@ object MatcherActor {
   case object ShutdownComplete
 
   case class GetMarketsResponse(publicKey: Array[Byte], markets: Seq[MarketData]) extends MatcherResponse {
-    def getMarketsJs: JsValue =
-      JsArray(
-        markets.map(m =>
-          Json.obj(
-            "amountAsset"     -> m.pair.amountAssetStr,
-            "amountAssetName" -> m.amountAssetName,
-            "amountAssetInfo" -> m.amountAssetInfo,
-            "priceAsset"      -> m.pair.priceAssetStr,
-            "priceAssetName"  -> m.priceAssetName,
-            "priceAssetInfo"  -> m.priceAssetinfo,
-            "created"         -> m.created
-        )))
-
-    def json: JsValue = Json.obj(
-      "matcherPublicKey" -> Base58.encode(publicKey),
-      "markets"          -> getMarketsJs
-    )
-
-    def code: StatusCode = StatusCodes.OK
+    override def toHttpResponse: HttpResponse =
+      httpJsonResponse(
+        Json.obj(
+          "matcherPublicKey" -> Base58.encode(publicKey),
+          "markets" -> JsArray(markets.map(m =>
+            Json.obj(
+              "amountAsset"     -> m.pair.amountAssetStr,
+              "amountAssetName" -> m.amountAssetName,
+              "amountAssetInfo" -> m.amountAssetInfo,
+              "priceAsset"      -> m.pair.priceAssetStr,
+              "priceAssetName"  -> m.priceAssetName,
+              "priceAssetInfo"  -> m.priceAssetinfo,
+              "created"         -> m.created
+          )))
+        ))
   }
 
   case class AssetInfo(decimals: Int)

--- a/src/main/scala/com/wavesplatform/matcher/market/MatcherTransactionWriter.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/MatcherTransactionWriter.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.matcher.market
 
 import akka.actor.{Actor, Props}
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.HttpResponse
 import com.wavesplatform.database.{DBExt, RW}
 import com.wavesplatform.matcher.api.MatcherResponse
 import com.wavesplatform.matcher.model.Events._
@@ -57,8 +57,7 @@ object MatcherTransactionWriter {
   case class GetTransactionsByOrder(orderId: ByteStr)
 
   case class GetTransactionsResponse(txs: Seq[ExchangeTransaction]) extends MatcherResponse {
-    val json                      = JsArray(txs.map(_.json()))
-    val code: StatusCodes.Success = StatusCodes.OK
+    override def toHttpResponse: HttpResponse = httpJsonResponse(JsArray(txs.map(_.json())))
   }
 
   private def appendTxId(rw: RW, orderId: ByteStr, txId: ByteStr): Unit = {

--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -1,11 +1,12 @@
 package com.wavesplatform.matcher.market
 
 import akka.actor.{ActorRef, Cancellable, Props, Stash}
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.`Content-Type`
+import akka.http.scaladsl.model.{HttpResponse, MediaTypes, StatusCodes}
 import akka.persistence._
 import com.google.common.cache.CacheBuilder
 import com.wavesplatform.matcher.MatcherSettings
-import com.wavesplatform.matcher.api.{CancelOrderRequest, MatcherResponse}
+import com.wavesplatform.matcher.api.{CancelOrderRequest, JsonSerializer, MatcherResponse}
 import com.wavesplatform.matcher.market.MatcherActor.{Shutdown, ShutdownComplete}
 import com.wavesplatform.matcher.market.OrderBookActor._
 import com.wavesplatform.matcher.market.OrderHistoryActor._
@@ -122,7 +123,7 @@ class OrderBookActor(assetPair: AssetPair,
         .foreach(x => context.system.eventStream.publish(Events.OrderCanceled(x, unmatchable = false)))
       deleteMessages(lastSequenceNr)
       deleteSnapshots(SnapshotSelectionCriteria.Latest)
-      sender() ! GetOrderBookResponse(pair, Seq(), Seq())
+      sender() ! GetOrderBookResponse(NTP.correctedTime(), pair, Seq(), Seq())
       context.stop(self)
 
     case DeleteSnapshotsSuccess(criteria) =>
@@ -495,37 +496,43 @@ object OrderBookActor {
   case object OrderCleanup
 
   case object OperationTimedOut extends MatcherResponse {
-    val json = Json.obj("status" -> "OperationTimedOut", "message" -> "Operation is timed out, please try later")
-    val code = StatusCodes.InternalServerError
+    override def toHttpResponse: HttpResponse = httpJsonResponse(
+      entity = Json.obj("status" -> "OperationTimedOut", "message" -> "Operation is timed out, please try later"),
+      status = StatusCodes.InternalServerError
+    )
   }
 
   case class OrderAccepted(order: Order) extends MatcherResponse {
-    val json: JsObject            = Json.obj("status" -> "OrderAccepted", "message" -> order.json())
-    val code: StatusCodes.Success = StatusCodes.OK
+    override def toHttpResponse: HttpResponse = httpJsonResponse(Json.obj("status" -> "OrderAccepted", "message" -> order.json()))
   }
 
   case class OrderRejected(message: String) extends MatcherResponse {
-    val json: JsObject                = Json.obj("status" -> "OrderRejected", "message" -> message)
-    val code: StatusCodes.ClientError = StatusCodes.BadRequest
+    override def toHttpResponse: HttpResponse = httpJsonResponse(
+      entity = Json.obj("status" -> "OrderRejected", "message" -> message),
+      status = StatusCodes.BadRequest
+    )
   }
 
   case class OrderCanceled(orderId: String) extends MatcherResponse {
-    val json: JsObject            = Json.obj("status" -> "OrderCanceled", "orderId" -> orderId)
-    val code: StatusCodes.Success = StatusCodes.OK
+    override def toHttpResponse: HttpResponse = httpJsonResponse(Json.obj("status" -> "OrderCanceled", "orderId" -> orderId))
   }
 
   case class OrderCancelRejected(message: String) extends MatcherResponse {
-    val json: JsObject                = Json.obj("status" -> "OrderCancelRejected", "message" -> message)
-    val code: StatusCodes.ClientError = StatusCodes.BadRequest
+    override def toHttpResponse: HttpResponse = httpJsonResponse(
+      entity = Json.obj("status" -> "OrderCancelRejected", "message" -> message),
+      status = StatusCodes.BadRequest
+    )
   }
 
-  case class GetOrderBookResponse(pair: AssetPair, bids: Seq[LevelAgg], asks: Seq[LevelAgg]) extends MatcherResponse {
-    val json: JsValue             = Json.toJson(OrderBookResult(NTP.correctedTime(), pair, bids, asks))
-    val code: StatusCodes.Success = StatusCodes.OK
+  case class GetOrderBookResponse(ts: Long, pair: AssetPair, bids: Seq[LevelAgg], asks: Seq[LevelAgg]) extends MatcherResponse {
+    override def toHttpResponse: HttpResponse = HttpResponse(
+      headers = collection.immutable.Seq(`Content-Type`(MediaTypes.`application/json`)),
+      entity = JsonSerializer.serialize(OrderBookResult(ts, pair, bids, asks))
+    )
   }
 
   object GetOrderBookResponse {
-    def empty(pair: AssetPair): GetOrderBookResponse = GetOrderBookResponse(pair, Seq(), Seq())
+    def empty(pair: AssetPair): GetOrderBookResponse = GetOrderBookResponse(NTP.correctedTime(), pair, Seq(), Seq())
   }
 
   // Direct requests

--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -471,7 +471,6 @@ object OrderBookActor {
 
   def name(assetPair: AssetPair): String = assetPair.toString
 
-  val MaxDepth                 = 50
   val AlreadyCanceledCacheSize = 10000L
 
   private case class ShutdownStatus(initiated: Boolean, oldMessagesDeleted: Boolean, oldSnapshotsDeleted: Boolean, onComplete: () => Unit) {

--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -1,8 +1,7 @@
 package com.wavesplatform.matcher.market
 
 import akka.actor.{ActorRef, Cancellable, Props, Stash}
-import akka.http.scaladsl.model.headers.`Content-Type`
-import akka.http.scaladsl.model.{HttpResponse, MediaTypes, StatusCodes}
+import akka.http.scaladsl.model._
 import akka.persistence._
 import com.google.common.cache.CacheBuilder
 import com.wavesplatform.matcher.MatcherSettings
@@ -525,8 +524,10 @@ object OrderBookActor {
 
   case class GetOrderBookResponse(ts: Long, pair: AssetPair, bids: Seq[LevelAgg], asks: Seq[LevelAgg]) extends MatcherResponse {
     override def toHttpResponse: HttpResponse = HttpResponse(
-      headers = collection.immutable.Seq(`Content-Type`(MediaTypes.`application/json`)),
-      entity = JsonSerializer.serialize(OrderBookResult(ts, pair, bids, asks))
+      entity = HttpEntity(
+        ContentTypes.`application/json`,
+        JsonSerializer.serialize(OrderBookResult(ts, pair, bids, asks))
+      )
     )
   }
 

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderBook.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderBook.scala
@@ -8,7 +8,6 @@ import scala.collection.immutable.TreeMap
 case class OrderBook(bids: TreeMap[Price, Level[BuyLimitOrder]], asks: TreeMap[Price, Level[SellLimitOrder]]) {
   def bestBid: Option[BuyLimitOrder]  = bids.headOption.flatMap(_._2.headOption)
   def bestAsk: Option[SellLimitOrder] = asks.headOption.flatMap(_._2.headOption)
-
 }
 
 object OrderBook {

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderBookResult.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderBookResult.scala
@@ -1,11 +1,21 @@
 package com.wavesplatform.matcher.model
 
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.wavesplatform.matcher.api.JsonSerializer
 import play.api.libs.json.{Json, Writes}
 import scorex.transaction.assets.exchange.AssetPair
+import scorex.utils.NTP
 
-case class OrderBookResult(timestamp: Long, pair: AssetPair, bids: Seq[LevelAgg], asks: Seq[LevelAgg]) {}
+@JsonSerialize(using = classOf[OrderBookResult.Serializer])
+case class OrderBookResult(timestamp: Long, pair: AssetPair, bids: Seq[LevelAgg], asks: Seq[LevelAgg])
 
 object OrderBookResult {
+
+  def empty(pair: AssetPair) = OrderBookResult(NTP.correctedTime(), pair, Seq.empty, Seq.empty)
+
   implicit val assetPairWrites = new Writes[AssetPair] {
     def writes(pair: AssetPair) = Json.obj(
       "amountAsset" -> pair.amountAssetStr,
@@ -27,5 +37,31 @@ object OrderBookResult {
       "bids"      -> ob.bids,
       "asks"      -> ob.asks
     )
+  }
+
+  def toJson(x: OrderBookResult): String = JsonSerializer.serialize(x)
+
+  class Serializer extends StdSerializer[OrderBookResult](classOf[OrderBookResult]) {
+    override def serialize(x: OrderBookResult, j: JsonGenerator, serializerProvider: SerializerProvider): Unit = {
+      j.writeStartObject()
+
+      j.writeNumberField("timestamp", x.timestamp)
+
+      j.writeFieldName("pair")
+      j.writeStartObject()
+      j.writeStringField("amountAsset", x.pair.amountAssetStr)
+      j.writeStringField("priceAsset", x.pair.priceAssetStr)
+      j.writeEndObject()
+
+      j.writeArrayFieldStart("bids")
+      x.bids.foreach(j.writeObject)
+      j.writeEndArray()
+
+      j.writeArrayFieldStart("asks")
+      x.asks.foreach(j.writeObject)
+      j.writeEndArray()
+
+      j.writeEndObject()
+    }
   }
 }

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderBookResult.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderBookResult.scala
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.wavesplatform.matcher.api.JsonSerializer
-import play.api.libs.json.{Json, Writes}
 import scorex.transaction.assets.exchange.AssetPair
 import scorex.utils.NTP
 
@@ -15,29 +14,6 @@ case class OrderBookResult(timestamp: Long, pair: AssetPair, bids: Seq[LevelAgg]
 object OrderBookResult {
 
   def empty(pair: AssetPair) = OrderBookResult(NTP.correctedTime(), pair, Seq.empty, Seq.empty)
-
-  implicit val assetPairWrites = new Writes[AssetPair] {
-    def writes(pair: AssetPair) = Json.obj(
-      "amountAsset" -> pair.amountAssetStr,
-      "priceAsset"  -> pair.priceAssetStr
-    )
-  }
-
-  implicit val levelAggtWrites = new Writes[LevelAgg] {
-    def writes(a: LevelAgg) = Json.obj(
-      "price"  -> a.price,
-      "amount" -> a.amount
-    )
-  }
-
-  implicit val OrderBookResultWrites = new Writes[OrderBookResult] {
-    def writes(ob: OrderBookResult) = Json.obj(
-      "timestamp" -> ob.timestamp,
-      "pair"      -> ob.pair,
-      "bids"      -> ob.bids,
-      "asks"      -> ob.asks
-    )
-  }
 
   def toJson(x: OrderBookResult): String = JsonSerializer.serialize(x)
 

--- a/src/test/scala/com/wavesplatform/matcher/api/OrderBookSnapshotHttpCacheSpec.scala
+++ b/src/test/scala/com/wavesplatform/matcher/api/OrderBookSnapshotHttpCacheSpec.scala
@@ -1,0 +1,215 @@
+package com.wavesplatform.matcher.api
+
+import java.nio.charset.StandardCharsets
+
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
+import com.wavesplatform.TransactionGenBase
+import com.wavesplatform.matcher.model.MatcherModel.Price
+import com.wavesplatform.matcher.model._
+import com.wavesplatform.state.ByteStr
+import org.scalacheck.Gen
+import org.scalatest.{FreeSpec, Matchers}
+import scorex.transaction.assets.exchange.{AssetPair, Order}
+
+import scala.collection.immutable.TreeMap
+import scala.concurrent.duration._
+
+class OrderBookSnapshotHttpCacheSpec extends FreeSpec with Matchers with TransactionGenBase {
+
+  private val defaultAssetPair = AssetPair(None, Some(ByteStr("asset".getBytes)))
+
+  "OrderBookSnapshotHttpCache" - {
+    "should cache" in {
+      val cache = createDefaultCache
+      def get   = cache.get(defaultAssetPair, Some(1))
+
+      val a = get
+      val b = get
+
+      a shouldBe b
+    }
+
+    "should not drop the cache if the timeout after an access was not reached" in {
+      val cache = createDefaultCache
+      def get   = cache.get(defaultAssetPair, Some(1))
+
+      val a = get
+      Thread.sleep(30)
+      val b = get
+
+      a shouldBe b
+    }
+
+    "should drop the cache after timeout" in {
+      val cache = createDefaultCache
+      def get   = cache.get(defaultAssetPair, Some(1))
+
+      val a = get
+      Thread.sleep(70)
+      val b = get
+
+      a shouldNot be(b)
+    }
+
+    "should aggregate levels and preserve right order" - {
+      "asks" in {
+        // Two levels: one is aggregated and one is not
+        val askLimitOrders = Gen
+          .containerOfN[Vector, Order](2, orderGen)
+          .map { xs =>
+            val r = xs.head +: xs.tail.map(_.copy(price = xs.head.price - 1))
+            r.map(x => SellLimitOrder(x.price, x.amount, x.matcherFee, x)).groupBy(_.price)
+          }
+          .sample
+          .get
+
+        val cache = new OrderBookSnapshotHttpCache(
+          OrderBookSnapshotHttpCache.Settings(1.minute, List(3, 9)), { _ =>
+            Some(
+              OrderBook(
+                bids = TreeMap.empty,
+                asks = TreeMap(askLimitOrders.toSeq: _*)(OrderBook.asksOrdering)
+              )
+            )
+          }
+        )
+
+        val ob = orderBookFrom(cache.get(defaultAssetPair, Some(3)))
+
+        withClue("bids size")(ob.bids shouldBe empty)
+        withClue("asks size")(ob.asks.size shouldBe 2)
+
+        def checkHasAggregatedAmount(x: LevelAgg): Unit = withClue(s"${x.price} should have the aggregated amount") {
+          x shouldBe LevelAgg(x.price, askLimitOrders(x.price).map(_.amount).sum)
+        }
+
+        ob.asks.foreach(checkHasAggregatedAmount)
+
+        withClue(s"asks have ascending order (${ob.asks.map(_.price).mkString(", ")})") {
+          ob.asks.zip(ob.asks.tail).foreach {
+            case (prev, next) => prev.price shouldBe <(next.price)
+          }
+        }
+      }
+
+      "bids" in {
+        // Two levels: one is aggregated and one is not
+        val bidLimitOrders = Gen
+          .containerOfN[Vector, Order](2, orderGen)
+          .map { xs =>
+            val r = xs.head +: xs.tail.map(_.copy(price = xs.head.price + 1))
+            r.map(x => BuyLimitOrder(x.price, x.amount, x.matcherFee, x)).groupBy(_.price)
+          }
+          .sample
+          .get
+
+        val cache = new OrderBookSnapshotHttpCache(
+          OrderBookSnapshotHttpCache.Settings(1.minute, List(3, 9)), { _ =>
+            Some(
+              OrderBook(
+                bids = TreeMap(bidLimitOrders.toSeq: _*)(OrderBook.bidsOrdering),
+                asks = TreeMap.empty
+              )
+            )
+          }
+        )
+
+        val ob = orderBookFrom(cache.get(defaultAssetPair, Some(3)))
+
+        withClue("bids size")(ob.bids.size shouldBe 2)
+        withClue("asks size")(ob.asks shouldBe empty)
+
+        def checkHasAggregatedAmount(x: LevelAgg): Unit = withClue(s"${x.price} should have the aggregated amount") {
+          x shouldBe LevelAgg(x.price, bidLimitOrders(x.price).map(_.amount).sum)
+        }
+
+        ob.bids.foreach(checkHasAggregatedAmount)
+
+        withClue(s"bids have descending order (${ob.bids.map(_.price).mkString(", ")})") {
+          ob.bids.zip(ob.bids.tail).foreach {
+            case (prev, next) => prev.price shouldBe >(next.price)
+          }
+        }
+      }
+    }
+
+    "should return the nearest depth cache" - {
+      // Two levels: one is aggregated and one is not
+      val bidLimitOrders = randomBidLimitOrders
+      val cache = new OrderBookSnapshotHttpCache(
+        OrderBookSnapshotHttpCache.Settings(1.minute, List(3, 9)), { _ =>
+          Some(
+            OrderBook(
+              bids = TreeMap(bidLimitOrders.toSeq: _*),
+              asks = TreeMap.empty
+            )
+          )
+        }
+      )
+
+      "None -> 9" in {
+        val ob = orderBookFrom(cache.get(defaultAssetPair, None))
+        ob.bids.size shouldBe 9
+      }
+
+      Seq(
+        0  -> 3,
+        1  -> 3,
+        3  -> 3,
+        5  -> 9,
+        10 -> 9
+      ).foreach {
+        case (depth, expectedSize) =>
+          s"$depth -> $expectedSize" in {
+            val ob = orderBookFrom(cache.get(defaultAssetPair, Some(depth)))
+            ob.bids.size shouldBe expectedSize
+          }
+      }
+    }
+
+    "should clear all depth caches after invalidate" in {
+      val bidLimitOrders = randomBidLimitOrders
+      val depths         = List(1, 3, 7, 9)
+      val cache = new OrderBookSnapshotHttpCache(
+        OrderBookSnapshotHttpCache.Settings(1.minute, depths), { _ =>
+          Some(
+            OrderBook(
+              bids = TreeMap(bidLimitOrders.toSeq: _*),
+              asks = TreeMap.empty
+            )
+          )
+        }
+      )
+
+      val prev = depths.map(x => x -> orderBookFrom(cache.get(defaultAssetPair, Some(x)))).toMap
+
+      Thread.sleep(100)
+      cache.invalidate(defaultAssetPair)
+
+      depths.foreach { depth =>
+        withClue(s"cache for depth=$depth was invalidated") {
+          val curr = orderBookFrom(cache.get(defaultAssetPair, Some(depth)))
+          curr.timestamp shouldNot be(prev(depth).timestamp)
+        }
+      }
+    }
+  }
+
+  private def createDefaultCache = new OrderBookSnapshotHttpCache(OrderBookSnapshotHttpCache.Settings(50.millis, List(3, 9)), _ => None)
+
+  private def orderBookFrom(x: HttpResponse): OrderBookResult = JsonSerializer.deserialize[OrderBookResult](
+    x.entity
+      .asInstanceOf[HttpEntity.Strict]
+      .getData()
+      .decodeString(StandardCharsets.UTF_8)
+  )
+
+  private def randomBidLimitOrders: Map[Price, Vector[BuyLimitOrder]] =
+    Gen
+      .containerOfN[Vector, Order](10, orderGen)
+      .map { xs =>
+        xs.map(x => BuyLimitOrder(x.price, x.amount, x.matcherFee, x)).groupBy(_.price)
+      }
+      .sample
+      .get
+}

--- a/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
@@ -1,10 +1,11 @@
 package com.wavesplatform.matcher.market
 
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
 import akka.persistence.inmemory.extension.{InMemoryJournalStorage, StorageExtension}
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import com.wavesplatform.matcher.api.StatusCodeMatcherResponse
@@ -20,6 +21,7 @@ import com.wavesplatform.utx.UtxPool
 import io.netty.channel.group.ChannelGroup
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
+import play.api.libs.json.Json
 import scorex.account.{PrivateKeyAccount, PublicKeyAccount}
 import scorex.settings.TestFunctionalitySettings
 import scorex.transaction.AssetId
@@ -178,8 +180,12 @@ class MatcherActorSpecification
       val pair2 = AssetPair(a1, a2)
 
       val now = NTP.correctedTime()
-      val json =
-        GetMarketsResponse(Array(), Seq(MarketData(pair1, a1Name, waves, now, None, None), MarketData(pair2, a1Name, a2Name, now, None, None))).json
+      val json = Json.parse(
+        GetMarketsResponse(Array(), Seq(MarketData(pair1, a1Name, waves, now, None, None), MarketData(pair2, a1Name, a2Name, now, None, None))).toHttpResponse.entity
+          .asInstanceOf[HttpEntity.Strict]
+          .getData()
+          .decodeString(StandardCharsets.UTF_8)
+      )
 
       ((json \ "markets")(0) \ "priceAsset").as[String] shouldBe AssetPair.WavesName
       ((json \ "markets")(0) \ "priceAssetName").as[String] shouldBe waves

--- a/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.settings
 
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.matcher.MatcherSettings
+import com.wavesplatform.matcher.api.OrderBookSnapshotHttpCache
 import org.scalatest.{FlatSpec, Matchers}
 import scorex.transaction.assets.exchange.AssetPair
 
@@ -39,6 +40,10 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |    blacklisted-names: ["b"]
         |    blacklisted-addresses: ["c"]
         |    validation-timeout = 10m
+        |    order-book-snapshot-http-cache {
+        |      cache-timeout = 11m
+        |      depth-ranges = [1, 5, 333]
+        |    }
         |  }
         |}""".stripMargin))
 
@@ -66,5 +71,9 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.blacklistedNames.map(_.pattern.pattern()) shouldBe Seq("b")
     settings.validationTimeout shouldBe 10.minutes
     settings.blacklistedAddresses shouldBe Set("c")
+    settings.orderBookSnapshotHttpCache shouldBe OrderBookSnapshotHttpCache.Settings(
+      cacheTimeout = 11.minutes,
+      depthRanges = List(1, 5, 333)
+    )
   }
 }


### PR DESCRIPTION
TODO:
* [x] Order books caching;
* [x] Metrics for order books caches;
* [x] Settings for OrderBookSnapshotHttpCache;
* [x] Unit tests for OrderBookSnapshotHttpCache;
* [x] Documentation: https://github.com/wavesplatform/waves-documentation/pull/268