### PR TITLE
NODE-1269 Transaction put to UTX but not in blockchain if tx is more than 1,5 hours old

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -384,8 +384,6 @@ waves {
   utx {
     # Pool size
     max-size = 100000
-    # Evict transaction from UTX pool after it gets older than specified
-    max-transaction-age = 90m
     # Utx cleanup task interval
     cleanup-interval = 5m
     # Blacklist transactions from these addresses (Base58 strings)

--- a/src/main/scala/com/wavesplatform/settings/UtxSettings.scala
+++ b/src/main/scala/com/wavesplatform/settings/UtxSettings.scala
@@ -3,7 +3,6 @@ package com.wavesplatform.settings
 import scala.concurrent.duration.FiniteDuration
 
 case class UtxSettings(maxSize: Int,
-                       maxTransactionAge: FiniteDuration,
                        blacklistSenderAddresses: Set[String],
                        allowBlacklistedTransferTo: Set[String],
                        cleanupInterval: FiniteDuration,

--- a/src/main/scala/com/wavesplatform/utx/UtxPoolImpl.scala
+++ b/src/main/scala/com/wavesplatform/utx/UtxPoolImpl.scala
@@ -11,7 +11,7 @@ import com.wavesplatform.consensus.TransactionsOrdering
 import com.wavesplatform.metrics.Instrumented
 import com.wavesplatform.mining.MultiDimensionalMiningConstraint
 import com.wavesplatform.settings.{FunctionalitySettings, UtxSettings}
-import com.wavesplatform.state.diffs.TransactionDiffer
+import com.wavesplatform.state.diffs.{CommonValidation, TransactionDiffer}
 import com.wavesplatform.state.reader.CompositeBlockchain.composite
 import com.wavesplatform.state.{Blockchain, ByteStr, Diff, Portfolio}
 import com.wavesplatform.transaction.ValidationError.{GenericError, SenderIsBlacklisted}
@@ -60,7 +60,7 @@ class UtxPoolImpl(time: Time, blockchain: Blockchain, fs: FunctionalitySettings,
   private val putRequestStats     = Kamon.counter("utx-pool-put-if-new")
 
   private def removeExpired(currentTs: Long): Unit = {
-    def isExpired(tx: Transaction) = (currentTs - tx.timestamp).millis > utxSettings.maxTransactionAge
+    def isExpired(tx: Transaction) = (currentTs - tx.timestamp).millis > CommonValidation.MaxTimePrevBlockOverTransactionDiff
 
     transactions.values.asScala
       .collect {

--- a/src/test/scala/com/wavesplatform/settings/UTXSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/UTXSettingsSpecification.scala
@@ -12,7 +12,6 @@ class UTXSettingsSpecification extends FlatSpec with Matchers {
     val config   = ConfigFactory.parseString("""waves {
         |  utx {
         |    max-size = 100
-        |    max-transaction-age = 100m
         |    cleanup-interval = 10m
         |    blacklist-sender-addresses = ["a"]
         |    allow-blacklisted-transfer-to = ["b"]
@@ -21,7 +20,6 @@ class UTXSettingsSpecification extends FlatSpec with Matchers {
         |}""".stripMargin).resolve()
     val settings = config.as[UtxSettings]("waves.utx")
     settings.maxSize should be(100)
-    settings.maxTransactionAge shouldBe 100.minutes
     settings.cleanupInterval shouldBe 10.minutes
     settings.blacklistSenderAddresses shouldBe Set("a")
     settings.allowBlacklistedTransferTo shouldBe Set("b")

--- a/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
+++ b/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration._
 
 class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with PropertyChecks with TransactionGen with NoShrink with WithDB {
 
-  import CommonValidation.{ScriptExtraFee => extraFee}
+  import CommonValidation.{MaxTimePrevBlockOverTransactionDiff => maxAge, ScriptExtraFee => extraFee}
 
   private def mkBlockchain(senderAccount: Address, senderBalance: Long) = {
     val config          = ConfigFactory.load()
@@ -103,7 +103,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
         time,
         bcu,
         FunctionalitySettings.TESTNET,
-        UtxSettings(10, 10.minutes, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
+        UtxSettings(10, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
       )
     val amountPart = (senderBalance - fee) / 2 - fee
     val txs        = for (_ <- 1 to n) yield createWavesTransfer(sender, recipient, amountPart, fee, time.getTimestamp()).explicitGet()
@@ -119,7 +119,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
             time,
             bcu,
             FunctionalitySettings.TESTNET,
-            UtxSettings(10, 1.minute, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
+            UtxSettings(10, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
           )
         (sender, bcu, utxPool)
     }
@@ -131,7 +131,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
     time = new TestTime()
     txs <- Gen.nonEmptyListOf(transferWithRecipient(sender, recipient, senderBalance / 10, time))
   } yield {
-    val settings = UtxSettings(10, 1.minute, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
+    val settings = UtxSettings(10, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
     val utxPool  = new UtxPoolImpl(time, bcu, FunctionalitySettings.TESTNET, settings)
     txs.foreach(utxPool.putIfNew)
     (sender, bcu, utxPool, time, settings)
@@ -143,7 +143,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
     time = new TestTime()
     txs <- Gen.nonEmptyListOf(transferWithRecipient(sender, recipient, senderBalance / 10, time)) // @TODO: Random transactions
   } yield {
-    val settings = UtxSettings(10, 1.minute, Set(sender.address), Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
+    val settings = UtxSettings(10, Set(sender.address), Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
     val utxPool  = new UtxPoolImpl(time, bcu, FunctionalitySettings.TESTNET, settings)
     (sender, utxPool, txs)
   }).label("withBlacklisted")
@@ -155,7 +155,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
     txs <- Gen.nonEmptyListOf(transferWithRecipient(sender, recipient, senderBalance / 10, time)) // @TODO: Random transactions
   } yield {
     val settings =
-      UtxSettings(txs.length, 1.minute, Set(sender.address), Set(recipient.address), 5.minutes, allowTransactionsFromSmartAccounts = true)
+      UtxSettings(txs.length, Set(sender.address), Set(recipient.address), 5.minutes, allowTransactionsFromSmartAccounts = true)
     val utxPool = new UtxPoolImpl(time, bcu, FunctionalitySettings.TESTNET, settings)
     (sender, utxPool, txs)
   }).label("withBlacklistedAndAllowedByRule")
@@ -169,13 +169,12 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
       txs <- Gen.nonEmptyListOf(massTransferWithRecipients(sender, recipients, senderBalance / 10, time))
     } yield {
       val whitelist: Set[String] = if (allowRecipients) recipients.map(_.address).toSet else Set.empty
-      val settings               = UtxSettings(txs.length, 1.minute, Set(sender.address), whitelist, 5.minutes, allowTransactionsFromSmartAccounts = true)
+      val settings               = UtxSettings(txs.length, Set(sender.address), whitelist, 5.minutes, allowTransactionsFromSmartAccounts = true)
       val utxPool                = new UtxPoolImpl(time, bcu, FunctionalitySettings.TESTNET, settings)
       (sender, utxPool, txs)
     }).label("massTransferWithBlacklisted")
 
-  private def utxTest(utxSettings: UtxSettings =
-                        UtxSettings(20, 5.seconds, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true),
+  private def utxTest(utxSettings: UtxSettings = UtxSettings(20, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true),
                       txCount: Int = 10)(f: (Seq[TransferTransactionV1], UtxPool, TestTime) => Unit): Unit =
     forAll(stateGen, chooseNum(2, txCount).label("txCount")) {
       case ((sender, senderBalance, bcu), count) =>
@@ -187,23 +186,22 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
         }
     }
 
-  private val dualTxGen: Gen[(UtxPool, TestTime, Seq[Transaction], FiniteDuration, Seq[Transaction])] =
+  private val dualTxGen: Gen[(UtxPool, TestTime, Seq[Transaction], Seq[Transaction])] =
     for {
       (sender, senderBalance, bcu) <- stateGen
       ts = System.currentTimeMillis()
       count1 <- chooseNum(5, 10)
       tx1    <- listOfN(count1, transfer(sender, senderBalance / 2, new TestTime(ts)))
-      offset <- chooseNum(5000L, 10000L)
-      tx2    <- listOfN(count1, transfer(sender, senderBalance / 2, new TestTime(ts + offset + 1000)))
+      tx2    <- listOfN(count1, transfer(sender, senderBalance / 2, new TestTime(ts + maxAge.toMillis + 1000)))
     } yield {
       val time = new TestTime()
       val utx = new UtxPoolImpl(
         time,
         bcu,
         FunctionalitySettings.TESTNET,
-        UtxSettings(10, offset.millis, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
+        UtxSettings(10, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)
       )
-      (utx, time, tx1, (offset + 1000).millis, tx2)
+      (utx, time, tx1, tx2)
     }
 
   private val expr: EXPR = {
@@ -238,7 +236,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
         new TestTime(),
         bcu,
         smartAccountsFs,
-        UtxSettings(10, 1.day, Set.empty, Set.empty, 1.day, allowTransactionsFromSmartAccounts = scEnabled)
+        UtxSettings(10, Set.empty, Set.empty, 1.day, allowTransactionsFromSmartAccounts = scEnabled)
       )
 
       (sender, senderBalance, utx, bcu.lastBlock.fold(0L)(_.timestamp))
@@ -253,10 +251,10 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
   }
 
   "UTX Pool" - {
-    "does not add new transactions when full" in utxTest(
-      UtxSettings(1, 5.seconds, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)) { (txs, utx, _) =>
-      utx.putIfNew(txs.head) shouldBe 'right
-      all(txs.tail.map(t => utx.putIfNew(t))) should produce("pool size limit")
+    "does not add new transactions when full" in utxTest(UtxSettings(1, Set.empty, Set.empty, 5.minutes, allowTransactionsFromSmartAccounts = true)) {
+      (txs, utx, _) =>
+        utx.putIfNew(txs.head) shouldBe 'right
+        all(txs.tail.map(t => utx.putIfNew(t))) should produce("pool size limit")
     }
 
     "does not broadcast the same transaction twice" in utxTest() { (txs, utx, _) =>
@@ -265,11 +263,11 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
     }
 
     "evicts expired transactions when removeAll is called" in forAll(dualTxGen) {
-      case (utx, time, txs1, offset, txs2) =>
+      case (utx, time, txs1, txs2) =>
         all(txs1.map(utx.putIfNew)) shouldBe 'right
         utx.all.size shouldEqual txs1.size
 
-        time.advance(offset)
+        time.advance(maxAge + 1000.millis)
         utx.removeAll(Seq.empty)
 
         all(txs2.map(utx.putIfNew)) shouldBe 'right
@@ -277,7 +275,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
     }
 
     "packUnconfirmed result is limited by constraint" in forAll(dualTxGen) {
-      case (utx, time, txs, _, _) =>
+      case (utx, time, txs, _) =>
         all(txs.map(utx.putIfNew)) shouldBe 'right
         utx.all.size shouldEqual txs.size
 
@@ -290,11 +288,11 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
     }
 
     "evicts expired transactions when packUnconfirmed is called" in forAll(dualTxGen) {
-      case (utx, time, txs, offset, _) =>
+      case (utx, time, txs, _) =>
         all(txs.map(utx.putIfNew)) shouldBe 'right
         utx.all.size shouldEqual txs.size
 
-        time.advance(offset)
+        time.advance(maxAge + 1000.millis)
 
         val (packed, _) = utx.packUnconfirmed(limitByNumber(100))
         packed shouldBe 'empty
@@ -346,7 +344,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
           val utxPortfolioBefore = utxPool.portfolio(sender)
           val poolSizeBefore     = utxPool.size
 
-          time.advance(settings.maxTransactionAge * 2)
+          time.advance(CommonValidation.MaxTimePrevBlockOverTransactionDiff * 2)
           utxPool.packUnconfirmed(limitByNumber(100))
 
           poolSizeBefore should be > utxPool.size


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-1269
The setting `waves.utx.max-transaction-age` duplicates the `CommonValidation.MaxTimePrevBlockOverTransactionDiff` consensus constant. These two have different values: 90 minutes vs 2 hours, hence the bug.

I suggest to remove the setting and use the constant everywhere instead.