### PR TITLE
Use the official debian repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ linuxScriptReplacements += "detect-loader" ->
 inConfig(Debian)(
   Seq(
     linuxStartScriptTemplate := (packageSource.value / "systemd.service").toURI.toURL,
-    debianPackageDependencies += "java8-runtime-headless",
+    debianPackageDependencies += "default-jre-headless",
     serviceAutostart := false,
     maintainerScripts := maintainerScriptsFromDirectory(packageSource.value / "debian", Seq("preinst", "postinst", "postrm", "prerm"))
   ))


### PR DESCRIPTION
Use the official debian repository because PPA is not safe to use in critical software

Packages providing java8-runtime-headless

default-jre-headless
Standard Java or Java compatible Runtime (headless)
openjdk-8-jre-headless
OpenJDK Java runtime, using Hotspot JIT (headless)
https://packages.debian.org/stretch/java8-runtime-headless

https://github.com/wavesplatform/Waves/issues/1472