### PR TITLE
NODE-1211 fix rounding for Double values in "waves" extension method

### DIFF
--- a/it/src/main/scala/com/wavesplatform/it/util/package.scala
+++ b/it/src/main/scala/com/wavesplatform/it/util/package.scala
@@ -25,6 +25,6 @@ package object util {
       f.flatMap(v => if (cond(v)) Future.successful(v) else schedule(retryUntil(f, cond, retryInterval), retryInterval))
   }
   implicit class DoubleExt(val d: Double) extends AnyVal {
-    def waves: Long = (d * Constants.UnitsInWave).toLong
+    def waves: Long = (BigDecimal(d) * Constants.UnitsInWave).toLong
   }
 }


### PR DESCRIPTION
When I use `4.999.waves` I expect value `499900000L` but it returns `4.9989999999999994E8`.
To fix the problem `4.999` value must be converted to BigDecimal.