### PR TITLE
DEX-166 Redundancy

### DIFF
--- a/dexgenerator/src/main/scala/com/wavesplatform/dexgen/utils/ApiRequests.scala
+++ b/dexgenerator/src/main/scala/com/wavesplatform/dexgen/utils/ApiRequests.scala
@@ -202,9 +202,9 @@ class ApiRequests(client: AsyncHttpClient) extends ScorexLogging {
     def unconfirmedTxInfo(txId: String)(implicit tag: String): Future[Transaction] = get(s"/transactions/unconfirmed/info/$txId").as[Transaction]
 
     def findTransactionInfo(txId: String)(implicit tag: String): Future[Option[Transaction]] = transactionInfo(txId).transform {
-      case Success(tx)                                       => Success(Some(tx))
-      case Failure(UnexpectedStatusCodeException(_, 404, _)) => Success(None)
-      case Failure(ex)                                       => Failure(ex)
+      case Success(tx)                                          => Success(Some(tx))
+      case Failure(UnexpectedStatusCodeException(_, _, 404, _)) => Success(None)
+      case Failure(ex)                                          => Failure(ex)
     }
 
     def ensureTxDoesntExist(txId: String)(implicit tag: String): Future[Unit] =

--- a/it/src/main/resources/template.conf
+++ b/it/src/main/resources/template.conf
@@ -71,6 +71,19 @@ waves {
     interval-after-last-block-then-generation-is-allowed = 1h
     micro-block-interval = 5s
     min-micro-block-age = 0s
+
+    events-queue {
+      type = "local" # kafka
+
+      local {
+        polling-interval = 100ms
+      }
+
+      kafka {
+        topic = "dex-events"
+        consumer-buffer-size = 100
+      }
+    }
   }
   rest-api {
     enable = yes

--- a/it/src/main/scala/com/wavesplatform/it/MatcherNode.scala
+++ b/it/src/main/scala/com/wavesplatform/it/MatcherNode.scala
@@ -3,6 +3,7 @@ package com.wavesplatform.it
 import com.wavesplatform.account.PrivateKeyAccount
 import com.wavesplatform.it.api.SyncHttpApi._
 import com.wavesplatform.it.util._
+import com.wavesplatform.state.EitherExt2
 import com.wavesplatform.transaction.smart.SetScriptTransaction
 import com.wavesplatform.transaction.smart.script.ScriptCompiler
 import com.wavesplatform.utils.ScorexLogging
@@ -42,8 +43,7 @@ trait MatcherNode extends BeforeAndAfterAll with Nodes with ScorexLogging {
       val pk     = PrivateKeyAccount.fromSeed(nodes(i).seed(addresses(i))).right.get
       val setScriptTransaction = SetScriptTransaction
         .selfSigned(SetScriptTransaction.supportedVersions.head, pk, Some(script), 0.01.waves, System.currentTimeMillis())
-        .right
-        .get
+        .explicitGet()
 
       matcherNode
         .signedBroadcast(setScriptTransaction.json(), waitForTx = true)
@@ -57,8 +57,7 @@ trait MatcherNode extends BeforeAndAfterAll with Nodes with ScorexLogging {
     }
     val setScriptTransaction = SetScriptTransaction
       .selfSigned(SetScriptTransaction.supportedVersions.head, acc, script, 0.014.waves, System.currentTimeMillis())
-      .right
-      .get
+      .explicitGet()
 
     matcherNode
       .signedBroadcast(setScriptTransaction.json(), waitForTx = true)

--- a/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
@@ -25,6 +25,7 @@ import org.scalactic.source.Position
 import org.scalatest.{Assertions, Matchers}
 import play.api.libs.json.Json.{stringify, toJson}
 import play.api.libs.json._
+
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -55,7 +56,7 @@ object AsyncHttpApi extends Assertions {
         .build()
     }
 
-    def postJsObjectWithApiKey(path: String, body: JsObject): Future[Response] = retrying {
+    def postJsObjectWithApiKey(path: String, body: JsValue): Future[Response] = retrying {
       _post(s"${n.nodeApiEndpoint}$path")
         .withApiKey(n.apiKey)
         .setHeader("Content-type", "application/json")
@@ -152,17 +153,17 @@ object AsyncHttpApi extends Assertions {
       get(s"/addresses/scriptInfo/$address").as[AddressApiRoute.AddressScriptInfo]
 
     def findTransactionInfo(txId: String): Future[Option[TransactionInfo]] = transactionInfo(txId).transform {
-      case Success(tx)                                       => Success(Some(tx))
-      case Failure(UnexpectedStatusCodeException(_, 404, _)) => Success(None)
-      case Failure(ex)                                       => Failure(ex)
+      case Success(tx)                                          => Success(Some(tx))
+      case Failure(UnexpectedStatusCodeException(_, _, 404, _)) => Success(None)
+      case Failure(ex)                                          => Failure(ex)
     }
 
     def waitForTransaction(txId: String, retryInterval: FiniteDuration = 1.second): Future[TransactionInfo] = {
       val condition = waitFor[Option[TransactionInfo]](s"transaction $txId")(
         _.transactionInfo(txId).transform {
-          case Success(tx)                                       => Success(Some(tx))
-          case Failure(UnexpectedStatusCodeException(_, 404, _)) => Success(None)
-          case Failure(ex)                                       => Failure(ex)
+          case Success(tx)                                          => Success(Some(tx))
+          case Failure(UnexpectedStatusCodeException(_, _, 404, _)) => Success(None)
+          case Failure(ex)                                          => Failure(ex)
         },
         tOpt => tOpt.exists(_.id == txId),
         retryInterval
@@ -334,13 +335,21 @@ object AsyncHttpApi extends Assertions {
 
     def broadcastRequest[A: Writes](req: A): Future[Transaction] = postJson("/transactions/broadcast", req).as[Transaction]
 
-    def sign(jsobj: JsObject): Future[JsObject] =
-      postJsObjectWithApiKey("/transactions/sign", jsobj).as[JsObject]
+    def sign(json: JsValue): Future[JsObject] =
+      postJsObjectWithApiKey("/transactions/sign", json).as[JsObject]
 
-    def signedBroadcast(jsobj: JsObject): Future[Transaction] =
-      post("/transactions/broadcast", stringify(jsobj)).as[Transaction]
+    def expectSignedBroadcastRejected(json: JsValue): Future[Int] = {
+      post("/transactions/broadcast", stringify(json)).transform {
+        case Failure(UnexpectedStatusCodeException(_, _, 400, body)) => Success((Json.parse(body) \ "error").as[Int])
+        case Failure(cause)                                          => Failure(cause)
+        case Success(resp)                                           => Failure(UnexpectedStatusCodeException("POST", "/transactions/broadcast", resp.getStatusCode, resp.getResponseBody))
+      }
+    }
 
-    def signAndBroadcast(jsobj: JsObject): Future[Transaction] = sign(jsobj).flatMap(signedBroadcast)
+    def signedBroadcast(json: JsValue): Future[Transaction] =
+      post("/transactions/broadcast", stringify(json)).as[Transaction]
+
+    def signAndBroadcast(json: JsValue): Future[Transaction] = sign(json).flatMap(signedBroadcast)
 
     def signedIssue(issue: SignedIssueV1Request): Future[Transaction] =
       postJson("/assets/broadcast/issue", issue).as[Transaction]
@@ -486,11 +495,11 @@ object AsyncHttpApi extends Assertions {
             new AsyncCompletionHandler[Response] {
               override def onCompleted(response: Response): Response = {
                 if (response.getStatusCode == statusCode) {
-                  n.log.debug(s"Request: ${r.getUrl}\nResponse: ${response.getResponseBody}")
+                  n.log.debug(s"Request: ${r.getMethod} ${r.getUrl}\nResponse: ${response.getResponseBody}")
                   response
                 } else {
-                  n.log.debug(s"Request: ${r.getUrl}\nUnexpected status code(${response.getStatusCode}): ${response.getResponseBody}")
-                  throw UnexpectedStatusCodeException(r.getUrl, response.getStatusCode, response.getResponseBody)
+                  n.log.debug(s"Request: ${r.getMethod} ${r.getUrl}\nUnexpected status code(${response.getStatusCode}): ${response.getResponseBody}")
+                  throw UnexpectedStatusCodeException(r.getMethod, r.getUrl, response.getStatusCode, response.getResponseBody)
                 }
               }
             }
@@ -498,7 +507,7 @@ object AsyncHttpApi extends Assertions {
           .toCompletableFuture
           .toScala
           .recoverWith {
-            case e: UnexpectedStatusCodeException if waitForStatus =>
+            case e: UnexpectedStatusCodeException if e.statusCode == 503 || waitForStatus =>
               n.log.debug(s"Failed to execute request '$r' with error: ${e.getMessage}")
               timer.schedule(executeRequest, interval)
             case e @ (_: IOException | _: TimeoutException) =>
@@ -560,8 +569,8 @@ object AsyncHttpApi extends Assertions {
       n.assetBalance(acc, assetIdString).map(_.balance shouldBe balance)
     }
 
-    def calculateFee(jsobj: JsObject): Future[FeeInfo] =
-      postJsObjectWithApiKey("/transactions/calculateFee", jsobj).as[FeeInfo]
+    def calculateFee(json: JsValue): Future[FeeInfo] =
+      postJsObjectWithApiKey("/transactions/calculateFee", json).as[FeeInfo]
 
   }
 
@@ -575,14 +584,14 @@ object AsyncHttpApi extends Assertions {
         finalHeights <- traverse(nodes)(_.waitForTransaction(transactionId).map(_.height))
       } yield all(finalHeights) should be >= (finalHeights.head)
 
-    def waitForTransaction(transactionId: String)(implicit p: Position): Future[Unit] =
-      traverse(nodes)(_.waitForTransaction(transactionId)).map(_ => ())
+    def waitForTransaction(transactionId: String)(implicit p: Position): Future[TransactionInfo] =
+      traverse(nodes)(_.waitForTransaction(transactionId)).map(_.head)
 
     def waitForHeightArise(): Future[Int] =
       for {
         height <- height.map(_.max)
         _      <- traverse(nodes)(_.waitForHeight(height + 1))
-      } yield (height + 1)
+      } yield height + 1
 
     def waitForSameBlockHeadesAt(height: Int, retryInterval: FiniteDuration = 5.seconds): Future[Boolean] = {
 

--- a/it/src/main/scala/com/wavesplatform/it/api/SyncHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/SyncHttpApi.scala
@@ -34,13 +34,13 @@ object SyncHttpApi extends Assertions {
   }
 
   def assertBadRequest[R](f: => R, expectedStatusCode: Int = 400): Assertion = Try(f) match {
-    case Failure(UnexpectedStatusCodeException(_, statusCode, _)) => Assertions.assert(statusCode == expectedStatusCode)
-    case Failure(e)                                               => Assertions.fail(e)
-    case _                                                        => Assertions.fail("Expecting bad request")
+    case Failure(UnexpectedStatusCodeException(_, _, statusCode, _)) => Assertions.assert(statusCode == expectedStatusCode)
+    case Failure(e)                                                  => Assertions.fail(e)
+    case _                                                           => Assertions.fail("Expecting bad request")
   }
 
   def assertBadRequestAndResponse[R](f: => R, errorRegex: String): Assertion = Try(f) match {
-    case Failure(UnexpectedStatusCodeException(_, statusCode, responseBody)) =>
+    case Failure(UnexpectedStatusCodeException(_, _, statusCode, responseBody)) =>
       Assertions.assert(statusCode == BadRequest.intValue && responseBody.replace("\n", "").matches(s".*$errorRegex.*"),
                         s"\nexpected '$errorRegex'\nactual '$responseBody'")
     case Failure(e) => Assertions.fail(e)
@@ -48,14 +48,14 @@ object SyncHttpApi extends Assertions {
   }
 
   def assertBadRequestAndMessage[R](f: => R, errorMessage: String, expectedStatusCode: Int = BadRequest.intValue): Assertion = Try(f) match {
-    case Failure(e @ UnexpectedStatusCodeException(_, statusCode, responseBody)) =>
+    case Failure(e @ UnexpectedStatusCodeException(_, _, statusCode, responseBody)) =>
       Assertions.assert(statusCode == expectedStatusCode && parse(responseBody).as[ErrorMessage].message.contains(errorMessage))
     case Failure(e) => Assertions.fail(e)
     case Success(s) => Assertions.fail(s"Expecting bad request but handle $s")
   }
 
   def assertNotFoundAndMessage[R](f: => R, errorMessage: String): Assertion = Try(f) match {
-    case Failure(UnexpectedStatusCodeException(_, statusCode, responseBody)) =>
+    case Failure(UnexpectedStatusCodeException(_, _, statusCode, responseBody)) =>
       Assertions.assert(statusCode == NotFound.intValue && parse(responseBody).as[NotFoundErrorMessage].details.contains(errorMessage))
     case Failure(e) => Assertions.fail(e)
     case _          => Assertions.fail(s"Expecting not found error")
@@ -176,8 +176,8 @@ object SyncHttpApi extends Assertions {
     def cancelSponsorship(sourceAddress: String, assetId: String, fee: Long): Transaction =
       sync(async(n).cancelSponsorship(sourceAddress, assetId, fee))
 
-    def sign(jsObject: JsObject): JsObject =
-      sync(async(n).sign(jsObject))
+    def sign(json: JsValue): JsObject =
+      sync(async(n).sign(json))
 
     def createAlias(targetAddress: String, alias: String, fee: Long): Transaction =
       sync(async(n).createAlias(targetAddress, alias, fee))
@@ -225,7 +225,9 @@ object SyncHttpApi extends Assertions {
     def cancelLease(sourceAddress: String, leaseId: String, fee: Long, version: Byte = 1): Transaction =
       sync(async(n).cancelLease(sourceAddress, leaseId, fee))
 
-    def signedBroadcast(tx: JsObject, waitForTx: Boolean = false): Transaction = {
+    def expectSignedBroadcastRejected(json: JsValue): Int = sync(async(n).expectSignedBroadcastRejected(json))
+
+    def signedBroadcast(tx: JsValue, waitForTx: Boolean = false): Transaction = {
       maybeWaitForTransaction(sync(async(n).signedBroadcast(tx)), waitForTx)
     }
 
@@ -247,7 +249,7 @@ object SyncHttpApi extends Assertions {
     def waitForTransaction(txId: String, retryInterval: FiniteDuration = 1.second): TransactionInfo =
       sync(async(n).waitForTransaction(txId))
 
-    def signAndBroadcast(tx: JsObject, waitForTx: Boolean = false): Transaction = {
+    def signAndBroadcast(tx: JsValue, waitForTx: Boolean = false): Transaction = {
       maybeWaitForTransaction(sync(async(n).signAndBroadcast(tx)), waitForTx)
     }
 
@@ -311,7 +313,7 @@ object SyncHttpApi extends Assertions {
     def waitForHeightAriseAndTxPresent(transactionId: String)(implicit pos: Position): Unit =
       sync(async(nodes).waitForHeightAriseAndTxPresent(transactionId), TxInBlockchainAwaitTime)
 
-    def waitForTransaction(transactionId: String)(implicit pos: Position): Unit =
+    def waitForTransaction(transactionId: String)(implicit pos: Position): TransactionInfo =
       sync(async(nodes).waitForTransaction(transactionId), TxInBlockchainAwaitTime)
 
     def waitForHeightArise(): Int =

--- a/it/src/main/scala/com/wavesplatform/it/api/SyncMatcherHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/SyncMatcherHttpApi.scala
@@ -27,7 +27,7 @@ object SyncMatcherHttpApi extends Assertions {
   }
 
   def assertNotFoundAndMessage[R](f: => R, errorMessage: String): Assertion = Try(f) match {
-    case Failure(UnexpectedStatusCodeException(_, statusCode, responseBody)) =>
+    case Failure(UnexpectedStatusCodeException(_, _, statusCode, responseBody)) =>
       Assertions.assert(statusCode == StatusCodes.NotFound.intValue && parse(responseBody).as[NotFoundErrorMessage].message.contains(errorMessage))
     case Failure(e) => Assertions.fail(e)
     case _          => Assertions.fail(s"Expecting not found error")

--- a/it/src/main/scala/com/wavesplatform/it/api/model.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/model.scala
@@ -8,8 +8,8 @@ import scala.util.{Failure, Success}
 
 // USCE no longer contains references to non-serializable Request/Response objects
 // to work around https://github.com/scalatest/scalatest/issues/556
-case class UnexpectedStatusCodeException(requestUrl: String, statusCode: Int, responseBody: String)
-    extends Exception(s"Request: $requestUrl; Unexpected status code ($statusCode): $responseBody")
+case class UnexpectedStatusCodeException(requestMethod: String, requestUrl: String, statusCode: Int, responseBody: String)
+    extends Exception(s"Request: $requestMethod $requestUrl; Unexpected status code ($statusCode): $responseBody")
 
 case class Status(blockchainHeight: Int, stateHeight: Int, updatedTimestamp: Long, updatedDate: String)
 object Status {
@@ -99,6 +99,7 @@ object TransactionInfo {
 }
 
 case class OrderInfo(id: String,
+                     version: Option[Byte],
                      sender: String,
                      senderPublicKey: String,
                      matcherPublicKey: String,
@@ -109,7 +110,8 @@ case class OrderInfo(id: String,
                      timestamp: Long,
                      expiration: Long,
                      matcherFee: Long,
-                     signature: String)
+                     signature: String,
+                     proofs: Option[Seq[String]])
 object OrderInfo {
   implicit val transactionFormat: Format[OrderInfo] = Json.format
 }
@@ -120,12 +122,14 @@ object AssetPairResponse {
 }
 
 case class ExchangeTransaction(`type`: Int,
+                               version: Option[Byte],
                                id: String,
                                sender: String,
                                senderPublicKey: String,
                                fee: Long,
                                timestamp: Long,
                                signature: Option[String],
+                               proofs: Option[Seq[String]],
                                order1: OrderInfo,
                                order2: OrderInfo,
                                amount: Long,

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherMassOrdersTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherMassOrdersTestSuite.scala
@@ -67,6 +67,7 @@ class MatcherMassOrdersTestSuite extends MatcherSuiteBase {
       .message
       .id
 
+    matcherNode.cancelOrder(aliceAcc, aliceSecondWavesPair, aliceOrderToCancelId) // TODO: remove this line in DEX-160
     matcherNode.waitOrderStatus(aliceSecondWavesPair, aliceOrderToCancelId, "Cancelled", 2.minutes)
 
     //Bob orders should partially fill one Alice order and fill another

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/OrderBookTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/OrderBookTestSuite.scala
@@ -15,14 +15,14 @@ class OrderBookTestSuite extends MatcherSuiteBase {
   override protected def nodeConfigs: Seq[Config] = Configs
 
   Seq(IssueUsdTx, IssueWctTx).map(createSignedIssueRequest).map(matcherNode.signedIssue).foreach { tx =>
-    matcherNode.waitForTransaction(tx.id)
+    nodes.waitForTransaction(tx.id)
   }
 
   Seq(
     aliceNode.transfer(IssueUsdTx.sender.toAddress.stringRepr, aliceAcc.address, defaultAssetQuantity, 100000, Some(UsdId.toString), None, 2),
     bobNode.transfer(IssueWctTx.sender.toAddress.stringRepr, bobAcc.address, defaultAssetQuantity, 100000, Some(WctId.toString), None, 2)
   ).foreach { tx =>
-    matcherNode.waitForTransaction(tx.id)
+    nodes.waitForTransaction(tx.id)
   }
 
   case class ReservedBalances(wct: Long, usd: Long, waves: Long)

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/config/MatcherDefaultConfig.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/config/MatcherDefaultConfig.scala
@@ -34,7 +34,9 @@ object MatcherDefaultConfig {
                                      |  blacklisted-assets = ["$ForbiddenAssetId"]
                                      |  balance-watching.enable = yes
                                      |  rest-order-limit=$orderLimit
-                                     |}""".stripMargin)
+                                     |  # events-queue.type = "kafka"
+                                     |}
+                                     |# akka.kafka.consumer.kafka-clients.bootstrap.servers = "10.56.1.169:34302"""".stripMargin)
 
   val Configs: Seq[Config] = (Default.last +: Random.shuffle(Default.init).take(2))
     .zip(Seq(matcherConfig, minerDisabled, minerEnabled))

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/smartcontracts/OrderTypeTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/smartcontracts/OrderTypeTestSuite.scala
@@ -1,6 +1,7 @@
 package com.wavesplatform.it.sync.matcher.smartcontracts
 
 import com.typesafe.config.Config
+import com.wavesplatform.api.http.TransactionNotAllowedByScript
 import com.wavesplatform.it.api.SyncHttpApi._
 import com.wavesplatform.it.api.SyncMatcherHttpApi._
 import com.wavesplatform.it.matcher.MatcherSuiteBase
@@ -9,6 +10,7 @@ import com.wavesplatform.it.sync.matcher.config.MatcherPriceAssetConfig._
 import com.wavesplatform.it.util._
 import com.wavesplatform.state.ByteStr
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order, OrderType}
+import play.api.libs.json.Json
 
 import scala.concurrent.duration._
 
@@ -22,10 +24,10 @@ class OrderTypeTestSuite extends MatcherSuiteBase {
 
   {
     val issueTx = matcherNode.signedIssue(createSignedIssueRequest(IssueUsdTx))
-    nodes.waitForHeightAriseAndTxPresent(issueTx.id)
+    nodes.waitForTransaction(issueTx.id)
 
     val transferTx = aliceNode.transfer(aliceNode.address, aliceAcc.address, defaultAssetQuantity, 100000, Some(UsdId.toString), None, 2)
-    nodes.waitForHeightAriseAndTxPresent(transferTx.id)
+    nodes.waitForTransaction(transferTx.id)
   }
 
   private val predefAssetPair = wavesUsdPair
@@ -149,14 +151,16 @@ class OrderTypeTestSuite extends MatcherSuiteBase {
           .id
 
         matcherNode.waitOrderStatus(predefAssetPair, aliceOrd1, "Filled", 1.minute)
-        matcherNode.waitOrderStatus(aliceWavesPair, aliceOrd2, "Cancelled", 1.minute)
+        matcherNode.waitOrderStatus(aliceWavesPair, aliceOrd2, "Filled", 1.minute)
         matcherNode.waitOrderStatus(predefAssetPair, bobOrd1, "Filled", 1.minute)
-        matcherNode.waitOrderStatus(aliceWavesPair, bobOrd2, "Accepted", 1.minute)
+        matcherNode.waitOrderStatus(aliceWavesPair, bobOrd2, "Filled", 1.minute)
 
         val exchangeTx1 = matcherNode.transactionsByOrder(bobOrd1).headOption.getOrElse(fail("Expected an exchange transaction"))
-        nodes.waitForHeightAriseAndTxPresent(exchangeTx1.id)
+        nodes.waitForTransaction(exchangeTx1.id)
 
-        setContract(None, aliceAcc)
+        val txs = matcherNode.transactionsByOrder(bobOrd2)
+        txs.size shouldBe 1
+        matcherNode.expectSignedBroadcastRejected(Json.toJson(txs.head)) shouldBe TransactionNotAllowedByScript.ErrorCode
       }
     }
   }

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/DataTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/DataTransactionSuite.scala
@@ -134,7 +134,7 @@ class DataTransactionSuite extends BaseTransactionSuite {
 
   test("queries for nonexistent data") {
     def assertNotFound(url: String): Assertion = Try(sender.get(url)) match {
-      case Failure(UnexpectedStatusCodeException(_, statusCode, responseBody)) =>
+      case Failure(UnexpectedStatusCodeException(_, _, statusCode, responseBody)) =>
         statusCode shouldBe 404
         responseBody should include("no data for this key")
       case _ => Assertions.fail("Expected 404")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,10 @@ object Dependencies {
   lazy val matcher = Seq(
     akkaModule("persistence"),
     akkaModule("persistence-tck") % "test",
-    "org.ethereum"                % "leveldbjni-all" % "1.18.3"
+    "com.github.dnvriend"         %% "akka-persistence-inmemory" % "2.5.15.1" % "test",
+    "com.typesafe.akka"           %% "akka-stream-kafka" % "1.0-M1",
+    // "org.apache.kafka"            % "kafka-clients" % "2.1.0",
+    "org.ethereum" % "leveldbjni-all" % "1.18.3"
   )
 
   lazy val metrics = Seq(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -125,6 +125,7 @@ waves {
     # Password to protect wallet file
     # password = "some string as password"
 
+    # The base seed, not an account one!
     # By default, the node will attempt to generate a new seed. To use a specific seed, uncomment the following line and
     # specify your base58-encoded seed.
     # seed = "BASE58SEED"
@@ -221,7 +222,7 @@ waves {
     snapshots-directory = ${waves.matcher.matcher-directory}"/snapshots"
 
     # Snapshots creation interval (in events)
-    snapshots-interval = 1000
+    snapshots-interval = 1000000
 
     # Make snapshots after recovery at start
     make-snapshots-at-start = no
@@ -260,6 +261,25 @@ waves {
 
       # Cache for these depths. When ?depth=3 is requested, returned a cache for depth of 10
       depth-ranges = [10, 100]
+    }
+
+    # Queue for events (order was added, order was cancelled)
+    events-queue {
+      # Store events locally in LevelDB
+      type = "local" # Other possible values: kafka
+
+      local {
+        # Interval between reads from the disk
+        polling-interval = 20ms
+      }
+
+      kafka {
+        # Where events should be written and read from
+        topic = "dex-events"
+
+        # Buffer for polled events
+        consumer-buffer-size = 100
+      }
     }
   }
 
@@ -479,11 +499,11 @@ akka {
   }
 
   http.server {
-   max-connections = 128
-   parsing {
-    max-method-length = 64
-    max-content-length = 1m
-   }
+    max-connections = 128
+    parsing {
+      max-method-length = 64
+      max-content-length = 1m
+    }
   }
 
   io.tcp {
@@ -500,5 +520,103 @@ akka {
       }
     }
     snapshot-store.plugin = waves.matcher.snapshot-store
+  }
+
+  kafka {
+    consumer {
+      # Tuning property of scheduled polls.
+      # Controls the interval from one scheduled poll to the next.
+      poll-interval = 100ms
+
+      # Tuning property of the `KafkaConsumer.poll` parameter.
+      # Note that non-zero value means that the thread that
+      # is executing the stage will be blocked. See also the `wakup-timeout` setting below.
+      poll-timeout = 100ms
+
+      # The stage will await outstanding offset commit requests before
+      # shutting down, but if that takes longer than this timeout it will
+      # stop forcefully.
+      stop-timeout = 30s
+
+      # Duration to wait for `KafkaConsumer.close` to finish.
+      close-timeout = 20s
+
+      # If offset commit requests are not completed within this timeout
+      # the returned Future is completed `CommitTimeoutException`.
+      commit-timeout = 15s
+
+      # If commits take longer than this time a warning is logged
+      commit-time-warning = 1s
+
+      # If for any reason `KafkaConsumer.poll` blocks for longer than the configured
+      # poll-timeout then it is forcefully woken up with `KafkaConsumer.wakeup`.
+      # The KafkaConsumerActor will throw
+      # `org.apache.kafka.common.errors.WakeupException` which will be ignored
+      # until `max-wakeups` limit gets exceeded.
+      wakeup-timeout = 3s
+
+      # After exceeding maximum wakeups the consumer will stop and the stage will fail.
+      # Setting it to 0 will let it ignore the wakeups and try to get the polling done forever.
+      max-wakeups = 0
+
+      # If set to a finite duration, the consumer will re-send the last committed offsets periodically
+      # for all assigned partitions. See https://issues.apache.org/jira/browse/KAFKA-4682.
+      commit-refresh-interval = infinite
+
+      # If enabled, log stack traces before waking up the KafkaConsumer to give
+      # some indication why the KafkaConsumer is not honouring the `poll-timeout`
+      wakeup-debug = true
+
+      # Fully qualified config path which holds the dispatcher configuration
+      # to be used by the KafkaConsumerActor. Some blocking may occur.
+      use-dispatcher = "akka.kafka.default-dispatcher"
+
+      # Properties defined by org.apache.kafka.clients.consumer.ConsumerConfig
+      # can be defined in this configuration section.
+      kafka-clients {
+        bootstrap.servers = ""
+        group.id = "0"
+        auto.offset.reset = "earliest"
+        enable.auto.commit = false
+      }
+
+      # Time to wait for pending requests when a partition is closed
+      wait-close-partition = 500ms
+
+      # Limits the query to Kafka for a topic's position
+      position-timeout = 5s
+
+      # When using `AssignmentOffsetsForTimes` subscriptions: timeout for the
+      # call to Kafka's API
+      offset-for-times-timeout = 5s
+
+      # Timeout for akka.kafka.Metadata requests
+      # This value is used instead of Kafka's default from `default.api.timeout.ms`
+      # which is 1 minute.
+      metadata-request-timeout = 5s
+    }
+
+    producer {
+      # Tuning parameter of how many sends that can run in parallel.
+      parallelism = 100
+
+      # Duration to wait for `KafkaConsumer.close` to finish.
+      close-timeout = 60s
+
+      # Fully qualified config path which holds the dispatcher configuration
+      # to be used by the producer stages. Some blocking may occur.
+      # When this value is empty, the dispatcher configured for the stream
+      # will be used.
+      use-dispatcher = "akka.kafka.default-dispatcher"
+
+      # The time interval to commit a transaction when using the `Transactional.sink` or `Transactional.flow`
+      eos-commit-interval = 100ms
+
+      # Properties defined by org.apache.kafka.clients.producer.ProducerConfig
+      # can be defined in this configuration section.
+      kafka-clients {
+        bootstrap.servers = ${akka.kafka.consumer.kafka-clients.bootstrap.servers}
+      }
+    }
   }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -40,6 +40,12 @@
     <logger name="com.wavesplatform.network.PeerSynchronizer" level="DEBUG"/>
     <logger name="com.wavesplatform.transaction.smart" level="INFO"/>
 
+    <logger name="org.apache.kafka.clients.consumer.KafkaConsumer" level="INFO"/>
+    <logger name="org.apache.kafka.clients.producer.KafkaProducer" level="INFO"/>
+    <logger name="org.apache.kafka.common.metrics.Metrics" level="INFO"/>
+    <logger name="org.apache.kafka.clients.producer.internals.RecordAccumulator" level="INFO"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.Fetcher" level="INFO"/>
+
     <logger name="org.aspectj" level="INFO"/>
     <logger name="org.asynchttpclient" level="INFO"/>
 

--- a/src/main/scala/akka/persistence/PersistenceProtocol.scala
+++ b/src/main/scala/akka/persistence/PersistenceProtocol.scala
@@ -1,0 +1,6 @@
+package akka.persistence
+
+object PersistenceProtocol {
+  def mkSaveSnapshot[T](metadata: SnapshotMetadata, snapshot: T)                   = SnapshotProtocol.SaveSnapshot(metadata, snapshot)
+  def mkDeleteSnapshot(persistenceId: String, criteria: SnapshotSelectionCriteria) = SnapshotProtocol.DeleteSnapshots(persistenceId, criteria)
+}

--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -103,7 +103,7 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
       new UtxPoolImpl(time, blockchainUpdater, settings.blockchainSettings.functionalitySettings, settings.utxSettings)
 
     matcher = if (settings.matcherSettings.enable) {
-      Matcher(actorSystem, time, wallet, innerUtxStorage, allChannels, blockchainUpdater, settings)
+      Matcher(actorSystem, time, wallet, innerUtxStorage, allChannels, blockchainUpdater, settings, () => shutdownInProgress)
     } else None
 
     val utxStorage =

--- a/src/main/scala/com/wavesplatform/api/http/ApiError.scala
+++ b/src/main/scala/com/wavesplatform/api/http/ApiError.scala
@@ -261,11 +261,14 @@ case class ScriptExecutionError(tx: Transaction, error: String, scriptSrc: Strin
 }
 
 case class TransactionNotAllowedByScript(tx: Transaction, log: Log, scriptSrc: String, isTokenScript: Boolean) extends ApiError {
-
-  override val id: Int             = 307
+  override val id: Int             = TransactionNotAllowedByScript.ErrorCode
   override val code: StatusCode    = StatusCodes.BadRequest
   override val message: String     = s"Transaction is not allowed by ${if (isTokenScript) "token" else "account"}-script"
   override lazy val json: JsObject = ScriptErrorJson(id, tx, message, scriptSrc, log)
+}
+
+object TransactionNotAllowedByScript {
+  val ErrorCode = 307
 }
 
 object ScriptErrorJson {

--- a/src/main/scala/com/wavesplatform/api/http/ApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/api/http/ApiRoute.scala
@@ -23,11 +23,8 @@ trait ApiRoute extends Directives with CommonApiFunctions with ApiMarshallers {
     }
     .result()
 
-  def json[A: Reads](f: A => ToResponseMarshallable): Route = handleRejections(jsonRejectionHandler) {
-    entity(as[A]) { a =>
-      complete(f(a))
-    }
-  }
+  def _json[A: Reads](f: A => Route): Route                 = (handleRejections(jsonRejectionHandler) & entity(as[A])).apply(f)
+  def json[A: Reads](f: A => ToResponseMarshallable): Route = _json[A](a => complete(f(a)))
 
   val jsonExceptionHandler = ExceptionHandler {
     case JsResultException(err)    => complete(WrongJson(errors = err))

--- a/src/main/scala/com/wavesplatform/database/KeyHelpers.scala
+++ b/src/main/scala/com/wavesplatform/database/KeyHelpers.scala
@@ -2,7 +2,7 @@ package com.wavesplatform.database
 
 import java.nio.ByteBuffer
 
-import com.google.common.primitives.{Ints, Shorts}
+import com.google.common.primitives.{Ints, Longs, Shorts}
 import com.wavesplatform.state.ByteStr
 
 object KeyHelpers {
@@ -25,6 +25,9 @@ object KeyHelpers {
 
   def intKey(name: String, prefix: Short, default: Int = 0): Key[Int] =
     Key(name, Shorts.toByteArray(prefix), Option(_).fold(default)(Ints.fromByteArray), Ints.toByteArray)
+
+  def longKey(name: String, prefix: Short, default: Long = 0): Key[Long] =
+    Key(name, Longs.toByteArray(prefix), Option(_).fold(default)(Longs.fromByteArray), Longs.toByteArray)
 
   def bytesSeqNr(name: String, prefix: Short, b: Array[Byte], default: Int = 0): Key[Int] =
     Key(name, bytes(prefix, b), Option(_).fold(default)(Ints.fromByteArray), Ints.toByteArray)

--- a/src/main/scala/com/wavesplatform/matcher/LocalQueueStore.scala
+++ b/src/main/scala/com/wavesplatform/matcher/LocalQueueStore.scala
@@ -1,0 +1,34 @@
+package com.wavesplatform.matcher
+
+import java.util.concurrent.atomic.AtomicLong
+
+import com.google.common.primitives.{Longs, Shorts}
+import com.wavesplatform.database.{DBExt, ReadOnlyDB}
+import com.wavesplatform.matcher.MatcherKeys._
+import com.wavesplatform.matcher.queue.{QueueEvent, QueueEventWithMeta}
+import org.iq80.leveldb.{DB, ReadOptions}
+
+class LocalQueueStore(db: DB) {
+
+  private val newestIdx = new AtomicLong(db.get(lpqNewestIdx))
+
+  def enqueue(event: QueueEvent, timestamp: Long): QueueEventWithMeta.Offset = {
+    val idx      = newestIdx.incrementAndGet()
+    val eventKey = lpqElement(idx)
+
+    db.readWrite { rw =>
+      rw.put(eventKey, Some(QueueEventWithMeta(idx, timestamp, event)))
+      rw.put(lpqNewestIdx, idx)
+    }
+
+    idx
+  }
+
+  def getFrom(offset: QueueEventWithMeta.Offset): Vector[QueueEventWithMeta] =
+    new ReadOnlyDB(db, new ReadOptions())
+      .read(LpqElementKeyName, LpqElementPrefixBytes, lpqElement(math.max(offset, 0)).keyBytes, Int.MaxValue) { e =>
+        val offset = Longs.fromByteArray(e.getKey.slice(Shorts.BYTES, Shorts.BYTES + Longs.BYTES))
+        lpqElement(offset).parse(e.getValue).getOrElse(throw new RuntimeException(s"Can't find a queue event at $offset"))
+      }
+
+}

--- a/src/main/scala/com/wavesplatform/matcher/MatcherTool.scala
+++ b/src/main/scala/com/wavesplatform/matcher/MatcherTool.scala
@@ -7,18 +7,18 @@ import akka.actor.ActorSystem
 import akka.persistence.serialization.Snapshot
 import akka.serialization.SerializationExtension
 import com.google.common.base.Charsets.UTF_8
-import com.google.common.primitives.{Ints, Shorts}
-import com.typesafe.config.{Config, ConfigFactory}
+import com.google.common.primitives.Shorts
+import com.typesafe.config.ConfigFactory
 import com.wavesplatform.account.{Address, AddressScheme}
 import com.wavesplatform.database._
 import com.wavesplatform.db.openDB
 import com.wavesplatform.matcher.api.DBUtils
-import com.wavesplatform.matcher.market.{MatcherActor, OrderBookActor}
-import com.wavesplatform.matcher.model.{LimitOrder, OrderBook}
+import com.wavesplatform.matcher.market.OrderBookActor
+import com.wavesplatform.matcher.model.LimitOrder
 import com.wavesplatform.settings.{WavesSettings, loadConfig}
 import com.wavesplatform.state.{ByteStr, EitherExt2}
 import com.wavesplatform.transaction.AssetId
-import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
+import com.wavesplatform.transaction.assets.exchange.AssetPair
 import com.wavesplatform.utils.ScorexLogging
 import org.iq80.leveldb.DB
 
@@ -159,117 +159,6 @@ object MatcherTool extends ScorexLogging {
     log.info("Completed")
   }
 
-  private def collectActiveOrders(db: DB): Map[AssetPair, Map[ByteStr, Order]] = {
-    val activeOrders = new JHashMap[AssetPair, Map[ByteStr, Order]]()
-    db.iterateOver(MatcherKeys.OrderInfoPrefix) { e =>
-      val info = MatcherKeys.decodeOrderInfo(e.getValue)
-      if (!info.status.isFinal) {
-        val orderId = e.extractId()
-        db.get(MatcherKeys.order(orderId)) match {
-          case Some(order) =>
-            activeOrders.compute(order.assetPair, { (_, maybePrev) =>
-              Option(maybePrev).fold(Map(orderId -> order))(_.updated(orderId, order))
-            })
-          case None =>
-            log.info(s"Missing order $orderId")
-        }
-
-      }
-    }
-
-    activeOrders.asScala.toMap
-  }
-
-  private def extractPersistenceId(key: Array[Byte]): (String, Int) = (
-    new String(key, 1, key.length - 5, UTF_8),
-    Ints.fromByteArray(key.takeRight(4))
-  )
-
-  private def recoverOrderBooks(db: DB, matcherSnapshotsDirectory: String, config: Config, dryRun: Boolean): Unit = {
-    log.info("Recovering order books")
-
-    val system = ActorSystem("matcher-tool", config)
-    val se     = SerializationExtension(system)
-
-    val orderBookSnapshots = new JHashMap[AssetPair, (OrderBook, Int)]
-    val snapshotDB         = openDB(matcherSnapshotsDirectory)
-    try {
-      snapshotDB.iterateOver(Array(3.toByte)) { e =>
-        val (persistenceId, seqNr) = extractPersistenceId(e.getKey)
-        se.deserialize(e.getValue, classOf[Snapshot]).get.data match {
-          case _: MatcherActor.Snapshot => log.info("Encountered Matcher Actor snapshot")
-          case OrderBookActor.Snapshot(orderBook) =>
-            val pairStr = persistenceId.split("-")
-            orderBookSnapshots.compute(AssetPair.createAssetPair(pairStr(0), pairStr(1)).get, { (_, v) =>
-              if (v == null || v._2 < seqNr) (orderBook, seqNr) else v
-            })
-        }
-
-      }
-
-      if (orderBookSnapshots.isEmpty) {
-        log.warn("No snapshots found, please check your configuration")
-      } else {
-        log.info(s"Collected ${orderBookSnapshots.size()} order book snapshots")
-
-        val allOrderBooks   = orderBookSnapshots.asScala.map { case (k, v) => k -> v._1 }
-        val allActiveOrders = collectActiveOrders(db)
-
-        val snapshotsToUpdate     = new JHashMap[AssetPair, OrderBook]
-        var snapshotUpdateCounter = 0
-        val ordersToCancel        = Set.newBuilder[ByteStr]
-
-        for (assetPair <- allOrderBooks.keySet ++ allActiveOrders.keySet) {
-          val orderBookFromSnapshot = allOrderBooks.getOrElse(assetPair, OrderBook.empty)
-          val computedActiveOrders  = allActiveOrders.getOrElse(assetPair, Map.empty)
-
-          for (orderId <- computedActiveOrders.keySet ++ orderBookFromSnapshot.allOrderIds) {
-            if (!computedActiveOrders.contains(orderId)) {
-              snapshotUpdateCounter += 1
-              snapshotsToUpdate.compute(
-                assetPair, { (_, ob) =>
-                  val currentOrderBook = Option(ob).getOrElse(orderBookFromSnapshot)
-                  OrderBook
-                    .cancelOrder(currentOrderBook, orderId)
-                    .fold(currentOrderBook)(OrderBook.updateState(currentOrderBook, _))
-                }
-              )
-            }
-            if (!orderBookFromSnapshot.allOrderIds(orderId)) {
-              ordersToCancel += orderId
-            }
-          }
-        }
-        val allOrderIdsToCancel = ordersToCancel.result().map(id => id -> DBUtils.orderInfo(db, id).copy(canceledByUser = Some(true)))
-        log.info(s"Cancelling ${allOrderIdsToCancel.size} order(s)")
-        db.readWrite { rw =>
-          for ((id, info) <- allOrderIdsToCancel) {
-            log.info(s"Cancelling order $id")
-            if (!dryRun) {
-              rw.put(MatcherKeys.orderInfo(id), info)
-            }
-          }
-        }
-
-        log.info(s"Updating ${snapshotsToUpdate.size()} snapshot(s)")
-        snapshotDB.readWrite { rw =>
-          for ((assetPair, orderBook) <- snapshotsToUpdate.asScala) {
-            val (_, seqNr)    = orderBookSnapshots.get(assetPair)
-            val snapshotBytes = se.serialize(Snapshot(OrderBookActor.Snapshot(orderBook)))
-            if (!dryRun) {
-              rw.put(MatcherSnapshotStore.kSnapshot(assetPair.toString, seqNr), snapshotBytes.get)
-            }
-          }
-        }
-      }
-    } finally {
-      log.info("Terminating actor system")
-      Await.ready(system.terminate(), Duration.Inf)
-      log.info("Closing snapshot store")
-      snapshotDB.close()
-    }
-  }
-
   def main(args: Array[String]): Unit = {
     log.info(s"OK, engine start")
 
@@ -343,9 +232,6 @@ object MatcherTool extends ScorexLogging {
       case "compact" =>
         log.info("Compacting database")
         db.compactRange(null, null)
-      case "recover-orderbooks" =>
-        val dryRun = args.length == 3 && args(2) == "--dry-run"
-        recoverOrderBooks(db, settings.matcherSettings.snapshotsDataDir, actualConfig, dryRun)
       case "dump-active" =>
         dumpActive(db, new File(args(2)))
       case _ =>

--- a/src/main/scala/com/wavesplatform/matcher/api/DBUtils.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/DBUtils.scala
@@ -22,6 +22,7 @@ object DBUtils {
 
       // We show all active orders even they count exceeds the pair limit
       def getAll(ro: ReadOnlyDB, address: Address): IndexedSeq[ActiveOrdersIndex.Node] = c(address).getAll(ro)
+      def has(ro: ReadOnlyDB, address: Address, id: Order.Id): Boolean                 = c(address).has(ro, id)
 
       private def c(address: Address) = new ActiveOrdersIndex(address, MaxElements)
     }

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.Executors
 import akka.actor.ActorRef
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.{Directive1, Route}
+import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import akka.pattern.ask
 import akka.util.Timeout
 import com.google.common.primitives.Longs
@@ -13,12 +13,14 @@ import com.wavesplatform.account.PublicKeyAccount
 import com.wavesplatform.api.http._
 import com.wavesplatform.crypto
 import com.wavesplatform.matcher.AssetPairBuilder
+import com.wavesplatform.matcher.Matcher.StoreEvent
 import com.wavesplatform.matcher.market.MatcherActor.{GetMarkets, MarketData}
 import com.wavesplatform.matcher.market.OrderBookActor._
 import com.wavesplatform.matcher.market.OrderHistoryActor
 import com.wavesplatform.matcher.model._
+import com.wavesplatform.matcher.queue.QueueEvent
 import com.wavesplatform.metrics.TimerExt
-import com.wavesplatform.settings.WavesSettings
+import com.wavesplatform.settings.{RestAPISettings, WavesSettings}
 import com.wavesplatform.state.ByteStr
 import com.wavesplatform.transaction.AssetAcc
 import com.wavesplatform.transaction.assets.exchange.OrderJson._
@@ -44,8 +46,10 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
                            orderHistory: ActorRef,
                            orderBook: AssetPair => Option[Either[Unit, ActorRef]],
                            getMarketStatus: AssetPair => Option[MarketStatus],
+                           storeEvent: StoreEvent,
                            orderBookSnapshot: OrderBookSnapshotHttpCache,
                            wavesSettings: WavesSettings,
+                           isDuringShutdown: () => Boolean,
                            db: DB,
                            time: Time)
     extends ApiRoute
@@ -55,7 +59,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   import PathMatchers._
   import wavesSettings._
 
-  override val settings = restAPISettings
+  override val settings: RestAPISettings = restAPISettings
 
   private val timer           = Kamon.timer("matcher.api-requests")
   private val placeTimer      = timer.refine("action" -> "place")
@@ -64,13 +68,21 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
 
   private val batchCancelExecutor = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor(new DefaultThreadFactory("batch-cancel", true)))
 
-  override lazy val route: Route =
+  override lazy val route: Route = shutdownBarrier {
     pathPrefix("matcher") {
       matcherPublicKey ~ getOrderBook ~ marketStatus ~ place ~ getAssetPairAndPublicKeyOrderHistory ~ getPublicKeyOrderHistory ~
         getAllOrderHistory ~ getTradableBalance ~ reservedBalance ~ orderStatus ~
         historyDelete ~ cancel ~ cancelAll ~ orderbooks ~ orderBookDelete ~ getTransactionsByOrder ~ forceCancelOrder ~
         getSettings
     }
+  }
+
+  private def shutdownBarrier: Directive0 = if (isDuringShutdown()) complete(DuringShutdown) else pass
+
+  private def unavailableOrderBookBarrier(p: AssetPair): Directive0 = orderBook(p) match {
+    case Some(Left(_)) => complete(OrderBookUnavailable)
+    case _             => pass
+  }
 
   private def withAssetPair(p: AssetPair, redirectToInverse: Boolean = false, suffix: String = ""): Directive1[AssetPair] =
     assetPairBuilder.validateAssetPair(p) match {
@@ -158,25 +170,32 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
     ))
   def place: Route = path("orderbook") {
     (pathEndOrSingleSlash & post) {
-      json[Order] { order =>
-        placeTimer.measureFuture {
-          orderValidator.validateNewOrder(order) match {
-            case Left(e)  => Future.successful[MatcherResponse](OrderRejected(e))
-            case Right(_) => (matcher ? order).mapTo[MatcherResponse]
+      _json[Order] { order =>
+        unavailableOrderBookBarrier(order.assetPair) {
+          complete {
+            placeTimer.measureFuture {
+              orderValidator.validateNewOrder(order) match {
+                case Left(e)  => Future.successful[MatcherResponse](OrderRejected(e))
+                case Right(_) => storeEvent(QueueEvent.Placed(order))
+              }
+            }
           }
         }
       }
     }
   }
 
-  private def doCancel(order: Order): Future[MatcherResponse] = orderBook(order.assetPair) match {
-    case Some(Right(orderBookRef)) =>
+  private def doCancel(order: Order): Future[WrappedMatcherResponse] = orderBook(order.assetPair) match {
+    case Some(Right(_)) =>
       log.trace(s"Canceling ${order.id()} for ${order.sender.address}")
-      (orderBookRef ? CancelOrder(order.id())).mapTo[MatcherResponse].map {
+      storeEvent(QueueEvent.Canceled(order.assetPair, order.id())).flatMap {
         case _: OrderCancelRejected =>
           orderHistory ! Events.OrderCanceled(LimitOrder(order), unmatchable = false)
-          OrderCanceled(order.id())
-        case x => x
+          Future.successful(OrderCanceled(order.id()))
+        case x: OrderCanceled => Future.successful(x)
+        case x =>
+          log.warn(s"Unexpected response for cancel: $x")
+          Future.failed(new RuntimeException("Unexpected response"))
       }
     case Some(Left(_)) => Future.successful(OrderBookUnavailable)
     case None =>
@@ -215,8 +234,8 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
         case Left(e) => Future.successful[ToResponseMarshallable](OrderCancelRejected(e))
         case Right(_) =>
           val ordersToCancel = assetPair match {
-            case Some(p) => DBUtils.ordersByAddressAndPair(db, senderPublicKey, p, true, DBUtils.indexes.active.MaxElements)
-            case None    => DBUtils.ordersByAddress(db, senderPublicKey, true, DBUtils.indexes.active.MaxElements)
+            case Some(p) => DBUtils.ordersByAddressAndPair(db, senderPublicKey, p, activeOnly = true, DBUtils.indexes.active.MaxElements)
+            case None    => DBUtils.ordersByAddress(db, senderPublicKey, activeOnly = true, DBUtils.indexes.active.MaxElements)
           }
 
           ordersToCancel
@@ -533,9 +552,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
     ))
   def orderBookDelete: Route = (path("orderbook" / AssetPairPM) & delete & withAuth) { p =>
     withAssetPair(p) { pair =>
-      complete((matcher ? DeleteOrderBookRequest(pair)).map { _ =>
-        GetOrderBookResponse(time.correctedTime(), pair, Seq(), Seq()).toHttpResponse
-      })
+      complete(storeEvent(QueueEvent.OrderBookDeleted(pair)))
     }
   }
 

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
@@ -2,11 +2,14 @@ package com.wavesplatform.matcher.api
 
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.{StatusCodes => C, _}
+import com.wavesplatform.matcher.model.OrderBookResult
 import com.wavesplatform.state.ByteStr
 import com.wavesplatform.transaction.assets.exchange.Order
 import play.api.libs.json.{JsNull, JsValue, Json}
 
-abstract class MatcherResponse(val statusCode: StatusCode, val json: JsValue) {
+sealed abstract class MatcherResponse(val statusCode: StatusCode, val jsonBody: String)
+
+sealed abstract class WrappedMatcherResponse(statusCode: StatusCode, val json: JsValue) extends MatcherResponse(statusCode, Json.stringify(json)) {
   def this(code: StatusCode, message: String) =
     this(code,
          Json.obj(
@@ -19,34 +22,39 @@ abstract class MatcherResponse(val statusCode: StatusCode, val json: JsValue) {
 object MatcherResponse {
   import akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers._
   import com.wavesplatform.http.ApiMarshallers._
+
   implicit val trm: ToResponseMarshaller[MatcherResponse] =
-    fromStatusCodeAndValue[StatusCode, JsValue].compose(mr => mr.statusCode -> mr.json)
+    fromStatusCodeAndHeadersAndValue[String].compose(mr =>
+      (mr.statusCode, List(headers.`Content-Type`(ContentTypes.`application/json`)), mr.jsonBody))
 
   implicit def tuple2MatcherResponse(v: (StatusCode, String)): MatcherResponse = MatcherResponse(v._1, v._2)
 
   def apply(code: StatusCode, message: String): MatcherResponse = SimpleResponse(code, message)
 }
 
-case class SimpleResponse(code: StatusCode, message: String) extends MatcherResponse(code, message)
+case class SimpleResponse(code: StatusCode, message: String) extends WrappedMatcherResponse(code, message)
 
-case class NotImplemented(message: String) extends MatcherResponse(C.NotImplemented, message)
+case class NotImplemented(message: String) extends WrappedMatcherResponse(C.NotImplemented, message)
 
-case object InvalidSignature extends MatcherResponse(C.BadRequest, "Invalid signature")
+case object InvalidSignature extends WrappedMatcherResponse(C.BadRequest, "Invalid signature")
 
 case object OperationTimedOut
-    extends MatcherResponse(C.InternalServerError, Json.obj("status" -> "OperationTimedOut", "message" -> "Operation is timed out, please try later"))
+    extends WrappedMatcherResponse(C.InternalServerError,
+                                   Json.obj("status" -> "OperationTimedOut", "message" -> "Operation is timed out, please try later"))
 
-case class OrderAccepted(order: Order) extends MatcherResponse(C.OK, Json.obj("status" -> "OrderAccepted", "message" -> order.json()))
+case class OrderAccepted(order: Order) extends WrappedMatcherResponse(C.OK, Json.obj("status" -> "OrderAccepted", "message" -> order.json()))
 
-case class OrderRejected(message: String) extends MatcherResponse(C.BadRequest, Json.obj("status" -> "OrderRejected", "message" -> message))
+case class OrderRejected(message: String) extends WrappedMatcherResponse(C.BadRequest, Json.obj("status" -> "OrderRejected", "message" -> message))
 
-case class OrderCanceled(orderId: ByteStr) extends MatcherResponse(C.OK, Json.obj("status" -> "OrderCanceled", "orderId" -> orderId))
+case class OrderCanceled(orderId: ByteStr) extends WrappedMatcherResponse(C.OK, Json.obj("status" -> "OrderCanceled", "orderId" -> orderId))
 
-case class OrderDeleted(orderId: ByteStr) extends MatcherResponse(C.OK, Json.obj("status" -> "OrderDeleted", "orderId" -> orderId))
+case class OrderDeleted(orderId: ByteStr) extends WrappedMatcherResponse(C.OK, Json.obj("status" -> "OrderDeleted", "orderId" -> orderId))
 
 case class OrderCancelRejected(message: String)
-    extends MatcherResponse(C.BadRequest, Json.obj("status" -> "OrderCancelRejected", "message" -> message))
+    extends WrappedMatcherResponse(C.BadRequest, Json.obj("status" -> "OrderCancelRejected", "message" -> message))
 
-case object OrderBookUnavailable extends MatcherResponse(C.ServiceUnavailable, "Order book is unavailable. Please contact the administrator")
+case object OrderBookUnavailable extends WrappedMatcherResponse(C.ServiceUnavailable, "Order book is unavailable. Please contact the administrator")
 
-case object DuringShutdown extends MatcherResponse(C.ServiceUnavailable, "System is going shutdown")
+case object DuringShutdown extends WrappedMatcherResponse(C.ServiceUnavailable, "System is going shutdown")
+
+case class GetOrderBookResponse(orderBookResult: OrderBookResult) extends MatcherResponse(C.OK, OrderBookResult.toJson(orderBookResult))

--- a/src/main/scala/com/wavesplatform/matcher/model/Command.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/Command.scala
@@ -1,0 +1,23 @@
+package com.wavesplatform.matcher.model
+
+import java.util.UUID
+
+import com.wavesplatform.account.Address
+import com.wavesplatform.matcher.model.MatcherModel.OrderId
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
+
+// ? Remove?
+sealed trait Command {
+  def id: Command.Id
+}
+
+object Command {
+  type Id = UUID
+  def newId: UUID = UUID.randomUUID()
+
+  case class Place(id: Id, order: Order)                   extends Command
+  case class Cancel(id: Id, orderId: OrderId)              extends Command
+  case class CancelAllInPair(id: Id, assetPair: AssetPair) extends Command
+  case class CancelAll(id: Id, address: Address)           extends Command
+  case class DeleteOrderBook(id: Id, assetPair: AssetPair) extends Command
+}

--- a/src/main/scala/com/wavesplatform/matcher/model/EventSerializers.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/EventSerializers.scala
@@ -145,8 +145,10 @@ object EventSerializers {
       JsSuccess(jv.as[Map[String, (Long, Long)]])
   }
 
-  implicit val snapshotFormat: Format[Snapshot] =
-    Format((JsPath \ "o").read[OrderBook].map(Snapshot), Writes[Snapshot](s => Json.obj("o" -> s.orderBook)))
+  implicit val snapshotFormat: Format[Snapshot] = Format(
+    ((JsPath \ "n").readNullable[Long].map(_.getOrElse(-1L)) and (JsPath \ "o").read[OrderBook])(Snapshot),
+    Writes[Snapshot](s => Json.obj("n" -> s.lastProcessedCommandNr, "o" -> s.orderBook))
+  )
 
   private def encodeOrder(o: LimitOrder) = {
     val orderBytes = o.order.version match {

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
@@ -136,7 +136,7 @@ class OrderValidator(db: DB,
             case x: OrderV1 => x.copy(orderType = x.orderType.opposite)
             case x: OrderV2 => x.copy(orderType = x.orderType.opposite)
           }
-          transactionCreator.createTransaction(OrderExecuted(LimitOrder(fakeOrder), LimitOrder(order))).left.map(_.toString)
+          transactionCreator.createTransaction(OrderExecuted(LimitOrder(fakeOrder), LimitOrder(order)), time.correctedTime()).left.map(_.toString)
         }
 
         def verifyAssetScript(assetId: Option[AssetId]) = assetId.fold[ValidationResult](Right(order)) { assetId =>

--- a/src/main/scala/com/wavesplatform/matcher/queue/KafkaMatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/KafkaMatcherQueue.scala
@@ -1,0 +1,97 @@
+package com.wavesplatform.matcher.queue
+
+import akka.kafka._
+import akka.kafka.scaladsl.{Consumer, Producer}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, OverflowStrategy}
+import com.wavesplatform.matcher.queue.KafkaMatcherQueue.Settings
+import com.wavesplatform.utils.ScorexLogging
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.{Deserializer, Serializer, StringDeserializer, StringSerializer}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Await, ExecutionContextExecutor, Future, Promise}
+
+class KafkaMatcherQueue(settings: Settings)(implicit mat: ActorMaterializer) extends MatcherQueue with ScorexLogging {
+  private implicit val dispatcher: ExecutionContextExecutor = mat.system.dispatcher
+
+  private val deserializer = new Deserializer[QueueEvent] {
+    override def configure(configs: java.util.Map[String, _], isKey: Boolean): Unit = {}
+    override def deserialize(topic: String, data: Array[Byte]): QueueEvent          = QueueEvent.fromBytes(data)
+    override def close(): Unit                                                      = {}
+  }
+
+  private val serializer = new Serializer[QueueEvent] {
+    override def configure(configs: java.util.Map[String, _], isKey: Boolean): Unit = {}
+    override def serialize(topic: String, data: QueueEvent): Array[Byte]            = QueueEvent.toBytes(data)
+    override def close(): Unit                                                      = {}
+  }
+
+  private var consumer = Option.empty[Consumer.Control]
+
+  private val consumerSettings = {
+    val config = mat.system.settings.config.getConfig("akka.kafka.consumer")
+    ConsumerSettings(config, new StringDeserializer, deserializer)
+  }
+
+  private val producerSettings = {
+    val config = mat.system.settings.config.getConfig("akka.kafka.producer")
+    ProducerSettings(config, new StringSerializer, serializer)
+  }
+
+  private val commandProducer = Source
+    .queue[(QueueEvent, Promise[QueueEventWithMeta.Offset])](1, OverflowStrategy.backpressure)
+    .map {
+      case (payload, p) =>
+        ProducerMessage.single(new ProducerRecord(settings.topic, "assetPair", payload), passThrough = p)
+    }
+    .via(Producer.flexiFlow(producerSettings))
+    .map {
+      case ProducerMessage.Result(meta, ProducerMessage.Message(_, passThrough)) => passThrough.success(meta.offset())
+      case ProducerMessage.MultiResult(parts, passThrough)                       => throw new RuntimeException(s"MultiResult(parts=$parts, passThrough=$passThrough)")
+      case ProducerMessage.PassThroughResult(passThrough)                        => throw new RuntimeException(s"PassThroughResult(passThrough=$passThrough)")
+    }
+    .toMat(Sink.ignore)(Keep.left)
+    .run()
+
+  override def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Future[Unit]): Unit = {
+    log.info(s"Start consuming from $fromOffset")
+    consumer = Some {
+      Consumer
+        .committableSource(consumerSettings, Subscriptions.assignmentWithOffset(new TopicPartition(settings.topic, 0) -> fromOffset))
+        .buffer(settings.consumerBufferSize, OverflowStrategy.dropTail)
+        .mapAsync(1) { msg =>
+          val req = QueueEventWithMeta(msg.record.offset(), msg.record.timestamp(), msg.record.value())
+          process(req)
+            .recoverWith {
+              case e =>
+                log.error(s"Matcher: Failed to process event at ${msg.record.offset()} offset: ${msg.record}")
+                Future.failed(e)
+            }
+            .map(_ => msg.committableOffset)
+        }
+        .batch(max = settings.consumerBufferSize, ConsumerMessage.CommittableOffsetBatch(_))(_.updated(_))
+        .mapAsync(5)(_.commitScaladsl())
+        .toMat(Sink.seq)(Keep.left)
+        .run()
+    }
+  }
+
+  override def storeEvent(event: QueueEvent): Future[QueueEventWithMeta.Offset] = {
+    val p = Promise[QueueEventWithMeta.Offset]()
+    commandProducer.offer((event, p))
+    p.future
+  }
+
+  override def close(timeout: FiniteDuration): Unit = {
+    commandProducer.complete()
+    Await.result(commandProducer.watchCompletion(), timeout)
+    consumer.foreach(x => Await.result(x.shutdown(), timeout))
+  }
+
+}
+
+object KafkaMatcherQueue {
+  case class Settings(topic: String, consumerBufferSize: Int)
+}

--- a/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
@@ -1,0 +1,50 @@
+package com.wavesplatform.matcher.queue
+
+import java.util.{Timer, TimerTask}
+
+import com.wavesplatform.matcher.LocalQueueStore
+import com.wavesplatform.matcher.queue.LocalMatcherQueue.Settings
+import com.wavesplatform.utils.{ScorexLogging, Time}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+class LocalMatcherQueue(settings: Settings, store: LocalQueueStore, time: Time)(implicit ec: ExecutionContext)
+    extends MatcherQueue
+    with ScorexLogging {
+
+  private var lastUnreadOffset: QueueEventWithMeta.Offset = 0
+  private val timer                                       = new Timer("local-dex-queue", true)
+
+  override def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Future[Unit]): Unit = {
+    lastUnreadOffset = fromOffset
+
+    timer.schedule(
+      new TimerTask {
+        override def run(): Unit = {
+          val requests = store.getFrom(lastUnreadOffset)
+          lastUnreadOffset = requests.lastOption.fold(lastUnreadOffset) { x =>
+            val r = x.offset + 1
+            log.trace(s"Read $r events")
+            r
+          }
+          requests.foreach(process)
+        }
+      },
+      0,
+      settings.pollingInterval.toMillis
+    )
+  }
+
+  override def storeEvent(event: QueueEvent): Future[QueueEventWithMeta.Offset] = {
+    val ts = time.correctedTime()
+    log.trace(s"Store $event with timestamp=$ts")
+    Future.successful(store.enqueue(event, time.correctedTime()))
+  }
+
+  override def close(timeout: FiniteDuration): Unit = timer.cancel()
+}
+
+object LocalMatcherQueue {
+  case class Settings(pollingInterval: FiniteDuration)
+}

--- a/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
@@ -1,0 +1,10 @@
+package com.wavesplatform.matcher.queue
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+trait MatcherQueue {
+  def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Future[Unit]): Unit
+  def storeEvent(payload: QueueEvent): Future[QueueEventWithMeta.Offset]
+  def close(timeout: FiniteDuration): Unit
+}

--- a/src/main/scala/com/wavesplatform/matcher/queue/QueueEvent.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/QueueEvent.scala
@@ -1,0 +1,32 @@
+package com.wavesplatform.matcher.queue
+
+import com.wavesplatform.crypto.DigestSize
+import com.wavesplatform.state.ByteStr
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
+
+sealed trait QueueEvent {
+  def assetPair: AssetPair
+}
+
+object QueueEvent {
+  case class Placed(order: Order) extends QueueEvent {
+    override def assetPair: AssetPair = order.assetPair
+  }
+  case class Canceled(assetPair: AssetPair, orderId: Order.Id) extends QueueEvent
+  case class OrderBookDeleted(assetPair: AssetPair)            extends QueueEvent
+
+  def toBytes(x: QueueEvent): Array[Byte] = x match {
+    case Placed(order)                => (1: Byte) +: order.version +: order.bytes()
+    case Canceled(assetPair, orderId) => (2: Byte) +: (assetPair.bytes ++ orderId.arr)
+    case OrderBookDeleted(assetPair)  => (3: Byte) +: assetPair.bytes
+  }
+
+  def fromBytes(xs: Array[Byte]): QueueEvent = xs.head match {
+    case 1 => QueueEvent.Placed(Order.fromBytes(xs.tail))
+    case 2 =>
+      val assetPair = AssetPair.fromBytes(xs.tail)
+      QueueEvent.Canceled(assetPair, ByteStr(xs.takeRight(DigestSize)))
+    case 3 => OrderBookDeleted(AssetPair.fromBytes(xs.tail))
+    case x => throw new IllegalArgumentException(s"Unknown event type: $x")
+  }
+}

--- a/src/main/scala/com/wavesplatform/matcher/queue/QueueEventWithMeta.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/QueueEventWithMeta.scala
@@ -1,0 +1,17 @@
+package com.wavesplatform.matcher.queue
+
+import com.google.common.primitives.Longs
+
+case class QueueEventWithMeta(offset: QueueEventWithMeta.Offset, timestamp: Long, event: QueueEvent)
+
+object QueueEventWithMeta {
+  type Offset = Long
+
+  def toBytes(x: QueueEventWithMeta): Array[Byte] = Longs.toByteArray(x.offset) ++ Longs.toByteArray(x.timestamp) ++ QueueEvent.toBytes(x.event)
+
+  def fromBytes(xs: Array[Byte]): QueueEventWithMeta = QueueEventWithMeta(
+    offset = Longs.fromByteArray(xs.take(8)),
+    timestamp = Longs.fromByteArray(xs.slice(8, 16)),
+    event = QueueEvent.fromBytes(xs.drop(16))
+  )
+}

--- a/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
@@ -108,7 +108,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
         (),
         GenericError(s"UNIMPLEMENTED ${displayFeatures(notImplementedFeatures)} ACTIVATED ON BLOCKCHAIN, UPDATE THE NODE IMMEDIATELY")
       )
-      .flatMap(_ =>
+      .flatMap[ValidationError, Option[DiscardedTransactions]](_ =>
         (ngState match {
           case None =>
             blockchain.lastBlockId match {

--- a/src/main/scala/com/wavesplatform/transaction/ValidationError.scala
+++ b/src/main/scala/com/wavesplatform/transaction/ValidationError.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.transaction.assets.exchange.Order
 
 import scala.util.Either
 
-trait ValidationError
+trait ValidationError extends Product with Serializable
 
 object ValidationError {
   type Validation[T] = Either[ValidationError, T]

--- a/src/main/scala/com/wavesplatform/transaction/assets/exchange/AssetPair.scala
+++ b/src/main/scala/com/wavesplatform/transaction/assets/exchange/AssetPair.scala
@@ -1,5 +1,6 @@
 package com.wavesplatform.transaction.assets.exchange
 
+import com.wavesplatform.serialization.Deser
 import com.wavesplatform.state.ByteStr
 import com.wavesplatform.transaction._
 import com.wavesplatform.transaction.assets.exchange.Order.assetIdBytes
@@ -55,4 +56,10 @@ object AssetPair {
       a1 <- extractAssetId(amountAsset)
       a2 <- extractAssetId(priceAsset)
     } yield AssetPair(a1, a2)
+
+  def fromBytes(xs: Array[Byte]): AssetPair = {
+    val (amount, offset) = Deser.parseByteArrayOption(xs, 0, AssetIdLength)
+    val (price, _)       = Deser.parseByteArrayOption(xs, offset, AssetIdLength)
+    AssetPair(amount.map(ByteStr(_)), price.map(ByteStr(_)))
+  }
 }

--- a/src/main/scala/com/wavesplatform/transaction/assets/exchange/Order.scala
+++ b/src/main/scala/com/wavesplatform/transaction/assets/exchange/Order.scala
@@ -273,4 +273,10 @@ object Order {
     assetId.map(a => (1: Byte) +: a.arr).getOrElse(Array(0: Byte))
   }
 
+  def fromBytes(xs: Array[Byte]): Order = xs.head match {
+    case 1     => OrderV1.parseBytes(xs.tail).get
+    case 2     => OrderV2.parseBytes(xs.tail).get
+    case other => throw new IllegalArgumentException(s"Unexpected order version: $other")
+  }
+
 }

--- a/src/main/scala/com/wavesplatform/transaction/assets/exchange/OrderJson.scala
+++ b/src/main/scala/com/wavesplatform/transaction/assets/exchange/OrderJson.scala
@@ -66,7 +66,7 @@ object OrderJson {
       expiration,
       matcherFee,
       eproofs,
-      version.getOrElse(if (eproofs.proofs.size == 1 && eproofs.proofs(0).arr.size == SignatureLength) { 1 } else { 2 })
+      version.getOrElse(if (eproofs.proofs.size == 1 && eproofs.proofs.head.arr.length == SignatureLength) 1 else 2)
     )
   }
 

--- a/src/main/scala/com/wavesplatform/transaction/assets/exchange/OrderV2.scala
+++ b/src/main/scala/com/wavesplatform/transaction/assets/exchange/OrderV2.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.account.{PrivateKeyAccount, PublicKeyAccount}
 import com.wavesplatform.crypto
 import com.wavesplatform.crypto._
 import com.wavesplatform.serialization.Deser
-import com.wavesplatform.state.ByteStr
+import com.wavesplatform.state.{ByteStr, EitherExt2}
 import com.wavesplatform.transaction._
 import monix.eval.Coeval
 
@@ -125,7 +125,7 @@ object OrderV2 {
         timestamp,
         expiration,
         matcherFee,
-        maybeProofs.right.get
+        maybeProofs.explicitGet()
       )
     }
     makeOrder.run(0).value._2

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -9,8 +9,8 @@ akka {
   # log-config-on-start = on
 
   persistence {
-    journal.plugin = "akka.persistence.journal.inmem"
-    snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+    journal.plugin = "inmemory-journal"
+    snapshot-store.plugin = "inmemory-snapshot-store"
   }
 
   actor {

--- a/src/test/scala/com/wavesplatform/matcher/MatcherTestData.scala
+++ b/src/test/scala/com/wavesplatform/matcher/MatcherTestData.scala
@@ -1,10 +1,14 @@
 package com.wavesplatform.matcher
 
+import java.util.concurrent.atomic.AtomicLong
+
 import com.google.common.primitives.{Bytes, Ints}
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.account.PrivateKeyAccount
+import com.wavesplatform.matcher.market.OrderBookActor.{CancelOrder, DeleteOrderBookRequest}
 import com.wavesplatform.matcher.model.MatcherModel.Price
 import com.wavesplatform.matcher.model.{BuyLimitOrder, SellLimitOrder}
+import com.wavesplatform.matcher.queue.{QueueEvent, QueueEventWithMeta}
 import com.wavesplatform.settings.loadConfig
 import com.wavesplatform.state.ByteStr
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order, OrderType}
@@ -17,12 +21,23 @@ trait MatcherTestData extends NTPTime { _: Suite =>
 
   val bytes32gen: Gen[Array[Byte]]       = Gen.listOfN(signatureSize, Arbitrary.arbitrary[Byte]).map(xs => xs.toArray)
   val WalletSeed                         = ByteStr("Matcher".getBytes())
-  val MatcherSeed                        = crypto.secureHash(Bytes.concat(Ints.toByteArray(0), WalletSeed.arr))
+  val MatcherSeed: Array[Byte]           = crypto.secureHash(Bytes.concat(Ints.toByteArray(0), WalletSeed.arr))
   val MatcherAccount                     = PrivateKeyAccount(MatcherSeed)
   val accountGen: Gen[PrivateKeyAccount] = bytes32gen.map(seed => PrivateKeyAccount(seed))
   val positiveLongGen: Gen[Long]         = Gen.choose(1, Long.MaxValue)
 
   val wavesAssetGen: Gen[Option[Array[Byte]]] = Gen.const(None)
+
+  private val seqNr                                       = new AtomicLong(-1)
+  def wrap(x: Order): QueueEventWithMeta                  = wrap(seqNr.incrementAndGet(), x)
+  def wrap(x: CancelOrder): QueueEventWithMeta            = wrap(seqNr.incrementAndGet(), x)
+  def wrap(x: DeleteOrderBookRequest): QueueEventWithMeta = wrap(seqNr.incrementAndGet(), x)
+
+  def wrap(n: Long, x: Order): QueueEventWithMeta                  = wrap(n, QueueEvent.Placed(x))
+  def wrap(n: Long, x: CancelOrder): QueueEventWithMeta            = wrap(n, QueueEvent.Canceled(x.assetPair, x.orderId))
+  def wrap(n: Long, x: DeleteOrderBookRequest): QueueEventWithMeta = wrap(n, QueueEvent.OrderBookDeleted(x.assetPair))
+
+  private def wrap(n: Long, event: QueueEvent): QueueEventWithMeta = QueueEventWithMeta(n, System.currentTimeMillis(), event)
 
   def assetIdGen(prefix: Byte) = Gen.listOfN(signatureSize - 1, Arbitrary.arbitrary[Byte]).map(xs => Some(ByteStr(Array(prefix, xs: _*))))
   val distinctPairGen: Gen[AssetPair] = for {

--- a/src/test/scala/com/wavesplatform/matcher/market/MatcherSpec.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/MatcherSpec.scala
@@ -1,27 +1,37 @@
 package com.wavesplatform.matcher.market
-import java.io.File
-import java.nio.file.Files
 
 import akka.actor.ActorSystem
-import akka.testkit.TestKitBase
+import akka.persistence.inmemory.extension.{InMemoryJournalStorage, InMemorySnapshotStorage, StorageExtension}
+import akka.testkit.{TestKitBase, TestProbe}
 import com.typesafe.config.ConfigFactory
-import com.wavesplatform.TestHelpers.deleteRecursively
 import com.wavesplatform.settings.loadConfig
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import com.wavesplatform.utils.ScorexLogging
+import org.scalatest._
 
-abstract class MatcherSpec(actorSystemName: String) extends TestKitBase with WordSpecLike with Matchers with BeforeAndAfterAll {
-  import MatcherSpec._
-  implicit lazy val system: ActorSystem = ActorSystem(
+abstract class MatcherSpec(actorSystemName: String)
+    extends TestKitBase
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with ScorexLogging {
+
+  implicit override lazy val system: ActorSystem = ActorSystem(
     actorSystemName,
-    loadConfig(ConfigFactory.parseString(s"$SnapshotStorePath = ${Files.createTempDirectory(actorSystemName)}"))
+    loadConfig(ConfigFactory.empty())
   )
+
+  override protected def beforeEach(): Unit = {
+    val p = TestProbe()
+    p.send(StorageExtension(system).journalStorage, InMemoryJournalStorage.ClearJournal)
+    p.expectMsg(akka.actor.Status.Success(""))
+    p.send(StorageExtension(system).snapshotStorage, InMemorySnapshotStorage.ClearSnapshots)
+    p.expectMsg(akka.actor.Status.Success(""))
+    super.beforeEach()
+  }
+
   override protected def afterAll(): Unit = {
     super.afterAll()
     shutdown(system)
-    deleteRecursively(new File(system.settings.config.getString(SnapshotStorePath)).toPath)
   }
-}
-
-object MatcherSpec {
-  private[MatcherSpec] val SnapshotStorePath = "akka.persistence.snapshot-store.local.dir"
 }

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
@@ -8,17 +8,15 @@ import com.wavesplatform.NTPTime
 import com.wavesplatform.OrderOps._
 import com.wavesplatform.matcher.MatcherTestData
 import com.wavesplatform.matcher.api.{OrderAccepted, OrderCanceled}
-import com.wavesplatform.matcher.fixtures.RestartableActor
 import com.wavesplatform.matcher.fixtures.RestartableActor.RestartActor
+import com.wavesplatform.matcher.market.MatcherActor.SaveSnapshot
 import com.wavesplatform.matcher.market.OrderBookActor._
 import com.wavesplatform.matcher.model._
 import com.wavesplatform.settings.Constants
-import com.wavesplatform.state.{ByteStr, Diff}
+import com.wavesplatform.state.{ByteStr, EitherExt2}
 import com.wavesplatform.transaction._
-import com.wavesplatform.transaction.assets.exchange.{AssetPair, ExchangeTransaction, Order}
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
 import com.wavesplatform.utils.EmptyBlockchain
-import com.wavesplatform.utx.UtxPool
-import io.netty.channel.group.ChannelGroup
 import org.scalamock.scalatest.PathMockFactory
 
 import scala.concurrent.duration._
@@ -26,7 +24,7 @@ import scala.util.Random
 
 class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTPTime with ImplicitSender with MatcherTestData with PathMockFactory {
 
-  private val txFactory = new ExchangeTransactionCreator(EmptyBlockchain, MatcherAccount, matcherSettings, ntpTime).createTransaction _
+  private val txFactory = new ExchangeTransactionCreator(EmptyBlockchain, MatcherAccount, matcherSettings).createTransaction _
   private val obc       = new ConcurrentHashMap[AssetPair, OrderBook]
   private val md        = new ConcurrentHashMap[AssetPair, MarketStatus]
 
@@ -44,14 +42,20 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
     Random.nextBytes(b.arr)
 
     val pair = AssetPair(Some(b), None)
-
-    val utx = stub[UtxPool]
-    (utx.putIfNew _).when(*).onCall((_: Transaction) => Right((true, Diff.empty)))
-    val allChannels = stub[ChannelGroup]
     val actor = system.actorOf(
       Props(
-        new OrderBookActor(TestProbe().ref, pair, update(pair), p => Option(md.get(p)), utx, allChannels, matcherSettings, txFactory, ntpTime)
-        with RestartableActor))
+        new OrderBookActor(
+          testActor,
+          pair,
+          update(pair),
+          p => Option(md.get(p)),
+          _ => {},
+          matcherSettings,
+          txFactory,
+          ntpTime
+        )))
+
+    expectMsg(OrderBookSnapshotUpdated(pair, -1))
 
     f(pair, actor)
   }
@@ -63,11 +67,11 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord2 = buy(pair, 170484969L, 34120)
       val ord3 = buy(pair, 44521418496L, 34000)
 
-      actor ! ord1
+      actor ! wrap(ord1)
       expectMsg(OrderAccepted(ord1))
-      actor ! ord2
+      actor ! wrap(ord2)
       expectMsg(OrderAccepted(ord2))
-      actor ! ord3
+      actor ! wrap(ord3)
       expectMsg(OrderAccepted(ord3))
 
       actor ! GetOrdersRequest
@@ -79,11 +83,11 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord2 = sell(pair, 170484969L, 34220)
       val ord3 = sell(pair, 44521418496L, 34000)
 
-      actor ! ord1
+      actor ! wrap(ord1)
       expectMsg(OrderAccepted(ord1))
-      actor ! ord2
+      actor ! wrap(ord2)
       expectMsg(OrderAccepted(ord2))
-      actor ! ord3
+      actor ! wrap(ord3)
       expectMsg(OrderAccepted(ord3))
 
       actor ! GetOrdersRequest
@@ -94,14 +98,14 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord1 = buy(pair, 10 * Order.PriceConstant, 100)
       val ord2 = buy(pair, 10 * Order.PriceConstant, 105)
 
-      actor ! ord1
-      actor ! ord2
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
       receiveN(2)
       actor ! GetOrdersRequest
       expectMsg(GetOrdersResponse(Seq(BuyLimitOrder(ord2.amount, ord2.matcherFee, ord2), BuyLimitOrder(ord1.amount, ord1.matcherFee, ord1))))
 
       val ord3 = sell(pair, 10 * Order.PriceConstant, 100)
-      actor ! ord3
+      actor ! wrap(ord3)
       expectMsg(OrderAccepted(ord3))
 
       actor ! GetOrdersRequest
@@ -112,8 +116,8 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord1 = buy(pair, 10 * Order.PriceConstant, 100)
       val ord2 = sell(pair, 15 * Order.PriceConstant, 150)
 
-      actor ! ord1
-      actor ! ord2
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
       receiveN(2)
 
       actor ! RestartActor
@@ -126,9 +130,9 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord1 = buy(pair, 10 * Order.PriceConstant, 100)
       val ord2 = sell(pair, 15 * Order.PriceConstant, 100)
 
-      actor ! ord1
+      actor ! wrap(ord1)
       expectMsgType[OrderAccepted]
-      actor ! ord2
+      actor ! wrap(ord2)
       expectMsgType[OrderAccepted]
 
       actor ! RestartActor
@@ -149,9 +153,9 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord2 = buy(pair, 5 * Order.PriceConstant, 100)
       val ord3 = sell(pair, 12 * Order.PriceConstant, 100)
 
-      actor ! ord1
-      actor ! ord2
-      actor ! ord3
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
+      actor ! wrap(ord3)
       receiveN(3)
 
       actor ! RestartActor
@@ -177,10 +181,10 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord3 = sell(pair, 5 * Order.PriceConstant, 90)
       val ord4 = buy(pair, 19 * Order.PriceConstant, 100)
 
-      actor ! ord1
-      actor ! ord2
-      actor ! ord3
-      actor ! ord4
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
+      actor ! wrap(ord3)
+      actor ! wrap(ord4)
       receiveN(4)
 
       actor ! RestartActor
@@ -207,10 +211,10 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord3 = sell(pair, 10 * Order.PriceConstant, 110)
       val ord4 = buy(pair, 22 * Order.PriceConstant, 115)
 
-      actor ! ord1
-      actor ! ord2
-      actor ! ord3
-      actor ! ord4
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
+      actor ! wrap(ord3)
+      actor ! wrap(ord4)
       receiveN(4)
 
       actor ! GetBidOrdersRequest
@@ -233,7 +237,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ts   = System.currentTimeMillis()
 
       (1 to 100).foreach({ i =>
-        actor ! ord1.updateTimestamp(ts + i)
+        actor ! wrap(ord1.updateTimestamp(ts + i))
       })
 
       within(10.seconds) {
@@ -253,23 +257,27 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val invalidOrd = buy(pair, 1000 * Order.PriceConstant, 5000)
       val ord2       = sell(pair, 10 * Order.PriceConstant, 100)
 
-      val pool = stub[UtxPool]
-      (pool.putIfNew _).when(*).onCall { tx: Transaction =>
-        tx match {
-          case om: ExchangeTransaction if om.buyOrder == invalidOrd => Left(ValidationError.GenericError("test"))
-          case _: Transaction                                       => Right((true, Diff.empty))
-        }
-      }
-      val allChannels = stub[ChannelGroup]
       val actor = system.actorOf(
-        Props(new OrderBookActor(TestProbe().ref, pair, update(pair), m => md.put(pair, m), pool, allChannels, matcherSettings, txFactory, ntpTime)
-        with RestartableActor))
+        Props(new OrderBookActor(
+          TestProbe().ref,
+          pair,
+          update(pair),
+          m => md.put(pair, m),
+          _ => {},
+          matcherSettings,
+          (event, ts) => {
+            if (event.submitted.order == invalidOrd || event.counter.order == invalidOrd)
+              Left(ValidationError.OrderValidationError(invalidOrd, "It's an invalid!"))
+            else Right(txFactory(event, ts).explicitGet())
+          },
+          ntpTime
+        )))
 
-      actor ! ord1
+      actor ! wrap(ord1)
       expectMsg(OrderAccepted(ord1))
-      actor ! invalidOrd
+      actor ! wrap(invalidOrd)
       expectMsg(OrderAccepted(invalidOrd))
-      actor ! ord2
+      actor ! wrap(ord2)
       expectMsg(OrderAccepted(ord2))
 
       actor ! RestartActor
@@ -295,9 +303,9 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord2 = sell(pair, 100000000, 0.0004)
       val ord3 = buy(pair, 100000001, 0.00045)
 
-      actor ! ord1
-      actor ! ord2
-      actor ! ord3
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
+      actor ! wrap(ord3)
       receiveN(3)
 
       actor ! GetAskOrdersRequest
@@ -310,9 +318,9 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord2 = sell(pair, 3075248828L, 0.00067634)
       val ord3 = buy(pair, 3075363900L, 0.00073697)
 
-      actor ! ord1
-      actor ! ord2
-      actor ! ord3
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
+      actor ! wrap(ord3)
       receiveN(3)
 
       actor ! GetAskOrdersRequest
@@ -331,9 +339,9 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val ord2 = sell(pair, (0.01 * Constants.UnitsInWave).toLong, 1840)
       val ord3 = buy(pair, (0.0100001 * Constants.UnitsInWave).toLong, 2000)
 
-      actor ! ord1
-      actor ! ord2
-      actor ! ord3
+      actor ! wrap(ord1)
+      actor ! wrap(ord2)
+      actor ! wrap(ord3)
       receiveN(3)
 
       actor ! GetAskOrdersRequest
@@ -346,8 +354,8 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       val p = AssetPair(Some(ByteStr("WAVES".getBytes)), Some(ByteStr("USD".getBytes)))
       val b = rawBuy(p, 700000L, 280)
       val s = rawSell(p, 30000000000L, 280)
-      actor ! s
-      actor ! b
+      actor ! wrap(s)
+      actor ! wrap(b)
       receiveN(2)
 
       actor ! GetAskOrdersRequest
@@ -360,32 +368,86 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       expectMsg(GetOrdersResponse(Seq.empty))
     }
 
-    "cancel expired orders after OrderCleanup command" in obcTest { (pair, actor) =>
+    // TODO: should be done in DEX-160
+    "cancel expired orders after OrderCleanup command" ignore obcTest { (pair, actor) =>
       val ts     = ntpTime.correctedTime()
       val amount = 1
       val price  = 34118
 
       val expiredOrder = buy(pair, amount, price).updateExpiration(ts)
-      actor ! expiredOrder
+      actor ! wrap(expiredOrder)
       receiveN(1)
       getOrders(actor) shouldEqual Seq(BuyLimitOrder(amount, expiredOrder.matcherFee, expiredOrder))
-      actor ! OrderCleanup
+      // actor ! OrderCleanup
       expectMsg(OrderCanceled(expiredOrder.id()))
       getOrders(actor).size should be(0)
     }
 
-    "preserve valid orders after OrderCleanup command" in obcTest { (pair, actor) =>
+    // TODO: should be done in DEX-160
+    "preserve valid orders after OrderCleanup command" ignore obcTest { (pair, actor) =>
       val amount = 1
       val price  = 34118
 
       val order          = buy(pair, amount, price)
       val expectedOrders = Seq(BuyLimitOrder(amount, order.matcherFee, order))
 
-      actor ! order
+      actor ! wrap(order)
       receiveN(1)
       getOrders(actor) shouldEqual expectedOrders
-      actor ! OrderCleanup
+      // actor ! OrderCleanup
       getOrders(actor) shouldEqual expectedOrders
+    }
+
+    "ignores outdated requests" in obcTest { (pair, actor) =>
+      (1 to 10).foreach { i =>
+        actor ! wrap(i, buy(pair, 100000000, 0.00041))
+      }
+      receiveN(10)
+
+      (1 to 10).foreach { i =>
+        actor ! wrap(i, buy(pair, 100000000, 0.00041))
+      }
+      expectNoMessage(200.millis)
+    }
+
+    "response on SaveSnapshotCommand" in obcTest { (pair, actor) =>
+      (1 to 10).foreach { i =>
+        actor ! wrap(i, buy(pair, 100000000, 0.00041))
+      }
+      receiveN(10)
+
+      actor ! SaveSnapshot
+      expectMsg(OrderBookSnapshotUpdated(pair, 10))
+
+      (11 to 20).foreach { i =>
+        actor ! wrap(i, buy(pair, 100000000, 0.00041))
+      }
+      receiveN(10)
+
+      actor ! SaveSnapshot
+      expectMsg(OrderBookSnapshotUpdated(pair, 20))
+    }
+
+    "don't do a snapshot if there is no changes" in obcTest { (pair, actor) =>
+      (1 to 10).foreach { i =>
+        actor ! wrap(i, buy(pair, 100000000, 0.00041))
+      }
+      receiveN(10)
+
+      actor ! SaveSnapshot
+      actor ! SaveSnapshot
+      expectMsgType[OrderBookSnapshotUpdated]
+      expectNoMessage(200.millis)
+    }
+
+    "restore its state at start" in obcTest { (pair, actor) =>
+      (1 to 10).foreach { i =>
+        actor ! wrap(i, buy(pair, 100000000, 0.00041))
+      }
+      receiveN(10)
+
+      actor ! SaveSnapshot
+      expectMsgType[OrderBookSnapshotUpdated]
     }
   }
 }

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
@@ -103,7 +103,7 @@ class OrderValidatorSpecification
           (bc.accountScript _).when(scripted.toAddress).returns(Some(ScriptV1(Terms.FALSE).explicitGet()))
           (bc.height _).when().returns(150).anyNumberOfTimes()
 
-          val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+          val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
           val ov = new OrderValidator(db, bc, tc, _ => defaultPortfolio, Right(_), matcherSettings, MatcherAccount, ntpTime)
           ov.validateNewOrder(newBuyOrder(scripted, version = 2)) should produce("Order rejected by script")
         }
@@ -112,7 +112,7 @@ class OrderValidatorSpecification
       "order expires too soon" in forAll(Gen.choose[Long](1, OrderValidator.MinExpiration), accountGen) { (offset, pk) =>
         val bc       = stub[Blockchain]
         val tt       = new TestTime
-        val tc       = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+        val tc       = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
         val ov       = new OrderValidator(db, bc, tc, _ => defaultPortfolio, Right(_), matcherSettings, MatcherAccount, tt)
         val unsigned = newBuyOrder
         val signed   = Order.sign(unsigned.updateExpiration(tt.getTimestamp() + offset).updateSender(pk), pk)
@@ -257,7 +257,7 @@ class OrderValidatorSpecification
         activate(bc, BlockchainFeatures.SmartAccountTrading -> 100)
         (bc.height _).when().returns(0).anyNumberOfTimes()
 
-        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
         val ov = new OrderValidator(db, bc, tc, _ => defaultPortfolio, Right(_), matcherSettings, MatcherAccount, ntpTime)
         ov.validateNewOrder(newBuyOrder(account, version = 2)) should produce("Orders of version 1 are only accepted")
       }
@@ -276,7 +276,7 @@ class OrderValidatorSpecification
         val script = ScriptCompiler(scriptText, isAssetScript = false).explicitGet()._1
         (bc.accountScript _).when(account.toAddress).returns(Some(script)).anyNumberOfTimes()
 
-        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
         val ov = new OrderValidator(db, bc, tc, _ => defaultPortfolio, Right(_), matcherSettings, MatcherAccount, ntpTime)
         ov.validateNewOrder(newBuyOrder(account, version = 2)) should produce("height is inaccessible when running script on matcher")
       }
@@ -287,14 +287,14 @@ class OrderValidatorSpecification
     val bc = stub[Blockchain]
     (bc.assetScript _).when(wbtc).returns(None)
     (bc.assetDescription _).when(wbtc).returns(mkAssetDescription(8)).anyNumberOfTimes()
-    val transactionCreator = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+    val transactionCreator = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
     f(new OrderValidator(db, bc, transactionCreator, _ => p, Right(_), matcherSettings, MatcherAccount, ntpTime), bc)
   }
 
   private def settingsTest(settings: MatcherSettings)(f: OrderValidator => Any): Unit = {
     val bc = stub[Blockchain]
     (bc.assetDescription _).when(wbtc).returns(mkAssetDescription(8)).anyNumberOfTimes()
-    val transactionCreator = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+    val transactionCreator = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
     f(new OrderValidator(db, bc, transactionCreator, _ => defaultPortfolio, Right(_), settings, MatcherAccount, ntpTime))
   }
 

--- a/src/test/scala/com/wavesplatform/matcher/model/EventJsonSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/model/EventJsonSpecification.scala
@@ -52,7 +52,7 @@ class EventJsonSpecification extends PropSpec with PropertyChecks with Matchers 
       val res = j.validate[OrderBook]
       res.get should ===(ob)
 
-      val s = Snapshot(ob)
+      val s = Snapshot(2, ob)
 
       val js       = Json.toJson(s)
       val restored = js.validate[Snapshot]

--- a/src/test/scala/com/wavesplatform/matcher/model/ExchangeTransactionCreatorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/model/ExchangeTransactionCreatorSpecification.scala
@@ -32,8 +32,8 @@ class ExchangeTransactionCreatorSpecification
 
         val bc = stub[Blockchain]
         (bc.activatedFeatures _).when().returns(Map.empty).anyNumberOfTimes()
-        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
-        tc.createTransaction(exec).explicitGet() shouldBe a[ExchangeTransactionV1]
+        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
+        tc.createTransaction(exec, System.currentTimeMillis()).explicitGet() shouldBe a[ExchangeTransactionV1]
       }
 
       "return an error" when {
@@ -46,8 +46,8 @@ class ExchangeTransactionCreatorSpecification
 
               val bc = stub[Blockchain]
               (bc.activatedFeatures _).when().returns(Map.empty).anyNumberOfTimes()
-              val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
-              tc.createTransaction(exec) should produce("SmartAccountTrading has not been activated yet")
+              val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
+              tc.createTransaction(exec, System.currentTimeMillis()) should produce("SmartAccountTrading has not been activated yet")
             }
         }
       }
@@ -61,8 +61,8 @@ class ExchangeTransactionCreatorSpecification
 
         val bc = stub[Blockchain]
         (bc.activatedFeatures _).when().returns(Map(BlockchainFeatures.SmartAccountTrading.id -> 0)).anyNumberOfTimes()
-        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
-        tc.createTransaction(exec).explicitGet() shouldBe a[ExchangeTransactionV2]
+        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings)
+        tc.createTransaction(exec, System.currentTimeMillis()).explicitGet() shouldBe a[ExchangeTransactionV2]
       }
     }
   }

--- a/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
@@ -2,7 +2,9 @@ package com.wavesplatform.settings
 
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.matcher.MatcherSettings
+import com.wavesplatform.matcher.MatcherSettings.EventsQueueSettings
 import com.wavesplatform.matcher.api.OrderBookSnapshotHttpCache
+import com.wavesplatform.matcher.queue.{KafkaMatcherQueue, LocalMatcherQueue}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
@@ -39,6 +41,18 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |      cache-timeout = 11m
         |      depth-ranges = [1, 5, 333]
         |    }
+        |    events-queue {
+        |      type = "kafka"
+        |
+        |      local {
+        |        polling-interval = 1d
+        |      }
+        |
+        |      kafka {
+        |        topic = "some-events"
+        |        consumer-buffer-size = 100
+        |      }
+        |    }
         |  }
         |}""".stripMargin))
 
@@ -64,6 +78,11 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.orderBookSnapshotHttpCache shouldBe OrderBookSnapshotHttpCache.Settings(
       cacheTimeout = 11.minutes,
       depthRanges = List(1, 5, 333)
+    )
+    settings.eventsQueue shouldBe EventsQueueSettings(
+      tpe = "kafka",
+      local = LocalMatcherQueue.Settings(1.day),
+      kafka = KafkaMatcherQueue.Settings("some-events", 100)
     )
   }
 }


### PR DESCRIPTION
High-level:
* New architecture of requests processing:
  * Mutable requests are validated and sent as events to the queue;
  * DEX processes events from the queue only;
  * Each instance of DEX processes the event and generates ExchangeTransaction (Event is translated to ExchangeTransactions in idenpotent manner);
  * DEX watches procession results and sends reponses to clients as soon as results are available;
* DEX can work with local events queue or distributed (Kafka);
* ExchangeTransactions are still validated in local UTX Pool before sending;

Matcher:
* All matcher responses now in MatcherResponse.scala;
* Matcher commands order books to create snapshots from time to time;

OrderBookActor:
* Doesn't use putIfNew;
* Has no Events;
* Snapshot contains the latest command number;
* Does snapshots on SaveSnapshot command;

OrderHistory:
* Events to OrderHistory are applied only once;

ExchangeTransaction:
* Timestamp is taken from Kafka's submitted order (Kafka queue);
* Timestamp is taken from local corrected time (Local queue);

ExchangeTransactionCreator:
* Doesn't depend on Time. A timestamp of ExchangeTransaction is the newest order timestamp;

MatcherSettings:
* New section "waves.matcher.events-queue". Contains settings for kafka, local queue and selected type;

API internals:
* ApiRoute._json alternative to json, when a better composition is needed;
* MatcherApiRoute - shutdownBarrier, unavailableOrderBookBarrier;

Integration tests:
* OrderInfo, ExchangeTransaction - added version and proofs;
* InMemory snapshots and journal stores for unit tests. They are cleaned before each test;
* expectSignedBroadcastRejected;
* OrdersFromScriptedAssetTestSuite, OrderTypeTestSuite, ProofAndAssetPairTestSuite - an exchange transaction isn't verified during matching, so we check it later;
* Logging a request's method name in integration tests;

Logging:
* Reduced amount of Kafka client logs;