### PR TITLE
NODE-1341 Customize status code of /debug/rollback

### DIFF
--- a/src/main/scala/com/wavesplatform/http/DebugApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/http/DebugApiRoute.scala
@@ -32,6 +32,7 @@ import monix.eval.{Coeval, Task}
 import play.api.libs.json._
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
@@ -193,7 +194,7 @@ case class DebugApiRoute(ws: WavesSettings,
     Array(
       new ApiResponse(code = 200, message = "200 if success, 404 if there are no block at this height")
     ))
-  def rollback: Route = (path("rollback") & post & withAuth) {
+  def rollback: Route = (path("rollback") & post & withAuth & withRequestTimeout(15.minutes)) {
     json[RollbackParams] { params =>
       ng.blockAt(params.rollbackTo) match {
         case Some(block) =>


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-1341
There are two relevant timeout settings:
* Request timeout can be set individually for each Akka endpoint. I'm setting request timeout for `/debug/rollback` to 15 minutes here
* Idle timeout is an Akka global setting. Can be configured using the `akka.http.server.idle-timeout` parameter