### PR TITLE
NODE-1322 When new key block is appended, microblocks are validated once again

### DIFF
--- a/src/main/scala/com/wavesplatform/Importer.scala
+++ b/src/main/scala/com/wavesplatform/Importer.scala
@@ -29,9 +29,16 @@ object Importer extends ScorexLogging {
     SLF4JBridgeHandler.removeHandlersForRootLogger()
     SLF4JBridgeHandler.install()
 
-    val configFilename     = Try(args(0)).toOption.getOrElse("waves-testnet.conf")
-    val blockchainFilename = Try(args(1))
-    val importHeight       = Try(args(2)).map(_.toInt).getOrElse(Int.MaxValue)
+    val argi = args.iterator
+    val (verifyTransactions, configOpt) = {
+      Try(argi.next) match {
+        case Success("-n") | Success("-no-verify") => (false, Try(argi.next))
+        case conf                                  => (true, conf)
+      }
+    }
+    val configFilename     = configOpt.toOption.getOrElse("waves-testnet.conf")
+    val blockchainFilename = Try(argi.next)
+    val importHeight       = Try(argi.next).map(_.toInt).getOrElse(Int.MaxValue)
 
     val config   = loadConfig(ConfigFactory.parseFile(new File(configFilename)))
     val settings = WavesSettings.fromConfig(config)
@@ -63,7 +70,7 @@ object Importer extends ScorexLogging {
             val blockchainUpdater = StorageFactory(settings, db, time)
             val pos               = new PoSSelector(blockchainUpdater, settings.blockchainSettings)
             val checkpoint        = new CheckpointServiceImpl(db, settings.checkpointsSettings)
-            val extAppender       = BlockAppender(checkpoint, blockchainUpdater, time, utxPoolStub, pos, settings, scheduler) _
+            val extAppender       = BlockAppender(checkpoint, blockchainUpdater, time, utxPoolStub, pos, settings, scheduler, verifyTransactions) _
             checkGenesis(settings, blockchainUpdater)
             val bis           = new BufferedInputStream(inputStream)
             var quit          = false
@@ -111,7 +118,7 @@ object Importer extends ScorexLogging {
             log.info(s"Imported $counter block(s) in ${humanReadableDuration(duration)}")
           case Failure(_) => log.error(s"Failed to open file '$filename")
         }
-      case Failure(_) => log.error("Usage: Importer <config file> <blockchain file> [height]")
+      case Failure(_) => log.error("Usage: Importer [-n | -no-verify] <config file> <blockchain file> [height]")
     }
 
     time.close()

--- a/src/main/scala/com/wavesplatform/mining/Miner.scala
+++ b/src/main/scala/com/wavesplatform/mining/Miner.scala
@@ -224,7 +224,7 @@ class MinerImpl(allChannels: ChannelGroup,
           microBlock <- EitherT.fromEither[Task](
             MicroBlock.buildAndSign(account, unconfirmed, accumulatedBlock.signerData.signature, signedBlock.signerData.signature))
           _ = microBlockBuildTimeStats.safeRecord(System.currentTimeMillis() - start)
-          _ <- EitherT(MicroblockAppender(checkpoint, blockchainUpdater, utx, appenderScheduler)(microBlock))
+          _ <- EitherT(MicroblockAppender(checkpoint, blockchainUpdater, utx, appenderScheduler, verify = false)(microBlock))
         } yield (microBlock, signedBlock)).value map {
           case Left(err) => Error(err)
           case Right((microBlock, signedBlock)) =>

--- a/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
@@ -98,7 +98,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
     }
   }
 
