### PR TITLE
NODE-1359 Add chainId to transactions info if it used in signature

### DIFF
--- a/src/main/scala/com/wavesplatform/transaction/assets/IssueTransactionV2.scala
+++ b/src/main/scala/com/wavesplatform/transaction/assets/IssueTransactionV2.scala
@@ -37,7 +37,7 @@ case class IssueTransactionV2 private (version: Byte,
     ))
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 
-  override val json: Coeval[JsObject] = Coeval.evalOnce(issueJson() ++ Json.obj("script" -> script.map(_.bytes().base64)))
+  override val json: Coeval[JsObject] = Coeval.evalOnce(issueJson() ++ Json.obj("chainId" -> chainId, "script" -> script.map(_.bytes().base64)))
 }
 
 object IssueTransactionV2 extends TransactionParserFor[IssueTransactionV2] with TransactionParser.MultipleVersions {

--- a/src/main/scala/com/wavesplatform/transaction/smart/SetScriptTransaction.scala
+++ b/src/main/scala/com/wavesplatform/transaction/smart/SetScriptTransaction.scala
@@ -37,7 +37,7 @@ case class SetScriptTransaction private (version: Byte,
     ))
 
   override val assetFee: (Option[AssetId], Long) = (None, fee)
-  override val json                              = Coeval.evalOnce(jsonBase() ++ Json.obj("version" -> version, "script" -> script.map(_.bytes().base64)))
+  override val json                              = Coeval.evalOnce(jsonBase() ++ Json.obj("chainId" -> chainId, "version" -> version, "script" -> script.map(_.bytes().base64)))
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(Bytes.concat(Array(0: Byte), bodyBytes(), proofs.bytes()))
 }

--- a/src/test/scala/com/wavesplatform/transaction/IssueTransactionV2Specification.scala
+++ b/src/test/scala/com/wavesplatform/transaction/IssueTransactionV2Specification.scala
@@ -40,6 +40,7 @@ class IssueTransactionV2Specification extends PropSpec with PropertyChecks with 
                        ],
                        "version": 2,
                        "assetId": "2ykNAo5JrvNCcL8PtCmc9pTcNtKUy2PjJkrFdRvTfUf4",
+                       "chainId": 84,
                        "name": "Gigacoin",
                        "quantity": 10000000000,
                        "reissuable": true,

--- a/src/test/scala/com/wavesplatform/transaction/SetScriptTransactionSpecification.scala
+++ b/src/test/scala/com/wavesplatform/transaction/SetScriptTransactionSpecification.scala
@@ -39,6 +39,7 @@ class SetScriptTransactionSpecification extends GenericTransactionSpecification[
                        "tcTr672rQ5gXvcA9xCGtQpkHC8sAY1TDYqDcQG7hQZAeHcvvHFo565VEv1iD1gVa3ZuGjYS7hDpuTnQBfY2dUhY"
                        ],
                        "version": 1,
+                       "chainId": 84,
                        "script": null
                        }
     """),


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-1359
Added `chainId` to IssueV2 and SetScriptV1 transactions.
ReissueV2, BurnV2, and LeaseCancel transactions already report `chainId` as they should