### PR TITLE
NODE-1319-order-by-fee-per-byte

### DIFF
--- a/src/main/scala/com/wavesplatform/consensus/TransactionsOrdering.scala
+++ b/src/main/scala/com/wavesplatform/consensus/TransactionsOrdering.scala
@@ -5,15 +5,15 @@ import com.wavesplatform.transaction.Transaction
 object TransactionsOrdering {
   trait WavesOrdering extends Ordering[Transaction] {
     def txTimestampOrder(ts: Long): Long
-    private def orderBy(t: Transaction): (Long, Long, String) = {
+    private def orderBy(t: Transaction): (Double, Long, Long) = {
+      val size        = t.bytes().size
       val byFee       = if (t.assetFee._1.nonEmpty) 0 else -t.assetFee._2
       val byTimestamp = txTimestampOrder(t.timestamp)
-      val byTxId      = t.id().base58
 
-      (byFee, byTimestamp, byTxId)
+      (byFee.toDouble / size.toDouble, byFee, byTimestamp)
     }
     override def compare(first: Transaction, second: Transaction): Int = {
-      implicitly[Ordering[(Long, Long, String)]].compare(orderBy(first), orderBy(second))
+      implicitly[Ordering[(Double, Long, Long)]].compare(orderBy(first), orderBy(second))
     }
   }
 

--- a/src/test/scala/com/wavesplatform/consensus/nxt/TransactionsOrderingSpecification.scala
+++ b/src/test/scala/com/wavesplatform/consensus/nxt/TransactionsOrderingSpecification.scala
@@ -11,23 +11,7 @@ import scala.util.Random
 class TransactionsOrderingSpecification extends PropSpec with Assertions with Matchers {
 
   property("TransactionsOrdering.InBlock should sort correctly") {
-    val txsDifferentById = (0 to 3)
-      .map(
-        i =>
-          TransferTransactionV1
-            .selfSigned(None,
-                        PrivateKeyAccount(Array.fill(32)(0)),
-                        Address.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").explicitGet(),
-                        100000,
-                        5,
-                        None,
-                        125L,
-                        Array(i.toByte))
-            .right
-            .get)
-      .sortBy(t => t.id().base58)
-
-    val correctSeq = txsDifferentById ++ Seq(
+    val correctSeq = Seq(
       TransferTransactionV1
         .selfSigned(None,
                     PrivateKeyAccount(Array.fill(32)(0)),
@@ -95,23 +79,7 @@ class TransactionsOrderingSpecification extends PropSpec with Assertions with Ma
   }
 
   property("TransactionsOrdering.InUTXPool should sort correctly") {
-    val txsDifferentById = (0 to 3)
-      .map(
-        i =>
-          TransferTransactionV1
-            .selfSigned(None,
-                        PrivateKeyAccount(Array.fill(32)(0)),
-                        Address.fromString("3MydsP4UeQdGwBq7yDbMvf9MzfB2pxFoUKU").explicitGet(),
-                        100000,
-                        5,
-                        None,
-                        125L,
-                        Array(i.toByte))
-            .right
-            .get)
-      .sortBy(t => t.id().base58)
-
-    val correctSeq = txsDifferentById ++ Seq(
+    val correctSeq = Seq(
       TransferTransactionV1
         .selfSigned(None,
                     PrivateKeyAccount(Array.fill(32)(0)),


### PR DESCRIPTION
Sorting transactions in UTX by fee-per-byte.
Do not sort by id.