### PR TITLE
DEX-185 Handle processing errors

### DIFF
--- a/benchmark/src/main/resources/logback.xml
+++ b/benchmark/src/main/resources/logback.xml
@@ -15,7 +15,7 @@
 
     <logger name="org.aspectj" level="INFO"/>
 
-    <root level="TRACE">
+    <root level="OFF">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/benchmark/src/test/scala/com/wavesplatform/state/StateSyntheticBenchmark.scala
+++ b/benchmark/src/test/scala/com/wavesplatform/state/StateSyntheticBenchmark.scala
@@ -73,7 +73,7 @@ object StateSyntheticBenchmark {
     override def init(): Unit = {
       super.init()
 
-      val textScript    = "sigVerify(tx.bodyBytes,tx.proofs[0],tx.senderPk)"
+      val textScript    = "sigVerify(tx.bodyBytes,tx.proofs[0],tx.senderPublicKey)"
       val untypedScript = Parser(textScript).get.value
       val typedScript   = CompilerV1(compilerContext(V1, isAssetScript = false), untypedScript).explicitGet()._1
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,18 +58,19 @@ resolvers ++= Seq(
   Resolver.sbtPluginRepo("releases")
 )
 
-fork in run := true
-javaOptions in run ++= Seq(
-  "-XX:+IgnoreUnrecognizedVMOptions",
-  "--add-modules=java.xml.bind"
-)
-
-Test / fork := true
-Test / javaOptions ++= Seq(
+val java9Options = Seq(
   "-XX:+IgnoreUnrecognizedVMOptions",
   "--add-modules=java.xml.bind",
   "--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED"
 )
+
+fork in run := true
+javaOptions in run ++= java9Options
+
+Test / fork := true
+Test / javaOptions ++= java9Options
+
+Jmh / javaOptions ++= java9Options
 
 val aopMerge: MergeStrategy = new MergeStrategy {
   val name = "aopMerge"

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/MultipleMatchersTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/MultipleMatchersTestSuite.scala
@@ -14,7 +14,7 @@ import org.scalacheck.Gen
 import scala.concurrent.duration.DurationInt
 import scala.util.Random
 
-// TODO: works only with kafka
+// Works only with kafka
 class MultipleMatchersTestSuite extends MatcherSuiteBase {
   private def configOverrides = ConfigFactory.parseString("""waves.matcher {
       |  price-assets = ["WAVES"]

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -597,6 +597,7 @@ akka {
         group.id = "0"
         auto.offset.reset = "earliest"
         enable.auto.commit = false
+        # max.poll.records = 10 # Should be <= ${waves.matcher.events-queue.kafka.consumer.buffer-size}
       }
 
       # Time to wait for pending requests when a partition is closed

--- a/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
@@ -72,7 +72,7 @@ class MatcherActorSpecification
           TestActorRef(
             new MatcherActor(
               matcherSettings,
-              (_, _) => (),
+              (_, _, _) => (),
               ob,
               (_, _) => Props(new FailAtStartActor(pair)),
               blockchain.assetDescription
@@ -179,7 +179,7 @@ class MatcherActorSpecification
       TestActorRef(
         new MatcherActor(
           matcherSettings.copy(snapshotsInterval = 20),
-          (_, _) => (),
+          (_, _, _) => (),
           emptyOrderBookRefs,
           (assetPair, _) => {
             val idx = assetPairs.indexOf(assetPair)
@@ -221,7 +221,7 @@ class MatcherActorSpecification
       TestActorRef(
         new MatcherActor(
           matcherSettings,
-          (_, _) => (),
+          (_, _, _) => (),
           ob,
           (assetPair, matcher) => OrderBookActor.props(matcher, assetPair, _ => {}, _ => {}, _ => {}, matcherSettings, txFactory, ntpTime),
           blockchain.assetDescription


### PR DESCRIPTION
* MatcherActor child actors (OrderBook) will be stopped if an error happens inside of them. They are restarted before;
* KafkaMatcherQueue: consumer store the offset locally;
* We don't resolve old requests, those was did before restart;

Benchmarks:
* Can run on Java8;
* Fixed smart contract code in StateSyntheticBenchmark;
* Disabled logging;