### PR TITLE
DEX-170 Can't create an ExchangeTransactionV2 before SmartAccountTrading activation

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/smartcontracts/OrdersFromScriptedAccTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/smartcontracts/OrdersFromScriptedAccTestSuite.scala
@@ -65,13 +65,20 @@ class OrdersFromScriptedAccTestSuite extends MatcherSuiteBase {
 
     "trading is deprecated" in {
       assertBadRequestAndResponse(
+        matcherNode.placeOrder(bobAcc, aliceWavesPair, OrderType.BUY, 500, 2.waves * Order.PriceConstant, smartTradeFee, version = 1, 10.minutes),
+        "Trading on scripted account isn't allowed yet"
+      )
+    }
+
+    "can't place an OrderV2 before the activation" in {
+      assertBadRequestAndResponse(
         matcherNode.placeOrder(bobAcc, aliceWavesPair, OrderType.BUY, 500, 2.waves * Order.PriceConstant, smartTradeFee, version = 2, 10.minutes),
-        "Trading on scripted account isn't allowed yet."
+        "Orders of version 1 are only accepted, because SmartAccountTrading has not been activated yet"
       )
     }
 
     "invalid setScript at account" in {
-      matcherNode.waitForHeight(ActivationHeight, 3.minutes)
+      matcherNode.waitForHeight(ActivationHeight, 5.minutes)
       setContract(Some("true && (height > 0)"), bobAcc)
       assertBadRequestAndResponse(
         matcherNode.placeOrder(bobAcc, aliceWavesPair, OrderType.BUY, 500, 2.waves * Order.PriceConstant, smartTradeFee, version = 2, 10.minutes),

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
@@ -145,6 +145,8 @@ class OrderValidator(db: DB,
 
         for {
           _ <- (Right(order): ValidationResult)
+            .ensure("Orders of version 1 are only accepted, because SmartAccountTrading has not been activated yet")(
+              _.version == 1 || blockchain.isFeatureActivated(BlockchainFeatures.SmartAccountTrading, blockchain.height))
             .ensure("Incorrect matcher public key")(_.matcherPublicKey == matcherPublicKey)
             .ensure("Invalid address")(_ => !blacklistedAddresses.contains(senderAddress))
             .ensure("Order expiration should be > 1 min")(_.expiration > time.correctedTime() + MinExpiration)

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
@@ -252,7 +252,7 @@ class OrderValidatorSpecification
       }
     }
 
-    "deny OrderV1 if SmartAccountTrading hasn't been activated yet" in forAll(accountGen) { account =>
+    "deny OrderV2 if SmartAccountTrading hasn't been activated yet" in forAll(accountGen) { account =>
       portfolioTest(defaultPortfolio) { (_, bc) =>
         activate(bc, BlockchainFeatures.SmartAccountTrading -> 100)
         (bc.height _).when().returns(0).anyNumberOfTimes()

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
@@ -42,6 +42,8 @@ class OrderValidatorSpecification
   "OrderValidator" should {
     "allow buying WAVES for BTC without balance for order fee" in
       portfolioTest(defaultPortfolio) { (ov, bc) =>
+        activate(bc, BlockchainFeatures.SmartAccountTrading -> 0)
+
         val o = newBuyOrder
         (bc.accountScript _).when(o.sender.toAddress).returns(None)
         ov.validateNewOrder(o) shouldBe 'right
@@ -79,7 +81,7 @@ class OrderValidatorSpecification
         portfolioTest(defaultPortfolio) { (ov, bc) =>
           activate(bc, BlockchainFeatures.SmartAccountTrading -> 100)
           (bc.accountScript _).when(scripted.toAddress).returns(Some(ScriptV1(Terms.TRUE).explicitGet()))
-          (bc.height _).when().returns(50).once()
+          (bc.height _).when().returns(50).anyNumberOfTimes()
 
           ov.validateNewOrder(newBuyOrder(scripted)) should produce("Trading on scripted account isn't allowed yet")
         }
@@ -89,17 +91,28 @@ class OrderValidatorSpecification
         portfolioTest(defaultPortfolio) { (ov, bc) =>
           activate(bc, BlockchainFeatures.SmartAccountTrading -> 100)
           (bc.accountScript _).when(scripted.toAddress).returns(Some(ScriptV1(Terms.TRUE).explicitGet()))
-          (bc.height _).when().returns(50).once()
+          (bc.height _).when().returns(50).anyNumberOfTimes()
 
           ov.validateNewOrder(newBuyOrder(scripted)) should produce("Trading on scripted account isn't allowed yet")
         }
       }
 
+//      "xxx" in forAll(accountGen) { scripted =>
+//        portfolioTest(defaultPortfolio) { (_, bc) =>
+//          activate(bc, BlockchainFeatures.SmartAccountTrading -> 100)
+//          (bc.height _).when().returns(150).anyNumberOfTimes()
+//
+//          val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+//          val ov = new OrderValidator(db, bc, tc, _ => defaultPortfolio, Right(_), matcherSettings, MatcherAccount, ntpTime)
+//          ov.validateNewOrder(newBuyOrder(scripted, version = 2)) should produce("Order rejected by script")
+//        }
+//      }
+
       "sender's address has a script returning FALSE" in forAll(accountGen) { scripted =>
         portfolioTest(defaultPortfolio) { (_, bc) =>
           activate(bc, BlockchainFeatures.SmartAccountTrading -> 100)
           (bc.accountScript _).when(scripted.toAddress).returns(Some(ScriptV1(Terms.FALSE).explicitGet()))
-          (bc.height _).when().returns(150).once()
+          (bc.height _).when().returns(150).anyNumberOfTimes()
 
           val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
           val ov = new OrderValidator(db, bc, tc, _ => defaultPortfolio, Right(_), matcherSettings, MatcherAccount, ntpTime)
@@ -203,30 +216,34 @@ class OrderValidatorSpecification
       val permitScript = ScriptV1(Terms.TRUE).explicitGet()
       val denyScript   = ScriptV1(Terms.FALSE).explicitGet()
 
-      "two assets are smart and they permit an order" in test { (ov, bc, o) =>
+      "two assets are smart and they permit an order" when test { (ov, bc, o) =>
         (bc.assetScript _).when(asset1).returns(Some(permitScript))
         (bc.assetScript _).when(asset2).returns(Some(permitScript))
 
         ov.validateNewOrder(o) shouldBe 'right
       }
 
-      "first asset is smart and it deny an order" in test { (ov, bc, o) =>
+      "first asset is smart and it deny an order" when test { (ov, bc, o) =>
         (bc.assetScript _).when(asset1).returns(Some(denyScript))
         (bc.assetScript _).when(asset2).returns(None)
 
         ov.validateNewOrder(o) should produce("Order rejected by script of asset")
       }
 
-      "second asset is smart and it deny an order" in test { (ov, bc, o) =>
+      "second asset is smart and it deny an order" when test { (ov, bc, o) =>
         (bc.assetScript _).when(asset1).returns(None)
         (bc.assetScript _).when(asset2).returns(Some(denyScript))
 
         ov.validateNewOrder(o) should produce("Order rejected by script of asset")
       }
 
-      def test(f: (OrderValidator, Blockchain, Order) => Any): Unit = forAll(Gen.oneOf(1, 2)) { version =>
-        portfolioTest(portfolio) { (ov, bc) =>
-          activate(bc, BlockchainFeatures.SmartAssets -> 0)
+      def test(f: (OrderValidator, Blockchain, Order) => Any): Unit = (1 to 2).foreach { version =>
+        s"v$version" in portfolioTest(portfolio) { (ov, bc) =>
+          val features = Seq(BlockchainFeatures.SmartAssets -> 0) ++ {
+            if (version == 1) Seq.empty
+            else Seq(BlockchainFeatures.SmartAccountTrading -> 0)
+          }
+          activate(bc, features: _*)
           (bc.assetDescription _).when(asset1).returns(mkAssetDescription(8))
           (bc.assetDescription _).when(asset2).returns(mkAssetDescription(8))
 
@@ -249,6 +266,7 @@ class OrderValidatorSpecification
 
   private def portfolioTest(p: Portfolio)(f: (OrderValidator, Blockchain) => Any): Unit = {
     val bc = stub[Blockchain]
+
     (bc.assetScript _).when(wbtc).returns(None)
     (bc.assetDescription _).when(wbtc).returns(mkAssetDescription(8)).anyNumberOfTimes()
     val transactionCreator = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)

--- a/src/test/scala/com/wavesplatform/matcher/model/ExchangeTransactionCreatorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/model/ExchangeTransactionCreatorSpecification.scala
@@ -1,0 +1,75 @@
+package com.wavesplatform.matcher.model
+
+import com.google.common.base.Charsets
+import com.wavesplatform.NoShrink
+import com.wavesplatform.features.BlockchainFeatures
+import com.wavesplatform.matcher.MatcherTestData
+import com.wavesplatform.matcher.model.Events.OrderExecuted
+import com.wavesplatform.state.diffs.produce
+import com.wavesplatform.state.{Blockchain, ByteStr, EitherExt2}
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, ExchangeTransactionV1, ExchangeTransactionV2}
+import org.scalamock.scalatest.PathMockFactory
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+
+class ExchangeTransactionCreatorSpecification
+    extends WordSpec
+    with Matchers
+    with MatcherTestData
+    with BeforeAndAfterAll
+    with PathMockFactory
+    with PropertyChecks
+    with NoShrink {
+
+  private val pair = AssetPair(None, mkAssetId("BTC"))
+
+  "ExchangeTransactionCreator" when {
+    "SmartAccountTrading hasn't been activated yet" should {
+      "create an ExchangeTransactionV1" in {
+        val counter   = buy(pair, 100000, 0.0008, matcherFee = Some(2000L))
+        val submitted = sell(pair, 100000, 0.0007, matcherFee = Some(1000L))
+        val exec      = OrderExecuted(LimitOrder(submitted), LimitOrder(counter))
+
+        val bc = stub[Blockchain]
+        (bc.activatedFeatures _).when().returns(Map.empty).anyNumberOfTimes()
+        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+        tc.createTransaction(exec).explicitGet() shouldBe a[ExchangeTransactionV1]
+      }
+
+      "return an error" when {
+        List((1, 2), (2, 1), (2, 2)).foreach {
+          case (buyVersion, sellVersion) =>
+            s"buyV$buyVersion and sellV$sellVersion" in {
+              val counter   = buy(pair, 100000, 0.0008, matcherFee = Some(2000L), version = buyVersion.toByte)
+              val submitted = sell(pair, 100000, 0.0007, matcherFee = Some(1000L), version = sellVersion.toByte)
+              val exec      = OrderExecuted(LimitOrder(submitted), LimitOrder(counter))
+
+              val bc = stub[Blockchain]
+              (bc.activatedFeatures _).when().returns(Map.empty).anyNumberOfTimes()
+              val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+              tc.createTransaction(exec) should produce("SmartAccountTrading has not been activated yet")
+            }
+        }
+      }
+    }
+
+    "SmartAccountTrading has been activated" should {
+      "create an ExchangeTransactionV2" in {
+        val counter   = buy(pair, 100000, 0.0008, matcherFee = Some(2000L), version = 2)
+        val submitted = sell(pair, 100000, 0.0007, matcherFee = Some(1000L), version = 2)
+        val exec      = OrderExecuted(LimitOrder(submitted), LimitOrder(counter))
+
+        val bc = stub[Blockchain]
+        (bc.activatedFeatures _).when().returns(Map(BlockchainFeatures.SmartAccountTrading.id -> 0)).anyNumberOfTimes()
+        val tc = new ExchangeTransactionCreator(bc, MatcherAccount, matcherSettings, ntpTime)
+        tc.createTransaction(exec).explicitGet() shouldBe a[ExchangeTransactionV2]
+      }
+    }
+  }
+
+  private def mkAssetId(prefix: String) = {
+    val prefixBytes = prefix.getBytes(Charsets.UTF_8)
+    Some(ByteStr((prefixBytes ++ Array.fill[Byte](32 - prefixBytes.length)(0.toByte)).take(32)))
+  }
+
+}


### PR DESCRIPTION
* ExchangeTransactionCreate creates ExchangeTransactionV1 if SmartAccountTrading hasn't been activated yet;
* OrderValidator doesn't allow to place OrderV2 if SmartAccountTrading hasn't been activated yet;
* Additional tests.