-  override def processBlock(block: Block): Either[ValidationError, Option[DiscardedTransactions]] = {
+  override def processBlock(block: Block, verify: Boolean = true): Either[ValidationError, Option[DiscardedTransactions]] = {
     val height                             = blockchain.height
     val notImplementedFeatures: Set[Short] = blockchain.activatedFeaturesAt(height).diff(BlockchainFeatures.implemented)
 
@@ -120,7 +120,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
                 val height            = lastBlockId.fold(0)(blockchain.unsafeHeightOf)
                 val miningConstraints = MiningConstraints(blockchain, height)
                 BlockDiffer
-                  .fromBlock(functionalitySettings, blockchain, blockchain.lastBlock, block, miningConstraints.total)
+                  .fromBlock(functionalitySettings, blockchain, blockchain.lastBlock, block, miningConstraints.total, verify)
                   .map(r => Some((r, Seq.empty[Transaction])))
             }
           case Some(ng) =>
@@ -130,7 +130,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
                 val miningConstraints = MiningConstraints(blockchain, height)
 
                 BlockDiffer
-                  .fromBlock(functionalitySettings, blockchain, blockchain.lastBlock, block, miningConstraints.total)
+                  .fromBlock(functionalitySettings, blockchain, blockchain.lastBlock, block, miningConstraints.total, verify)
                   .map { r =>
                     log.trace(
                       s"Better liquid block(score=${block.blockScore()}) received and applied instead of existing(score=${ng.base.blockScore()})")
@@ -146,7 +146,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
                   val miningConstraints = MiningConstraints(blockchain, height)
 
                   BlockDiffer
-                    .fromBlock(functionalitySettings, blockchain, blockchain.lastBlock, block, miningConstraints.total)
+                    .fromBlock(functionalitySettings, blockchain, blockchain.lastBlock, block, miningConstraints.total, verify)
                     .map(r => Some((r, Seq.empty[Transaction])))
                 }
               } else
@@ -175,7 +175,8 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
                         CompositeBlockchain.composite(blockchain, referencedLiquidDiff, carry),
                         Some(referencedForgedBlock),
                         block,
-                        constraint
+                        constraint,
+                        verify
                       )
 
                     diff.map { hardenedDiff =>
@@ -220,7 +221,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
     }
   }
 
