### PR TITLE
NODE-1240 Return readable message error for SetScript Tx with empty script

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/SignAndBroadcastApiSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/SignAndBroadcastApiSuite.scala
@@ -205,7 +205,7 @@ class SignAndBroadcastApiSuite extends BaseTransactionSuite {
         "type"    -> 13,
         "version" -> 1,
         "sender"  -> firstAddress,
-        "script"  -> None
+        "script"  -> ""
       ),
       usesProofs = true
     )

--- a/src/main/scala/com/wavesplatform/api/http/assets/SignedSetAssetScriptRequest.scala
+++ b/src/main/scala/com/wavesplatform/api/http/assets/SignedSetAssetScriptRequest.scala
@@ -34,8 +34,8 @@ case class SignedSetAssetScriptRequest(@ApiModelProperty(required = true)
       _sender  <- PublicKeyAccount.fromBase58String(senderPublicKey)
       _assetId <- parseBase58(assetId, "invalid.assetId", AssetIdStringLength)
       _script <- script match {
-        case None    => Right(None)
-        case Some(s) => Script.fromBase64String(s).map(Some(_))
+        case None | Some("") => Right(None)
+        case Some(s)         => Script.fromBase64String(s).map(Some(_))
       }
       _proofBytes <- proofs.traverse(s => parseBase58(s, "invalid proof", Proofs.MaxProofStringSize))
       _proofs     <- Proofs.create(_proofBytes)

--- a/src/main/scala/com/wavesplatform/api/http/assets/SignedSetScriptRequest.scala
+++ b/src/main/scala/com/wavesplatform/api/http/assets/SignedSetScriptRequest.scala
@@ -31,8 +31,8 @@ case class SignedSetScriptRequest(@ApiModelProperty(required = true)
     for {
       _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
       _script <- script match {
-        case None    => Right(None)
-        case Some(s) => Script.fromBase64String(s).map(Some(_))
+        case None | Some("") => Right(None)
+        case Some(s)         => Script.fromBase64String(s).map(Some(_))
       }
       _proofBytes <- proofs.traverse(s => parseBase58(s, "invalid proof", Proofs.MaxProofStringSize))
       _proofs     <- Proofs.create(_proofBytes)

--- a/src/main/scala/com/wavesplatform/transaction/TransactionFactory.scala
+++ b/src/main/scala/com/wavesplatform/transaction/TransactionFactory.scala
@@ -147,8 +147,8 @@ object TransactionFactory {
       sender <- wallet.findPrivateKey(request.sender)
       signer <- if (request.sender == signerAddress) Right(sender) else wallet.findPrivateKey(signerAddress)
       script <- request.script match {
-        case None    => Right(None)
-        case Some(s) => Script.fromBase64String(s).map(Some(_))
+        case None | Some("") => Right(None)
+        case Some(s)         => Script.fromBase64String(s).map(Some(_))
       }
       tx <- SetScriptTransaction.signed(
         request.version,
@@ -163,8 +163,8 @@ object TransactionFactory {
   def setScript(request: SetScriptRequest, sender: PublicKeyAccount): Either[ValidationError, SetScriptTransaction] =
     for {
       script <- request.script match {
-        case None    => Right(None)
-        case Some(s) => Script.fromBase64String(s).map(Some(_))
+        case None | Some("") => Right(None)
+        case Some(s)         => Script.fromBase64String(s).map(Some(_))
       }
       tx <- SetScriptTransaction.create(
         request.version,

--- a/src/main/scala/com/wavesplatform/transaction/TransactionFactory.scala
+++ b/src/main/scala/com/wavesplatform/transaction/TransactionFactory.scala
@@ -184,8 +184,8 @@ object TransactionFactory {
       sender <- wallet.findPrivateKey(request.sender)
       signer <- if (request.sender == signerAddress) Right(sender) else wallet.findPrivateKey(signerAddress)
       script <- request.script match {
-        case None    => Right(None)
-        case Some(s) => Script.fromBase64String(s).map(Some(_))
+        case None | Some("") => Right(None)
+        case Some(s)         => Script.fromBase64String(s).map(Some(_))
       }
       tx <- SetAssetScriptTransaction.signed(
         request.version,
@@ -202,8 +202,8 @@ object TransactionFactory {
   def setAssetScript(request: SetAssetScriptRequest, sender: PublicKeyAccount): Either[ValidationError, SetAssetScriptTransaction] =
     for {
       script <- request.script match {
-        case None    => Right(None)
-        case Some(s) => Script.fromBase64String(s).map(Some(_))
+        case None | Some("") => Right(None)
+        case Some(s)         => Script.fromBase64String(s).map(Some(_))
       }
       tx <- SetAssetScriptTransaction.create(
         request.version,


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-1240
The fix is to treat `"script": ""` as `"script": null` in both SetScript and SetAssetScript transactions. I'm adding explicit checks for `""` in a few places