### PR TITLE
NODE-1077 Sponsorship rounding fixes

### DIFF
--- a/benchmark/src/test/scala/com/wavesplatform/state/BaseState.scala
+++ b/benchmark/src/test/scala/com/wavesplatform/state/BaseState.scala
@@ -67,7 +67,7 @@ trait BaseState extends TransactionGenBase {
 
   private def append(prev: Option[Block], next: Block): Unit = {
     val preconditionDiff = BlockDiffer.fromBlock(fsSettings, state, prev, next, MiningConstraint.Unlimited).explicitGet()._1
-    state.append(preconditionDiff, next)
+    state.append(preconditionDiff, None, next)
   }
 
   def applyBlock(b: Block): Unit = {

--- a/benchmark/src/test/scala/com/wavesplatform/state/BaseState.scala
+++ b/benchmark/src/test/scala/com/wavesplatform/state/BaseState.scala
@@ -67,7 +67,7 @@ trait BaseState extends TransactionGenBase {
 
   private def append(prev: Option[Block], next: Block): Unit = {
     val preconditionDiff = BlockDiffer.fromBlock(fsSettings, state, prev, next, MiningConstraint.Unlimited).explicitGet()._1
-    state.append(preconditionDiff, None, next)
+    state.append(preconditionDiff, 0, next)
   }
 
   def applyBlock(b: Block): Unit = {

--- a/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
@@ -471,6 +471,8 @@ object AsyncHttpApi extends Assertions {
       for {
         newBalance          <- accountBalance(acc)
         newEffectiveBalance <- accountEffectiveBalance(acc)
+        _ = Console.err.println(s"$acc exp $balance | $effectiveBalance")       ///
+        _ = Console.err.println(s"$acc act $newBalance | $newEffectiveBalance") ///
       } yield {
         withClue(s"effective balance of $acc") {
           newEffectiveBalance shouldBe effectiveBalance

--- a/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
@@ -471,8 +471,6 @@ object AsyncHttpApi extends Assertions {
       for {
         newBalance          <- accountBalance(acc)
         newEffectiveBalance <- accountEffectiveBalance(acc)
-        _ = Console.err.println(s"$acc exp $balance | $effectiveBalance")       ///
-        _ = Console.err.println(s"$acc act $newBalance | $newEffectiveBalance") ///
       } yield {
         withClue(s"effective balance of $acc") {
           newEffectiveBalance shouldBe effectiveBalance

--- a/src/main/scala/com/wavesplatform/database/Caches.scala
+++ b/src/main/scala/com/wavesplatform/database/Caches.scala
@@ -92,6 +92,7 @@ trait Caches extends Blockchain {
   override def activatedFeatures: Map[Short, Int] = activatedFeaturesCache
 
   protected def doAppend(block: Block,
+                         carryFee: Option[Portfolio],
                          addresses: Map[Address, BigInt],
                          wavesBalances: Map[BigInt, Long],
                          assetBalances: Map[BigInt, Map[ByteStr, Long]],
@@ -106,7 +107,7 @@ trait Caches extends Blockchain {
                          aliases: Map[Alias, BigInt],
                          sponsorship: Map[AssetId, Sponsorship]): Unit
 
-  override def append(diff: Diff, block: Block): Unit = {
+  override def append(diff: Diff, carryFee: Option[Portfolio], block: Block): Unit = {
     heightCache += 1
     scoreCache += block.blockScore()
     lastBlockCache = Some(block)
@@ -162,6 +163,7 @@ trait Caches extends Blockchain {
 
     doAppend(
       block,
+      carryFee,
       newAddressIds,
       wavesBalances.result(),
       assetBalances.result(),

--- a/src/main/scala/com/wavesplatform/database/Caches.scala
+++ b/src/main/scala/com/wavesplatform/database/Caches.scala
@@ -92,7 +92,7 @@ trait Caches extends Blockchain {
   override def activatedFeatures: Map[Short, Int] = activatedFeaturesCache
 
   protected def doAppend(block: Block,
-                         carryFee: Option[Portfolio],
+                         carryFee: Long,
                          addresses: Map[Address, BigInt],
                          wavesBalances: Map[BigInt, Long],
                          assetBalances: Map[BigInt, Map[ByteStr, Long]],
@@ -107,7 +107,7 @@ trait Caches extends Blockchain {
                          aliases: Map[Alias, BigInt],
                          sponsorship: Map[AssetId, Sponsorship]): Unit
 
-  override def append(diff: Diff, carryFee: Option[Portfolio], block: Block): Unit = {
+  override def append(diff: Diff, carryFee: Long, block: Block): Unit = {
     heightCache += 1
     scoreCache += block.blockScore()
     lastBlockCache = Some(block)

--- a/src/main/scala/com/wavesplatform/database/Keys.scala
+++ b/src/main/scala/com/wavesplatform/database/Keys.scala
@@ -95,6 +95,6 @@ object Keys {
   def aliasIsDisabled(alias: Alias): Key[Boolean] =
     Key(bytes(AliasIsDisabledPrefix, alias.bytes.arr), Option(_).exists(_(0) == 1), if (_) Array[Byte](1) else Array[Byte](0))
 
-  def carryFeeHistory: Key[Seq[Int]]           = historyKey(44, Array())
-  def carryFee(height: Int): Key[Option[Long]] = Key.opt(h(45, height), Option(_).fold(0L)(Longs.fromByteArray), Longs.toByteArray)
+  def carryFeeHistory: Key[Seq[Int]]   = historyKey(44, Array())
+  def carryFee(height: Int): Key[Long] = Key(h(45, height), Option(_).fold(0L)(Longs.fromByteArray), Longs.toByteArray)
 }

--- a/src/main/scala/com/wavesplatform/database/Keys.scala
+++ b/src/main/scala/com/wavesplatform/database/Keys.scala
@@ -94,4 +94,7 @@ object Keys {
   val AliasIsDisabledPrefix: Short = 43
   def aliasIsDisabled(alias: Alias): Key[Boolean] =
     Key(bytes(AliasIsDisabledPrefix, alias.bytes.arr), Option(_).exists(_(0) == 1), if (_) Array[Byte](1) else Array[Byte](0))
+
+  def carryFeeHistory: Key[Seq[Int]]           = historyKey(44, Array())
+  def carryFee(height: Int): Key[Option[Long]] = Key.opt(h(45, height), Option(_).fold(0L)(Longs.fromByteArray), Longs.toByteArray)
 }

--- a/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
+++ b/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
@@ -124,10 +124,8 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
     }
   }
 
-  override def carryFee: Option[Portfolio] = readOnly { db =>
-    val c = db
-      .get(Keys.carryFee(db.get(Keys.height))) ///just height?
-      .map(fee => Portfolio(fee, LeaseBalance(0, 0), Map.empty))
+  override def carryFee: Long = readOnly { db =>
+    val c = db.get(Keys.carryFee(db.get(Keys.height))) ///just height?
     Console.err.println(s"<==> LDBW read carry $c") ///
     c
   }
@@ -201,7 +199,7 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
   }
 
   override protected def doAppend(block: Block,
-                                  carry: Option[Portfolio],
+                                  carry: Long,
                                   newAddresses: Map[Address, BigInt],
                                   wavesBalances: Map[BigInt, Long],
                                   assetBalances: Map[BigInt, Map[ByteStr, Long]],
@@ -362,10 +360,8 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
     }
 
     Console.err.println(s"<==> LDBW writing carry $carry") ///
-    carry.foreach { c =>
-      rw.put(Keys.carryFee(height), carry.map(_.balance))
-      expiredKeys ++= updateHistory(rw, Keys.carryFeeHistory, threshold, Keys.carryFee)
-    }
+    rw.put(Keys.carryFee(height), carry)
+    expiredKeys ++= updateHistory(rw, Keys.carryFeeHistory, threshold, Keys.carryFee)
 
     rw.put(Keys.transactionIdsAtHeight(height), transactions.keys.toSeq)
 

--- a/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
+++ b/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
@@ -124,11 +124,7 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
     }
   }
 
-  override def carryFee: Long = readOnly { db =>
-    val c = db.get(Keys.carryFee(db.get(Keys.height))) ///just height?
-    Console.err.println(s"<==> LDBW read carry $c") ///
-    c
-  }
+  override def carryFee: Long = readOnly(_.get(Keys.carryFee(height)))
 
   override def accountData(address: Address): AccountDataInfo = readOnly { db =>
     AccountDataInfo((for {
@@ -236,7 +232,6 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
         newAddressesForWaves += addressId
       }
       rw.put(Keys.wavesBalance(addressId)(height), balance)
-      Console.err.println(s"<==> LDBW bal of $addressId @$height = $balance") ///
       expiredKeys ++= updateHistory(rw, wbh, kwbh, threshold, Keys.wavesBalance(addressId))
       addressId
     }
@@ -359,7 +354,6 @@ class LevelDBWriter(writableDB: DB, fs: FunctionalitySettings, val maxCacheSize:
       expiredKeys ++= updateHistory(rw, Keys.sponsorshipHistory(assetId), threshold, Keys.sponsorship(assetId))
     }
 
-    Console.err.println(s"<==> LDBW writing carry $carry") ///
     rw.put(Keys.carryFee(height), carry)
     expiredKeys ++= updateHistory(rw, Keys.carryFeeHistory, threshold, Keys.carryFee)
 

--- a/src/main/scala/com/wavesplatform/state/Blockchain.scala
+++ b/src/main/scala/com/wavesplatform/state/Blockchain.scala
@@ -16,7 +16,7 @@ trait Blockchain {
   def blockHeaderAndSize(blockId: ByteStr): Option[(BlockHeader, Int)]
 
   def lastBlock: Option[Block]
-  def carryFee: Option[Portfolio]
+  def carryFee: Long
   def blockBytes(height: Int): Option[Array[Byte]]
   def blockBytes(blockId: ByteStr): Option[Array[Byte]]
 
@@ -75,6 +75,6 @@ trait Blockchain {
     * @note Portfolios passed to `pf` only contain Waves and Leasing balances to improve performance */
   def collectLposPortfolios[A](pf: PartialFunction[(Address, Portfolio), A]): Map[Address, A]
 
-  def append(diff: Diff, carryFee: Option[Portfolio], block: Block): Unit
+  def append(diff: Diff, carryFee: Long, block: Block): Unit
   def rollbackTo(targetBlockId: ByteStr): Seq[Block]
 }

--- a/src/main/scala/com/wavesplatform/state/Blockchain.scala
+++ b/src/main/scala/com/wavesplatform/state/Blockchain.scala
@@ -16,6 +16,7 @@ trait Blockchain {
   def blockHeaderAndSize(blockId: ByteStr): Option[(BlockHeader, Int)]
 
   def lastBlock: Option[Block]
+  def carryFee: Option[Portfolio]
   def blockBytes(height: Int): Option[Array[Byte]]
   def blockBytes(blockId: ByteStr): Option[Array[Byte]]
 
@@ -74,6 +75,6 @@ trait Blockchain {
     * @note Portfolios passed to `pf` only contain Waves and Leasing balances to improve performance */
   def collectLposPortfolios[A](pf: PartialFunction[(Address, Portfolio), A]): Map[Address, A]
 
-  def append(diff: Diff, block: Block): Unit
+  def append(diff: Diff, carryFee: Option[Portfolio], block: Block): Unit
   def rollbackTo(targetBlockId: ByteStr): Seq[Block]
 }

--- a/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
@@ -156,7 +156,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
             } else
               measureSuccessful(forgeBlockTimeStats, ng.totalDiffOf(block.reference)) match {
                 case None => Left(BlockAppendError(s"References incorrect or non-existing block", block))
-                case Some((referencedForgedBlock, referencedLiquidDiff, discarded)) =>
+                case Some((referencedForgedBlock, referencedLiquidDiff, carry, discarded)) =>
                   if (referencedForgedBlock.signatureValid()) {
                     if (discarded.nonEmpty) {
                       microBlockForkStats.increment()
@@ -174,7 +174,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
                     val diff = BlockDiffer
                       .fromBlock(
                         functionalitySettings,
-                        CompositeBlockchain.composite(blockchain, referencedLiquidDiff),
+                        CompositeBlockchain.composite(blockchain, referencedLiquidDiff, carry),
                         Some(referencedForgedBlock),
                         block,
                         constraint
@@ -186,7 +186,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
                     }
 
                     diff.map { hardenedDiff =>
-                      blockchain.append(referencedLiquidDiff, referencedForgedBlock)
+                      blockchain.append(referencedLiquidDiff, carry, referencedForgedBlock)
                       TxsInBlockchainStats.record(ng.transactions.size)
                       Some((hardenedDiff, discarded.flatMap(_.transactionData)))
                     }
@@ -198,10 +198,10 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
               }
         }).map {
           _ map {
-            case ((newBlockDiff, updatedTotalConstraint), discarded) =>
+            case ((newBlockDiff, carry, updatedTotalConstraint), discarded) =>
               val height = blockchain.height + 1
               restTotalConstraint = updatedTotalConstraint
-              ngState = Some(new NgState(block, newBlockDiff, featuresApprovedWithBlock(block)))
+              ngState = Some(new NgState(block, newBlockDiff, carry, featuresApprovedWithBlock(block)))
               lastBlockId.foreach(id => internalLastBlockInfo.onNext(LastBlockInfo(id, height, score, blockchainReady)))
               if ((block.timestamp > time
                     .getTimestamp() - settings.minerSettings.intervalAfterLastBlockThenGenerationIsAllowed.toMillis) || (height % 100 == 0)) {
@@ -246,9 +246,9 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
                 BlockDiffer.fromMicroBlock(functionalitySettings, this, blockchain.lastBlockTimestamp, microBlock, ng.base.timestamp, mdConstraint)
               }
             } yield {
-              val (diff, updatedMdConstraint) = r
+              val (diff, carry, updatedMdConstraint) = r
               restTotalConstraint = updatedMdConstraint.constraints.head
-              ng.append(microBlock, diff, System.currentTimeMillis)
+              ng.append(microBlock, diff, carry, System.currentTimeMillis)
               log.info(s"$microBlock appended")
               internalLastBlockInfo.onNext(LastBlockInfo(microBlock.totalResBlockSig, height, score, ready = true))
             }
@@ -340,10 +340,16 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
 
   override def lastBlock: Option[Block] = ngState.map(_.bestLiquidBlock).orElse(blockchain.lastBlock)
 
+  override def carryFee: Option[Portfolio] = {
+    val ng = ngState.flatMap(_.carryFee)
+    Console.err.println(s"<==> BUI.carryFee: ng $ng, bc ${blockchain.carryFee}") ///
+    ng.orElse(blockchain.carryFee)
+  }
+
   override def blockBytes(blockId: ByteStr): Option[Array[Byte]] =
     (for {
-      ng            <- ngState
-      (block, _, _) <- ng.totalDiffOf(blockId)
+      ng               <- ngState
+      (block, _, _, _) <- ng.totalDiffOf(blockId)
     } yield block.bytes()).orElse(blockchain.blockBytes(blockId))
 
   override def blockIdsAfter(parentSignature: ByteStr, howMany: Int): Option[Seq[ByteStr]] = {
@@ -511,7 +517,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
       blockchain.collectLposPortfolios(pf) ++ b.result()
     }
 
-  override def append(diff: Diff, block: Block): Unit = blockchain.append(diff, block)
+  override def append(diff: Diff, carry: Option[Portfolio], block: Block): Unit = blockchain.append(diff, carry, block)
 
   override def rollbackTo(targetBlockId: AssetId): Seq[Block] = blockchain.rollbackTo(targetBlockId)
 

--- a/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
@@ -340,11 +340,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
 
   override def lastBlock: Option[Block] = ngState.map(_.bestLiquidBlock).orElse(blockchain.lastBlock)
 
-  override def carryFee: Option[Portfolio] = {
-    val ng = ngState.flatMap(_.carryFee)
-    Console.err.println(s"<==> BUI.carryFee: ng $ng, bc ${blockchain.carryFee}") ///
-    ng.orElse(blockchain.carryFee)
-  }
+  override def carryFee: Long = ngState.map(_.carryFee).getOrElse(blockchain.carryFee)
 
   override def blockBytes(blockId: ByteStr): Option[Array[Byte]] =
     (for {
@@ -517,7 +513,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
       blockchain.collectLposPortfolios(pf) ++ b.result()
     }
 
-  override def append(diff: Diff, carry: Option[Portfolio], block: Block): Unit = blockchain.append(diff, carry, block)
+  override def append(diff: Diff, carry: Long, block: Block): Unit = blockchain.append(diff, carry, block)
 
   override def rollbackTo(targetBlockId: AssetId): Seq[Block] = blockchain.rollbackTo(targetBlockId)
 

--- a/src/main/scala/com/wavesplatform/state/NgState.scala
+++ b/src/main/scala/com/wavesplatform/state/NgState.scala
@@ -58,7 +58,6 @@ class NgState(val base: Block, val baseBlockDiff: Diff, val baseBlockCarry: Long
     forgeBlock(id).map {
       case (b, txs) =>
         val (d, c) = diffFor(id)
-//        Console.err.println(s"<==> NGS totalDiff $d carry $c") ///
         (b, d, c, txs)
     }
 
@@ -104,10 +103,7 @@ class NgState(val base: Block, val baseBlockDiff: Diff, val baseBlockCarry: Long
   def append(m: MicroBlock, diff: Diff, microblockCarry: Long, timestamp: Long): Unit = {
     microDiffs.put(m.totalResBlockSig, (diff, microblockCarry, timestamp))
     micros.prepend(m)
-    Console.err.println(s"<==> NGS append: diff $diff carry $microblockCarry") ///
   }
 
   def carryFee: Long = baseBlockCarry + microDiffs.values.map(_._2).sum
-
-  Console.err.println(s"<==> NGS mdiffs=$microDiffs baseCarry=$baseBlockCarry") ///
 }

--- a/src/main/scala/com/wavesplatform/state/diffs/BlockDiffer.scala
+++ b/src/main/scala/com/wavesplatform/state/diffs/BlockDiffer.scala
@@ -19,64 +19,45 @@ import com.wavesplatform.utils.ScorexLogging
 
 object BlockDiffer extends ScorexLogging with Instrumented {
 
-  private def clearSponsorship(blockchain: Blockchain, portfolio: Portfolio, height: Int, fs: FunctionalitySettings): Portfolio = {
-    if (height >= Sponsorship.sponsoredFeesSwitchHeight(blockchain, fs)) {
-      val sponsoredAssets = portfolio.assets
-        .map {
-          case (assetId, totalFee) =>
-            (assetId, totalFee, blockchain.assetDescription(assetId))
-        }
-        .collect {
-          case (assetId, totalFee, Some(desc)) if desc.sponsorship > 0 =>
-            (assetId, totalFee, desc.sponsorship)
-        }
-      val unsponsoredPf = portfolio.copy(assets = portfolio.assets -- sponsoredAssets.map(_._1))
-      val sponsoredWaves = sponsoredAssets.map {
-        case (_, totalFee, baseFee) => Sponsorship.toWaves(totalFee, baseFee)
-      }.sum
-      unsponsoredPf.copy(balance = unsponsoredPf.balance + sponsoredWaves)
-    } else portfolio
-  }
-
   def fromBlock[Constraint <: MiningConstraint](settings: FunctionalitySettings,
                                                 blockchain: Blockchain,
                                                 maybePrevBlock: Option[Block],
                                                 block: Block,
-                                                constraint: Constraint): Either[ValidationError, (Diff, Constraint)] = {
-    val blockSigner = block.signerData.generator.toAddress
+                                                constraint: Constraint): Either[ValidationError, (Diff, Option[Portfolio], Constraint)] = {
     val stateHeight = blockchain.height
 
     // height switch is next after activation
-    val ng4060switchHeight = blockchain.featureActivationHeight(BlockchainFeatures.NG.id).getOrElse(Int.MaxValue)
+    val ngHeight          = blockchain.featureActivationHeight(BlockchainFeatures.NG.id).getOrElse(Int.MaxValue)
+    val sponsorshipHeight = Sponsorship.sponsoredFeesSwitchHeight(blockchain, settings)
 
-    lazy val prevBlockFeeDistr: Option[Diff] =
-      if (stateHeight > ng4060switchHeight)
-        maybePrevBlock.map(
-          prevBlock =>
-            Diff.empty.copy(portfolios = Map(blockSigner ->
-              clearSponsorship(blockchain, prevBlock.prevBlockFeePart(), stateHeight, settings))))
+    lazy val prevBlockFeeDistr: Option[Portfolio] =
+      if (stateHeight >= sponsorshipHeight) {
+        Console.err.println(s"FB prevFee read from $blockchain") ///
+        blockchain.carryFee
+      } else if (stateHeight > ngHeight)
+        maybePrevBlock.map(_.prevBlockFeePart())
       else None
 
-    lazy val currentBlockFeeDistr =
-      if (stateHeight < ng4060switchHeight)
-        Some(Diff.empty.copy(portfolios = Map(blockSigner -> block.feesPortfolio())))
+    lazy val currentBlockFeeDistr: Option[Portfolio] =
+      if (stateHeight < ngHeight)
+        Some(block.feesPortfolio())
       else
         None
 
-    val prevBlockTimestamp = maybePrevBlock.map(_.timestamp)
+    Console.err.println(s"FB h=$stateHeight ng@$ngHeight sp@$sponsorshipHeight") ///
     for {
       _ <- block.sigValidEi()
       r <- apply(
         settings,
         blockchain,
         constraint,
-        prevBlockTimestamp,
+        maybePrevBlock.map(_.timestamp),
         block.signerData.generator,
         prevBlockFeeDistr,
         currentBlockFeeDistr,
         block.timestamp,
         block.transactionData,
-        1
+        stateHeight + 1
       )
     } yield r
   }
@@ -86,7 +67,7 @@ object BlockDiffer extends ScorexLogging with Instrumented {
                                                      prevBlockTimestamp: Option[Long],
                                                      micro: MicroBlock,
                                                      timestamp: Long,
-                                                     constraint: Constraint): Either[ValidationError, (Diff, Constraint)] = {
+                                                     constraint: Constraint): Either[ValidationError, (Diff, Option[Portfolio], Constraint)] = {
     for {
       // microblocks are processed within block which is next after 40-only-block which goes on top of activated height
       _ <- Either.cond(blockchain.activatedFeatures.contains(BlockchainFeatures.NG.id), (), ActivationError(s"MicroBlocks are not yet activated"))
@@ -101,7 +82,7 @@ object BlockDiffer extends ScorexLogging with Instrumented {
         None,
         timestamp,
         micro.transactionData,
-        0
+        blockchain.height
       )
     } yield r
   }
@@ -111,67 +92,87 @@ object BlockDiffer extends ScorexLogging with Instrumented {
                                                     initConstraint: Constraint,
                                                     prevBlockTimestamp: Option[Long],
                                                     blockGenerator: Address,
-                                                    prevBlockFeeDistr: Option[Diff],
-                                                    currentBlockFeeDistr: Option[Diff],
+                                                    prevBlockFeeDistr: Option[Portfolio],
+                                                    currentBlockFeeDistr: Option[Portfolio],
                                                     timestamp: Long,
                                                     txs: Seq[Transaction],
-                                                    heightDiff: Int): Either[ValidationError, (Diff, Constraint)] = {
+                                                    currentBlockHeight: Int): Either[ValidationError, (Diff, Option[Portfolio], Constraint)] = {
     def updateConstraint(constraint: Constraint, blockchain: Blockchain, tx: Transaction): Constraint =
       constraint.put(blockchain, tx).asInstanceOf[Constraint]
 
-    val currentBlockHeight = blockchain.height + heightDiff
-    val txDiffer           = TransactionDiffer(settings, prevBlockTimestamp, timestamp, currentBlockHeight) _
+    val txDiffer                                    = TransactionDiffer(settings, prevBlockTimestamp, timestamp, currentBlockHeight) _
+    val initDiff                                    = Diff.empty.copy(portfolios = Map(blockGenerator -> currentBlockFeeDistr.orElse(prevBlockFeeDistr).orEmpty))
+    val init: (Diff, Option[Portfolio], Constraint) = (initDiff, None, initConstraint)
+    val hasNg                                       = currentBlockFeeDistr.isEmpty
+    val hasSponsorship                              = currentBlockHeight >= Sponsorship.sponsoredFeesSwitchHeight(blockchain, settings)
 
-    val txsDiffEi = currentBlockFeeDistr match {
-      case Some(feedistr) =>
-        val initDiff = Monoid.combine(prevBlockFeeDistr.orEmpty, feedistr)
-        txs.foldLeft((initDiff, initConstraint).asRight[ValidationError]) {
-          case (r @ Left(_), _) => r
-          case (Right((currDiff, currConstraint)), tx) =>
-            val updatedBlockchain = composite(blockchain, currDiff)
-            val updatedConstraint = updateConstraint(currConstraint, updatedBlockchain, tx)
-            if (updatedConstraint.isOverfilled) Left(ValidationError.GenericError(s"Limit of txs was reached: $initConstraint -> $updatedConstraint"))
-            else
-              txDiffer(updatedBlockchain, tx).map { newDiff =>
-                (currDiff.combine(newDiff), updatedConstraint)
-              }
-        }
-      case None =>
-        txs.foldLeft((prevBlockFeeDistr.orEmpty, initConstraint).asRight[ValidationError]) {
-          case (r @ Left(_), _) => r
-          case (Right((currDiff, currConstraint)), tx) =>
-            val updatedBlockchain = composite(blockchain, currDiff)
-            val updatedConstraint = updateConstraint(currConstraint, updatedBlockchain, tx)
-            if (updatedConstraint.isOverfilled) Left(ValidationError.GenericError(s"Limit of txs was reached: $initConstraint -> $updatedConstraint"))
-            else
-              txDiffer(updatedBlockchain, tx).map { newDiff =>
-                val updatedPortfolios = newDiff.portfolios.combine(
-                  Map(blockGenerator -> clearSponsorship(blockchain, tx.feeDiff().multiply(Block.CurrentBlockFeePart), currentBlockHeight, settings))
-                )
+    def clearSponsorship(blockchain: Blockchain, portfolio: Portfolio): (Portfolio, Option[Portfolio]) = {
+      val spPf =
+        if (hasSponsorship)
+          Portfolio.empty.copy(
+            balance = portfolio.balance +
+              portfolio.assets.map {
+                case (assetId, assetFee) =>
+                  val baseFee = blockchain.assetDescription(assetId).get.sponsorship
+                  Sponsorship.toWaves(assetFee, baseFee)
+              }.sum)
+        else portfolio
 
-                (currDiff.combine(newDiff.copy(portfolios = updatedPortfolios)), updatedConstraint)
-              }
-        }
+      val ngPf = if (hasNg) {
+        val curPf  = spPf.multiply(Block.CurrentBlockFeePart)
+        val nextPf = spPf.minus(curPf)
+        (curPf, Some(nextPf))
+      } else (spPf, None)
+      if (hasSponsorship) ngPf else ngPf.copy(_2 = None)
     }
 
-    txsDiffEi.map {
-      case (d, constraint) =>
-        val diffWithCancelledLeases =
-          if (currentBlockHeight == settings.resetEffectiveBalancesAtHeight)
-            Monoid.combine(d, CancelAllLeases(composite(blockchain, d)))
-          else d
+    Console.err.println(s"A prevFees = $prevBlockFeeDistr")    ///
+    Console.err.println(s"A currFees = $currentBlockFeeDistr") ///
+    txs
+      .foldLeft(init.asRight[ValidationError]) {
+        case (r @ Left(_), _) => r
+        case (Right((currDiff, carryFee, currConstraint)), tx) =>
+          val updatedBlockchain = composite(blockchain, currDiff)
+          val updatedConstraint = updateConstraint(currConstraint, updatedBlockchain, tx)
+          if (updatedConstraint.isOverfilled)
+            Left(ValidationError.GenericError(s"Limit of txs was reached: $initConstraint -> $updatedConstraint"))
+          else {
+            val z = txDiffer(updatedBlockchain, tx).map { newDiff =>
+              val updatedDiff = currDiff.combine(newDiff)
+              Console.err.println(s"A   cbh=$currentBlockHeight ng=$hasNg sp=$hasSponsorship") ///
+              if (hasNg) {
+                val (curPf, nextPf) = clearSponsorship(updatedBlockchain, tx.feeDiff())
+                Console.err.println(s"A      NG curr=$curPf")  ///
+                Console.err.println(s"A      NG next=$nextPf") ///
+                val diff  = updatedDiff.combine(Diff.empty.copy(portfolios = Map(blockGenerator -> curPf)))
+                val carry = carryFee.flatMap(pf => nextPf.map(_.combine(pf))).orElse(nextPf)
+                (diff, carry, updatedConstraint)
+              } else (updatedDiff, None, updatedConstraint)
+            }
+            Console.err.println(s"A   tx=$tx") ///
+//            Console.err.println(s"A   diff = ${z.map(_._1)}") ///
+            Console.err.println(s"A   crry = ${z.map(_._2)}") ///
+            z
+          }
+      }
+      .map {
+        case (d, carryFee, constraint) =>
+          val diffWithCancelledLeases =
+            if (currentBlockHeight == settings.resetEffectiveBalancesAtHeight)
+              Monoid.combine(d, CancelAllLeases(composite(blockchain, d)))
+            else d
 
-        val diffWithLeasePatches =
-          if (currentBlockHeight == settings.blockVersion3AfterHeight)
-            Monoid.combine(diffWithCancelledLeases, CancelLeaseOverflow(composite(blockchain, diffWithCancelledLeases)))
-          else diffWithCancelledLeases
+          val diffWithLeasePatches =
+            if (currentBlockHeight == settings.blockVersion3AfterHeight)
+              Monoid.combine(diffWithCancelledLeases, CancelLeaseOverflow(composite(blockchain, diffWithCancelledLeases)))
+            else diffWithCancelledLeases
 
-        val diffWithCancelledLeaseIns =
-          if (blockchain.featureActivationHeight(BlockchainFeatures.DataTransaction.id).contains(currentBlockHeight))
-            Monoid.combine(diffWithLeasePatches, CancelInvalidLeaseIn(composite(blockchain, diffWithLeasePatches)))
-          else diffWithLeasePatches
+          val diffWithCancelledLeaseIns =
+            if (blockchain.featureActivationHeight(BlockchainFeatures.DataTransaction.id).contains(currentBlockHeight))
+              Monoid.combine(diffWithLeasePatches, CancelInvalidLeaseIn(composite(blockchain, diffWithLeasePatches)))
+            else diffWithLeasePatches
 
-        (diffWithCancelledLeaseIns, constraint)
-    }
+          (diffWithCancelledLeaseIns, carryFee, constraint)
+      }
   }
 }

--- a/src/main/scala/com/wavesplatform/state/reader/CompositeBlockchain.scala
+++ b/src/main/scala/com/wavesplatform/state/reader/CompositeBlockchain.scala
@@ -190,10 +190,7 @@ class CompositeBlockchain(inner: Blockchain, maybeDiff: => Option[Diff], carry: 
 
   override def lastBlock: Option[Block] = inner.lastBlock
 
-  override def carryFee: Long = {
-    Console.err.println(s"<==> CompB carry=$carry") // inner=$inner") ///
-    carry                                           //.orElse(inner.carryFee)
-  }
+  override def carryFee: Long = carry
 
   override def blockBytes(height: Int): Option[Array[Type]] = inner.blockBytes(height)
 

--- a/src/main/scala/com/wavesplatform/state/reader/CompositeBlockchain.scala
+++ b/src/main/scala/com/wavesplatform/state/reader/CompositeBlockchain.scala
@@ -12,7 +12,7 @@ import com.wavesplatform.transaction.lease.LeaseTransaction
 import com.wavesplatform.transaction.smart.script.Script
 import com.wavesplatform.transaction.{AssetId, Transaction, ValidationError}
 
-class CompositeBlockchain(inner: Blockchain, maybeDiff: => Option[Diff], carry: Option[Portfolio] = None) extends Blockchain {
+class CompositeBlockchain(inner: Blockchain, maybeDiff: => Option[Diff], carry: Long = 0) extends Blockchain {
 
   private def diff = maybeDiff.getOrElse(Diff.empty)
 
@@ -190,7 +190,7 @@ class CompositeBlockchain(inner: Blockchain, maybeDiff: => Option[Diff], carry: 
 
   override def lastBlock: Option[Block] = inner.lastBlock
 
-  override def carryFee: Option[Portfolio] = {
+  override def carryFee: Long = {
     Console.err.println(s"<==> CompB carry=$carry") // inner=$inner") ///
     carry                                           //.orElse(inner.carryFee)
   }
@@ -216,12 +216,12 @@ class CompositeBlockchain(inner: Blockchain, maybeDiff: => Option[Diff], carry: 
 
   override def featureVotes(height: Int): Map[Short, Int] = inner.featureVotes(height)
 
-  override def append(diff: Diff, carryFee: Option[Portfolio], block: Block): Unit = inner.append(diff, carryFee, block)
+  override def append(diff: Diff, carryFee: Long, block: Block): Unit = inner.append(diff, carryFee, block)
 
   override def rollbackTo(targetBlockId: ByteStr): Seq[Block] = inner.rollbackTo(targetBlockId)
 }
 
 object CompositeBlockchain {
-  def composite(inner: Blockchain, diff: => Option[Diff]): Blockchain                          = new CompositeBlockchain(inner, diff)
-  def composite(inner: Blockchain, diff: Diff, carryFee: Option[Portfolio] = None): Blockchain = new CompositeBlockchain(inner, Some(diff), carryFee)
+  def composite(inner: Blockchain, diff: => Option[Diff]): Blockchain          = new CompositeBlockchain(inner, diff)
+  def composite(inner: Blockchain, diff: Diff, carryFee: Long = 0): Blockchain = new CompositeBlockchain(inner, Some(diff), carryFee)
 }

--- a/src/test/scala/com/wavesplatform/history/Domain.scala
+++ b/src/test/scala/com/wavesplatform/history/Domain.scala
@@ -12,4 +12,5 @@ case class Domain(blockchainUpdater: BlockchainUpdater with NG) {
   def lastBlockId                           = blockchainUpdater.lastBlockId.get
   def portfolio(address: Address)           = blockchainUpdater.portfolio(address)
   def addressTransactions(address: Address) = blockchainUpdater.addressTransactions(address, Set.empty, 128, 0)
+  def carryFee                              = blockchainUpdater.carryFee
 }

--- a/src/test/scala/com/wavesplatform/state/RollbackSpec.scala
+++ b/src/test/scala/com/wavesplatform/state/RollbackSpec.scala
@@ -426,7 +426,7 @@ class RollbackSpec extends FreeSpec with Matchers with WithState with Transactio
             d.appendBlock(TestBlock.create(ts, d.lastBlockId, Seq(tx)))
             d.lastBlockId
           }
-          def carry(fee: Long) = Some(Portfolio(fee - fee / 5 * 2, LeaseBalance(0, 0), Map.empty))
+          def carry(fee: Long) = fee - fee / 5 * 2
 
           d.appendBlock(genesisBlock(ts, sender, Long.MaxValue / 3))
           d.carryFee shouldBe carry(0)

--- a/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTest.scala
@@ -47,8 +47,9 @@ class CommonValidationTest extends PropSpec with PropertyChecks with Matchers wi
     forAll(gen) {
       case (genesisBlock, transferTx) =>
         withStateAndHistory(settings) { blockchain =>
-          val preconditionDiff = BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()._1
-          blockchain.append(preconditionDiff, genesisBlock)
+          val (preconditionDiff, preconditionFees, _) =
+            BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()
+          blockchain.append(preconditionDiff, preconditionFees, genesisBlock)
 
           f(CommonValidation.checkFee(blockchain, settings, 1, transferTx))
         }
@@ -69,8 +70,9 @@ class CommonValidationTest extends PropSpec with PropertyChecks with Matchers wi
     forAll(gen) {
       case (genesisBlock, transferTx) =>
         withStateAndHistory(settings) { blockchain =>
-          val preconditionDiff = BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()._1
-          blockchain.append(preconditionDiff, genesisBlock)
+          val (preconditionDiff, preconditionFees, _) =
+            BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()
+          blockchain.append(preconditionDiff, preconditionFees, genesisBlock)
 
           f(CommonValidation.checkFee(blockchain, settings, 1, transferTx))
         }
@@ -91,8 +93,9 @@ class CommonValidationTest extends PropSpec with PropertyChecks with Matchers wi
     forAll(gen) {
       case (genesisBlock, transferTx) =>
         withStateAndHistory(settings) { blockchain =>
-          val preconditionDiff = BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()._1
-          blockchain.append(preconditionDiff, genesisBlock)
+          val (preconditionDiff, preconditionFees, _) =
+            BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()
+          blockchain.append(preconditionDiff, preconditionFees, genesisBlock)
 
           f(CommonValidation.checkFee(blockchain, settings, 1, transferTx))
         }
@@ -117,8 +120,9 @@ class CommonValidationTest extends PropSpec with PropertyChecks with Matchers wi
     forAll(gen) {
       case (genesisBlock, transferTx) =>
         withStateAndHistory(settings) { blockchain =>
-          val preconditionDiff = BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()._1
-          blockchain.append(preconditionDiff, genesisBlock)
+          val (preconditionDiff, preconditionFees, _) =
+            BlockDiffer.fromBlock(settings, blockchain, None, genesisBlock, MiningConstraint.Unlimited).explicitGet()
+          blockchain.append(preconditionDiff, preconditionFees, genesisBlock)
 
           CommonValidation.checkFee(blockchain, settings, 1, transferTx) shouldBe 'right
         }

--- a/src/test/scala/com/wavesplatform/state/diffs/package.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/package.scala
@@ -15,37 +15,46 @@ package object diffs extends WithState with Matchers {
 
   def assertDiffEi(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(
       assertion: Either[ValidationError, Diff] => Unit): Unit = withStateAndHistory(fs) { state =>
-    def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlock(fs, blockchain, None, b, MiningConstraint.Unlimited).map(_._1)
+    def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlock(fs, blockchain, None, b, MiningConstraint.Unlimited)
 
     preconditions.foreach { precondition =>
-      val preconditionDiffEI = differ(state, precondition)
-      val preconditionDiff   = preconditionDiffEI.explicitGet()
-      state.append(preconditionDiff, precondition)
+      val (preconditionDiff, preconditionFees, _) = differ(state, precondition).explicitGet()
+      state.append(preconditionDiff, preconditionFees, precondition)
     }
     val totalDiff1 = differ(state, block)
-    assertion(totalDiff1)
+    assertion(totalDiff1.map(_._1))
   }
+
+  private def assertDiffAndState(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings, withNg: Boolean)(
+      assertion: (Diff, Blockchain) => Unit): Unit = withStateAndHistory(fs) { state =>
+    def differ(blockchain: Blockchain, prevBlock: Option[Block], b: Block) =
+      BlockDiffer.fromBlock(fs, blockchain, if (withNg) prevBlock else None, b, MiningConstraint.Unlimited)
+
+    preconditions.foldLeft[Option[Block]](None) { (prevBlock, curBlock) =>
+      val (diff, fees, _) = differ(state, prevBlock, curBlock).explicitGet()
+      state.append(diff, fees, curBlock)
+      Some(curBlock)
+    }
+    val (diff, fees, _) = differ(state, preconditions.lastOption, block).explicitGet()
+    state.append(diff, fees, block)
+    assertion(diff, state)
+  }
+
+  def assertNgDiffState(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(
+      assertion: (Diff, Blockchain) => Unit): Unit =
+    assertDiffAndState(preconditions, block, fs, withNg = true)(assertion)
 
   def assertDiffAndState(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(
-      assertion: (Diff, Blockchain) => Unit): Unit = withStateAndHistory(fs) { state =>
-    def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlock(fs, blockchain, None, b, MiningConstraint.Unlimited).map(_._1)
-
-    preconditions.foreach { precondition =>
-      val preconditionDiff = differ(state, precondition).explicitGet()
-      state.append(preconditionDiff, precondition)
-    }
-    val totalDiff1 = differ(state, block).explicitGet()
-    state.append(totalDiff1, block)
-    assertion(totalDiff1, state)
-  }
+      assertion: (Diff, Blockchain) => Unit): Unit =
+    assertDiffAndState(preconditions, block, fs, withNg = false)(assertion)
 
   def assertDiffAndState(fs: FunctionalitySettings)(test: (Seq[Transaction] => Either[ValidationError, Unit]) => Unit): Unit =
     withStateAndHistory(fs) { state =>
-      def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlock(fs, blockchain, None, b, MiningConstraint.Unlimited).map(_._1)
+      def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlock(fs, blockchain, None, b, MiningConstraint.Unlimited)
 
       test(txs => {
         val block = TestBlock.create(txs)
-        differ(state, block).map(diff => state.append(diff, block))
+        differ(state, block).map(diff => state.append(diff._1, diff._2, block))
       })
     }
 
@@ -60,8 +69,4 @@ package object diffs extends WithState with Matchers {
     assertDiffEi(preconditions, block, fs)(_ should produce(errorMessage))
 
   def produce(errorMessage: String): ProduceError = new ProduceError(errorMessage)
-
-  def zipWithPrev[A](seq: Seq[A]): Seq[(Option[A], A)] = {
-    seq.zipWithIndex.map { case (a, i) => (if (i == 0) None else Some(seq(i - 1)), a) }
-  }
 }

--- a/src/test/scala/com/wavesplatform/transaction/NgStateTest.scala
+++ b/src/test/scala/com/wavesplatform/transaction/NgStateTest.scala
@@ -25,14 +25,14 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
       case (genesis, payments) =>
         val (block, microBlocks) = chainBaseAndMicro(randomSig, genesis, payments.map(t => Seq(t)))
 
-        val ng = new NgState(block, Diff.empty, Set.empty)
-        microBlocks.foreach(m => ng.append(m, Diff.empty, 0L))
+        val ng = new NgState(block, Diff.empty, None, Set.empty)
+        microBlocks.foreach(m => ng.append(m, Diff.empty, None, 0L))
 
         ng.totalDiffOf(microBlocks.last.totalResBlockSig)
         microBlocks.foreach { m =>
           ng.totalDiffOf(m.totalResBlockSig).get match {
-            case (forged, _, _) => forged.signatureValid() shouldBe true
-            case _              => ???
+            case (forged, _, _, _) => forged.signatureValid() shouldBe true
+            case _                 => ???
           }
         }
         Seq(microBlocks(4)).map(x => ng.totalDiffOf(x.totalResBlockSig))
@@ -44,12 +44,12 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
       case (genesis, payments) =>
         val (block, microBlocks) = chainBaseAndMicro(randomSig, genesis, payments.map(t => Seq(t)))
 
-        val ng = new NgState(block, Diff.empty, Set.empty)
-        microBlocks.foreach(m => ng.append(m, Diff.empty, 0L))
+        val ng = new NgState(block, Diff.empty, None, Set.empty)
+        microBlocks.foreach(m => ng.append(m, Diff.empty, None, 0L))
 
         ng.bestLiquidBlock.uniqueId shouldBe microBlocks.last.totalResBlockSig
 
-        new NgState(block, Diff.empty, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
+        new NgState(block, Diff.empty, None, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
     }
   }
 
@@ -58,11 +58,11 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
       case (genesis, payments) =>
         val (block, microBlocks) = chainBaseAndMicro(randomSig, genesis, payments.map(t => Seq(t)))
 
-        val ng = new NgState(block, Diff.empty, Set.empty)
+        val ng = new NgState(block, Diff.empty, None, Set.empty)
 
         microBlocks.foldLeft(1000) {
           case (thisTime, m) =>
-            ng.append(m, Diff.empty, thisTime)
+            ng.append(m, Diff.empty, None, thisTime)
             thisTime + 50
         }
 
@@ -71,7 +71,7 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
         ng.bestLastBlockInfo(1051).blockId shouldBe microBlocks.tail.head.totalResBlockSig
         ng.bestLastBlockInfo(2000).blockId shouldBe microBlocks.last.totalResBlockSig
 
-        new NgState(block, Diff.empty, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
+        new NgState(block, Diff.empty, None, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
     }
   }
 }

--- a/src/test/scala/com/wavesplatform/transaction/NgStateTest.scala
+++ b/src/test/scala/com/wavesplatform/transaction/NgStateTest.scala
@@ -25,8 +25,8 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
       case (genesis, payments) =>
         val (block, microBlocks) = chainBaseAndMicro(randomSig, genesis, payments.map(t => Seq(t)))
 
-        val ng = new NgState(block, Diff.empty, None, Set.empty)
-        microBlocks.foreach(m => ng.append(m, Diff.empty, None, 0L))
+        val ng = new NgState(block, Diff.empty, 0L, Set.empty)
+        microBlocks.foreach(m => ng.append(m, Diff.empty, 0L, 0L))
 
         ng.totalDiffOf(microBlocks.last.totalResBlockSig)
         microBlocks.foreach { m =>
@@ -44,12 +44,12 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
       case (genesis, payments) =>
         val (block, microBlocks) = chainBaseAndMicro(randomSig, genesis, payments.map(t => Seq(t)))
 
-        val ng = new NgState(block, Diff.empty, None, Set.empty)
-        microBlocks.foreach(m => ng.append(m, Diff.empty, None, 0L))
+        val ng = new NgState(block, Diff.empty, 0L, Set.empty)
+        microBlocks.foreach(m => ng.append(m, Diff.empty, 0L, 0L))
 
         ng.bestLiquidBlock.uniqueId shouldBe microBlocks.last.totalResBlockSig
 
-        new NgState(block, Diff.empty, None, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
+        new NgState(block, Diff.empty, 0L, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
     }
   }
 
@@ -58,11 +58,11 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
       case (genesis, payments) =>
         val (block, microBlocks) = chainBaseAndMicro(randomSig, genesis, payments.map(t => Seq(t)))
 
-        val ng = new NgState(block, Diff.empty, None, Set.empty)
+        val ng = new NgState(block, Diff.empty, 0L, Set.empty)
 
         microBlocks.foldLeft(1000) {
           case (thisTime, m) =>
-            ng.append(m, Diff.empty, None, thisTime)
+            ng.append(m, Diff.empty, 0L, thisTime)
             thisTime + 50
         }
 
@@ -71,7 +71,7 @@ class NgStateTest extends PropSpec with PropertyChecks with Matchers with Transa
         ng.bestLastBlockInfo(1051).blockId shouldBe microBlocks.tail.head.totalResBlockSig
         ng.bestLastBlockInfo(2000).blockId shouldBe microBlocks.last.totalResBlockSig
 
-        new NgState(block, Diff.empty, None, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
+        new NgState(block, Diff.empty, 0L, Set.empty).bestLiquidBlock.uniqueId shouldBe block.uniqueId
     }
   }
 }

--- a/src/test/scala/com/wavesplatform/transaction/SponsorFeeTransactionSpecification.scala
+++ b/src/test/scala/com/wavesplatform/transaction/SponsorFeeTransactionSpecification.scala
@@ -1,16 +1,25 @@
 package com.wavesplatform.transaction
 
 import com.wavesplatform.TransactionGen
-import com.wavesplatform.settings.Constants
+import com.wavesplatform.account.PublicKeyAccount
+import com.wavesplatform.features.BlockchainFeatures._
+import com.wavesplatform.lagonaki.mocks.TestBlock.{create => block}
+import com.wavesplatform.settings.{Constants, TestFunctionalitySettings}
 import com.wavesplatform.state.diffs._
 import com.wavesplatform.state.{ByteStr, EitherExt2}
+import com.wavesplatform.transaction.assets.{IssueTransactionV1, SponsorFeeTransaction}
+import com.wavesplatform.transaction.transfer.TransferTransactionV1
+import org.scalacheck.Gen
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.Json
-import com.wavesplatform.account.PublicKeyAccount
-import com.wavesplatform.transaction.assets.{IssueTransactionV1, SponsorFeeTransaction}
 
 class SponsorFeeTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
+  val One = 100000000L
+  val NgAndSponsorshipSettings = TestFunctionalitySettings.Enabled.copy(preActivatedFeatures =
+                                                                          Map(NG.id -> 0, FeeSponsorship.id -> 0, SmartAccounts.id -> 0),
+                                                                        blocksForFeatureActivation = 1,
+                                                                        featureCheckBlocksPeriod = 1)
 
   property("SponsorFee serialization roundtrip") {
     forAll(sponsorFeeGen) { transaction: SponsorFeeTransaction =>
@@ -27,12 +36,12 @@ class SponsorFeeTransactionSpecification extends PropSpec with PropertyChecks wi
   }
 
   property("JSON format validation") {
-    val js = Json.parse("""{
+    val js = Json.parse(s"""{
  "type": 14,
  "id": "Gobt7AiyQAfduRkW8Mk3naWbzH67Zsv9rdmgRNmon1Mb",
  "sender": "3N5GRqzDBhjVXnCn44baHcz2GoZy5qLxtTh",
  "senderPublicKey": "FM5ojNqW7e9cZ9zhPYGkpSP1Pcd8Z3e3MNKYVS5pGJ8Z",
- "fee": 100000000,
+ "fee": $One,
  "timestamp": 1520945679531,
  "proofs": [
  "3QrF81WkwGhbNvKcwpAVyBPL1MLuAG5qmR6fmtK9PTYQoFKGsFg1Rtd2kbMBuX2ZfiFX58nR1XwC19LUXZUmkXE7"
@@ -49,7 +58,7 @@ class SponsorFeeTransactionSpecification extends PropSpec with PropertyChecks wi
         PublicKeyAccount.fromBase58String("FM5ojNqW7e9cZ9zhPYGkpSP1Pcd8Z3e3MNKYVS5pGJ8Z").explicitGet(),
         ByteStr.decodeBase58("9ekQuYn92natMnMq8KqeGK3Nn7cpKd3BvPEGgD6fFyyz").get,
         Some(100000),
-        100000000L,
+        One,
         1520945679531L,
         Proofs(Seq(ByteStr.decodeBase58("3QrF81WkwGhbNvKcwpAVyBPL1MLuAG5qmR6fmtK9PTYQoFKGsFg1Rtd2kbMBuX2ZfiFX58nR1XwC19LUXZUmkXE7").get))
       )
@@ -95,4 +104,76 @@ class SponsorFeeTransactionSpecification extends PropSpec with PropertyChecks wi
     }
   }
 
+  property("miner receives one satoshi less than sponsor pays") {
+    val setup = for {
+      (acc, name, desc, quantity, decimals, reissuable, fee, ts) <- issueParamGen
+      genesis = GenesisTransaction.create(acc, ENOUGH_AMT, ts).explicitGet()
+      issue   = IssueTransactionV1.selfSigned(acc, name, desc, quantity, decimals, reissuable, fee, ts).explicitGet()
+      minFee <- Gen.choose(1, issue.quantity)
+      sponsor  = SponsorFeeTransaction.selfSigned(version = 1, acc, issue.id(), Some(minFee), One, ts).explicitGet()
+      transfer = TransferTransactionV1.selfSigned(None, acc, acc, 1, ts, feeAssetId = Some(issue.id()), minFee, Array()).explicitGet()
+    } yield (acc, genesis, issue, sponsor, transfer)
+
+    forAll(setup) {
+      case (acc, genesis, issue, sponsor, transfer) =>
+        val b0 = block(acc, Seq(genesis, issue, sponsor))
+        val b1 = block(acc, Seq(transfer))
+        val b2 = block(acc, Seq.empty)
+
+        assertNgDiffState(Seq(b0, b1), b2, NgAndSponsorshipSettings) {
+          case (diff, state) =>
+            state.balance(acc, None) - ENOUGH_AMT shouldBe 0
+        }
+    }
+  }
+
+  property("miner receives one satoshi more than sponsor pays") {
+    val setup = for {
+      (acc, name, desc, quantity, decimals, reissuable, fee, ts) <- issueParamGen
+      genesis = GenesisTransaction.create(acc, ENOUGH_AMT, ts).explicitGet()
+      issue   = IssueTransactionV1.selfSigned(acc, name, desc, quantity, decimals, reissuable, fee, ts).explicitGet()
+      minFee <- Gen.choose(1000000, issue.quantity)
+      sponsor   = SponsorFeeTransaction.selfSigned(version = 1, acc, issue.id(), Some(minFee), One, ts).explicitGet()
+      transfer1 = TransferTransactionV1.selfSigned(None, acc, acc, 1, ts, feeAssetId = Some(issue.id()), minFee + 7, Array()).explicitGet()
+      transfer2 = TransferTransactionV1.selfSigned(None, acc, acc, 1, ts, feeAssetId = Some(issue.id()), minFee + 9, Array()).explicitGet()
+    } yield (acc, genesis, issue, sponsor, transfer1, transfer2)
+
+    forAll(setup) {
+      case (acc, genesis, issue, sponsor, transfer1, transfer2) =>
+        val b0 = block(acc, Seq(genesis, issue, sponsor))
+        val b1 = block(acc, Seq(transfer1, transfer2))
+        val b2 = block(acc, Seq.empty)
+
+        assertNgDiffState(Seq(b0, b1), b2, NgAndSponsorshipSettings) {
+          case (diff, state) =>
+            state.balance(acc, None) - ENOUGH_AMT shouldBe 0
+        }
+    }
+  }
+
+  property("sponsorship changes in the middle of a block") {
+    val setup = for {
+      (acc, name, desc, quantity, decimals, reissuable, fee, ts) <- issueParamGen
+      genesis = GenesisTransaction.create(acc, ENOUGH_AMT, ts).explicitGet()
+      issue   = IssueTransactionV1.selfSigned(acc, name, desc, quantity, decimals, reissuable, fee, ts).explicitGet()
+      minFee <- Gen.choose(1, issue.quantity / 11)
+
+      sponsor1  = SponsorFeeTransaction.selfSigned(version = 1, acc, issue.id(), Some(minFee), One, ts).explicitGet()
+      transfer1 = TransferTransactionV1.selfSigned(None, acc, acc, 1, ts, Some(issue.id()), feeAmount = minFee, Array()).explicitGet()
+      sponsor2  = SponsorFeeTransaction.selfSigned(version = 1, acc, issue.id(), Some(minFee * 10), One, ts).explicitGet()
+      transfer2 = TransferTransactionV1.selfSigned(None, acc, acc, 1, ts, Some(issue.id()), feeAmount = minFee * 10, Array()).explicitGet()
+    } yield (acc, genesis, issue, sponsor1, transfer1, sponsor2, transfer2)
+
+    forAll(setup) {
+      case (acc, genesis, issue, sponsor1, transfer1, sponsor2, transfer2) =>
+        val b0 = block(acc, Seq(genesis, issue, sponsor1))
+        val b1 = block(acc, Seq(transfer1, sponsor2, transfer2))
+        val b2 = block(acc, Seq.empty)
+
+        assertNgDiffState(Seq(b0, b1), b2, NgAndSponsorshipSettings) {
+          case (diff, state) =>
+            state.balance(acc, None) - ENOUGH_AMT shouldBe 0
+        }
+    }
+  }
 }


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-1077

We cannot calculate block fee from the block alone any more -- we need state for sponsored fees. Once we have the block fee, we need to pass 60% of it into the next block. One way to do it is via state.

Changes:
- Added `carryFee` parameter to both Blockchain and NgState
- In case of sponsorship, `carryFee` is written to the DB as one Long number. If sponsorship is not activated, this parameter is not used.