-  override def processMicroBlock(microBlock: MicroBlock): Either[ValidationError, Unit] = {
+  override def processMicroBlock(microBlock: MicroBlock, verify: Boolean = true): Either[ValidationError, Unit] = {
     ngState match {
       case None =>
         Left(MicroBlockAppendError("No base block exists", microBlock))
@@ -240,7 +241,13 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, settings: WavesSettings, tim
               r <- {
                 val constraints  = MiningConstraints(blockchain, blockchain.height)
                 val mdConstraint = MultiDimensionalMiningConstraint(restTotalConstraint, constraints.micro)
-                BlockDiffer.fromMicroBlock(functionalitySettings, this, blockchain.lastBlockTimestamp, microBlock, ng.base.timestamp, mdConstraint)
+                BlockDiffer.fromMicroBlock(functionalitySettings,
+                                           this,
+                                           blockchain.lastBlockTimestamp,
+                                           microBlock,
+                                           ng.base.timestamp,
+                                           mdConstraint,
+                                           verify)
               }
             } yield {
               val (diff, carry, updatedMdConstraint) = r

--- a/src/main/scala/com/wavesplatform/state/appender/BlockAppender.scala
+++ b/src/main/scala/com/wavesplatform/state/appender/BlockAppender.scala
@@ -28,12 +28,13 @@ object BlockAppender extends ScorexLogging with Instrumented {
             utxStorage: UtxPool,
             pos: PoSSelector,
             settings: WavesSettings,
-            scheduler: Scheduler)(newBlock: Block): Task[Either[ValidationError, Option[BigInt]]] =
+            scheduler: Scheduler,
+            verify: Boolean = true)(newBlock: Block): Task[Either[ValidationError, Option[BigInt]]] =
     Task {
       measureSuccessful(
         blockProcessingTimeStats, {
           if (blockchainUpdater.isLastBlockId(newBlock.reference)) {
-            appendBlock(checkpoint, blockchainUpdater, utxStorage, pos, time, settings)(newBlock).map(_ => Some(blockchainUpdater.score))
+            appendBlock(checkpoint, blockchainUpdater, utxStorage, pos, time, settings, verify)(newBlock).map(_ => Some(blockchainUpdater.score))
           } else if (blockchainUpdater.contains(newBlock.uniqueId)) {
             Right(None)
           } else {

--- a/src/main/scala/com/wavesplatform/state/appender/MicroblockAppender.scala
+++ b/src/main/scala/com/wavesplatform/state/appender/MicroblockAppender.scala
@@ -20,8 +20,11 @@ import scala.util.{Left, Right}
 
 object MicroblockAppender extends ScorexLogging with Instrumented {
 
-  def apply(checkpoint: CheckpointService, blockchainUpdater: BlockchainUpdater with Blockchain, utxStorage: UtxPool, scheduler: Scheduler)(
-      microBlock: MicroBlock): Task[Either[ValidationError, Unit]] =
+  def apply(checkpoint: CheckpointService,
+            blockchainUpdater: BlockchainUpdater with Blockchain,
+            utxStorage: UtxPool,
+            scheduler: Scheduler,
+            verify: Boolean = true)(microBlock: MicroBlock): Task[Either[ValidationError, Unit]] =
     Task(
       measureSuccessful(
         microblockProcessingTimeStats,
@@ -31,7 +34,7 @@ object MicroblockAppender extends ScorexLogging with Instrumented {
             (),
             MicroBlockAppendError(s"[h = ${blockchainUpdater.height + 1}] is not valid with respect to checkpoint", microBlock)
           )
-          _ <- blockchainUpdater.processMicroBlock(microBlock)
+          _ <- blockchainUpdater.processMicroBlock(microBlock, verify)
         } yield utxStorage.removeAll(microBlock.transactionData)
       )).executeOn(scheduler)
 

--- a/src/main/scala/com/wavesplatform/state/appender/package.scala
+++ b/src/main/scala/com/wavesplatform/state/appender/package.scala
@@ -53,6 +53,19 @@ package object appender extends ScorexLogging {
                                     utxStorage: UtxPool,
                                     pos: PoSSelector,
                                     time: Time,
+                                    settings: WavesSettings,
+                                    verify: Boolean)(block: Block): Either[ValidationError, Option[Int]] = {
+    val append =
+      if (verify) appendBlock(checkpoint, blockchainUpdater, utxStorage, pos, time, settings) _
+      else appendBlock(blockchainUpdater, utxStorage, verify = false) _
+    append(block)
+  }
+
+  private[appender] def appendBlock(checkpoint: CheckpointService,
+                                    blockchainUpdater: BlockchainUpdater with Blockchain,
+                                    utxStorage: UtxPool,
+                                    pos: PoSSelector,
+                                    time: Time,
                                     settings: WavesSettings)(block: Block): Either[ValidationError, Option[Int]] =
     for {
       _ <- Either.cond(
@@ -77,14 +90,17 @@ package object appender extends ScorexLogging {
           s"generator's effective balance $balance is less that required for generation"
         )
       }
-      baseHeight = blockchainUpdater.height
-      maybeDiscardedTxs <- blockchainUpdater.processBlock(block)
-    } yield {
+      baseHeight <- appendBlock(blockchainUpdater, utxStorage, verify = true)(block)
+    } yield baseHeight
+
+  private[appender] def appendBlock(blockchainUpdater: BlockchainUpdater with Blockchain, utxStorage: UtxPool, verify: Boolean)(
+      block: Block): Either[ValidationError, Option[Int]] =
+    blockchainUpdater.processBlock(block, verify).map { maybeDiscardedTxs =>
       utxStorage.removeAll(block.transactionData)
       utxStorage.batched { ops =>
         maybeDiscardedTxs.toSeq.flatten.foreach(ops.putIfNew)
       }
-      maybeDiscardedTxs.map(_ => baseHeight)
+      maybeDiscardedTxs.map(_ => blockchainUpdater.height)
     }
 
   private def blockConsensusValidation(blockchain: Blockchain, settings: WavesSettings, pos: PoSSelector, currentTs: Long, block: Block)(

--- a/src/main/scala/com/wavesplatform/state/diffs/TransactionDiffer.scala
+++ b/src/main/scala/com/wavesplatform/state/diffs/TransactionDiffer.scala
@@ -20,7 +20,18 @@ object TransactionDiffer extends Instrumented with ScorexLogging {
 
   case class TransactionValidationError(cause: ValidationError, tx: Transaction) extends ValidationError
 
-  def apply(settings: FunctionalitySettings, prevBlockTimestamp: Option[Long], currentBlockTimestamp: Long, currentBlockHeight: Int)(
+  def apply(settings: FunctionalitySettings,
+            prevBlockTimestamp: Option[Long],
+            currentBlockTimestamp: Long,
+            currentBlockHeight: Int,
+            verify: Boolean = true)(blockchain: Blockchain, tx: Transaction): Either[ValidationError, Diff] = {
+    val func =
+      if (verify) verified(settings, prevBlockTimestamp, currentBlockTimestamp, currentBlockHeight) _
+      else unverified(settings, currentBlockTimestamp, currentBlockHeight) _
+    func(blockchain, tx)
+  }
+
+  def verified(settings: FunctionalitySettings, prevBlockTimestamp: Option[Long], currentBlockTimestamp: Long, currentBlockHeight: Int)(
       blockchain: Blockchain,
       tx: Transaction): Either[ValidationError, Diff] = {
     for {
@@ -36,31 +47,37 @@ object TransactionDiffer extends Instrumented with ScorexLogging {
             _ <- CommonValidation.checkFee(blockchain, settings, currentBlockHeight, tx)
           } yield ()
         }
-      diff <- stats.transactionDiffValidation.measureForType(tx.builder.typeId) {
-        tx match {
-          case gtx: GenesisTransaction      => GenesisTransactionDiff(currentBlockHeight)(gtx)
-          case ptx: PaymentTransaction      => PaymentTransactionDiff(blockchain, currentBlockHeight, settings, currentBlockTimestamp)(ptx)
-          case itx: IssueTransaction        => AssetTransactionsDiff.issue(currentBlockHeight)(itx)
-          case rtx: ReissueTransaction      => AssetTransactionsDiff.reissue(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(rtx)
-          case btx: BurnTransaction         => AssetTransactionsDiff.burn(blockchain, currentBlockHeight)(btx)
-          case ttx: TransferTransaction     => TransferTransactionDiff(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(ttx)
-          case mtx: MassTransferTransaction => MassTransferTransactionDiff(blockchain, currentBlockTimestamp, currentBlockHeight)(mtx)
-          case ltx: LeaseTransaction        => LeaseTransactionsDiff.lease(blockchain, currentBlockHeight)(ltx)
-          case ltx: LeaseCancelTransaction  => LeaseTransactionsDiff.leaseCancel(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(ltx)
-          case etx: ExchangeTransaction     => ExchangeTransactionDiff(blockchain, currentBlockHeight)(etx)
-          case atx: CreateAliasTransaction  => CreateAliasTransactionDiff(blockchain, currentBlockHeight)(atx)
-          case dtx: DataTransaction         => DataTransactionDiff(blockchain, currentBlockHeight)(dtx)
-          case sstx: SetScriptTransaction   => SetScriptTransactionDiff(blockchain, currentBlockHeight)(sstx)
-          case sstx: SetAssetScriptTransaction =>
-            AssetTransactionsDiff.setAssetScript(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(sstx)
-          case stx: SponsorFeeTransaction => AssetTransactionsDiff.sponsor(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(stx)
-          case _                          => Left(UnsupportedTransactionType)
-        }
-      }
+      diff <- unverified(settings, currentBlockTimestamp, currentBlockHeight)(blockchain, tx)
       positiveDiff <- stats.balanceValidation
         .measureForType(tx.builder.typeId) {
           BalanceDiffValidation(blockchain, currentBlockHeight, settings)(diff)
         }
     } yield positiveDiff
   }.left.map(TransactionValidationError(_, tx))
+
+  def unverified(settings: FunctionalitySettings, currentBlockTimestamp: Long, currentBlockHeight: Int)(
+      blockchain: Blockchain,
+      tx: Transaction): Either[ValidationError, Diff] = {
+    stats.transactionDiffValidation.measureForType(tx.builder.typeId) {
+      tx match {
+        case gtx: GenesisTransaction      => GenesisTransactionDiff(currentBlockHeight)(gtx)
+        case ptx: PaymentTransaction      => PaymentTransactionDiff(blockchain, currentBlockHeight, settings, currentBlockTimestamp)(ptx)
+        case itx: IssueTransaction        => AssetTransactionsDiff.issue(currentBlockHeight)(itx)
+        case rtx: ReissueTransaction      => AssetTransactionsDiff.reissue(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(rtx)
+        case btx: BurnTransaction         => AssetTransactionsDiff.burn(blockchain, currentBlockHeight)(btx)
+        case ttx: TransferTransaction     => TransferTransactionDiff(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(ttx)
+        case mtx: MassTransferTransaction => MassTransferTransactionDiff(blockchain, currentBlockTimestamp, currentBlockHeight)(mtx)
+        case ltx: LeaseTransaction        => LeaseTransactionsDiff.lease(blockchain, currentBlockHeight)(ltx)
+        case ltx: LeaseCancelTransaction  => LeaseTransactionsDiff.leaseCancel(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(ltx)
+        case etx: ExchangeTransaction     => ExchangeTransactionDiff(blockchain, currentBlockHeight)(etx)
+        case atx: CreateAliasTransaction  => CreateAliasTransactionDiff(blockchain, currentBlockHeight)(atx)
+        case dtx: DataTransaction         => DataTransactionDiff(blockchain, currentBlockHeight)(dtx)
+        case sstx: SetScriptTransaction   => SetScriptTransactionDiff(blockchain, currentBlockHeight)(sstx)
+        case sstx: SetAssetScriptTransaction =>
+          AssetTransactionsDiff.setAssetScript(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(sstx)
+        case stx: SponsorFeeTransaction => AssetTransactionsDiff.sponsor(blockchain, settings, currentBlockTimestamp, currentBlockHeight)(stx)
+        case _                          => Left(UnsupportedTransactionType)
+      }
+    }
+  }
 }

--- a/src/main/scala/com/wavesplatform/transaction/BlockchainUpdater.scala
+++ b/src/main/scala/com/wavesplatform/transaction/BlockchainUpdater.scala
@@ -6,9 +6,9 @@ import com.wavesplatform.block.Block.BlockId
 import com.wavesplatform.block.{Block, MicroBlock}
 
 trait BlockchainUpdater {
-  def processBlock(block: Block): Either[ValidationError, Option[DiscardedTransactions]]
+  def processBlock(block: Block, verify: Boolean = true): Either[ValidationError, Option[DiscardedTransactions]]
 
-  def processMicroBlock(microBlock: MicroBlock): Either[ValidationError, Unit]
+  def processMicroBlock(microBlock: MicroBlock, verify: Boolean = true): Either[ValidationError, Unit]
 
   def removeAfter(blockId: ByteStr): Either[ValidationError, DiscardedBlocks]
 


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-1322
Changes:
* When miner mines a microblock, there's no need to validate it again before appending (see Miner.scala)
* In Importer, I'm adding the `-no-verify` or `-n` option that turns transaction validation off (see Importer.scala)
* The rest of changes is needed to pass the `verify` flag to TransactionDiffer where validation is done