### PR TITLE
NODE-1252-enable-assetfee-on-smartaccount

### DIFF
--- a/src/main/scala/com/wavesplatform/state/diffs/CommonValidation.scala
+++ b/src/main/scala/com/wavesplatform/state/diffs/CommonValidation.scala
@@ -251,9 +251,7 @@ object CommonValidation {
       case _                               => false
     }
 
-    if (tx.assetFee._1.nonEmpty && !blockchain.isFeatureActivated(BlockchainFeatures.SmartAssets, height) && hasSmartAccountScript) {
-      Left(GenericError("Transactions from scripted accounts require Waves as fee"))
-    } else if (height >= Sponsorship.sponsoredFeesSwitchHeight(blockchain, fs)) {
+    if (height >= Sponsorship.sponsoredFeesSwitchHeight(blockchain, fs)) {
       for {
         minAFee <- getMinFee(blockchain, fs, height, tx)
         minWaves   = minAFee._3

--- a/src/main/scala/com/wavesplatform/state/diffs/CommonValidation.scala
+++ b/src/main/scala/com/wavesplatform/state/diffs/CommonValidation.scala
@@ -246,11 +246,6 @@ object CommonValidation {
   }
 
   def checkFee(blockchain: Blockchain, fs: FunctionalitySettings, height: Int, tx: Transaction): Either[ValidationError, Unit] = {
-    def hasSmartAccountScript: Boolean = tx match {
-      case tx: Transaction with Authorized => blockchain.hasScript(tx.sender)
-      case _                               => false
-    }
-
     if (height >= Sponsorship.sponsoredFeesSwitchHeight(blockchain, fs)) {
       for {
         minAFee <- getMinFee(blockchain, fs, height, tx)

--- a/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTest.scala
@@ -83,10 +83,6 @@ class CommonValidationTest extends PropSpec with PropertyChecks with Matchers wi
     smartAccountCheckFeeTest(feeInAssets = false, feeAmount = 400000)(_ shouldBe 'right)
   }
 
-  property("checkFee for smart accounts fails if the fee is in tokens") {
-    smartAccountCheckFeeTest(feeInAssets = true, feeAmount = 1)(_ should produce("Transactions from scripted accounts require Waves as fee"))
-  }
-
   private def sponsorAndSetScriptGen(sponsorship: Boolean, smartToken: Boolean, smartAccount: Boolean, feeInAssets: Boolean, feeAmount: Long) =
     for {
       richAcc      <- accountGen


### PR DESCRIPTION
Fix using sponsored asset fee on smart account.
Checking asset fee on smart account no need more (after sponsorship activated).