### PR TITLE
NODE-1269 Moved transaction back/forward time offsets into config params

### DIFF
--- a/it/src/main/resources/template.conf
+++ b/it/src/main/resources/template.conf
@@ -40,6 +40,8 @@ waves {
           10 = 0
         }
         double-features-periods-after-height = 100000000
+        max-transaction-time-back-offset = 120m
+        max-transaction-time-forward-offset = 90m
       }
       genesis {
         average-block-delay = 10s

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/DataTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/DataTransactionSuite.scala
@@ -51,7 +51,7 @@ class DataTransactionSuite extends BaseTransactionSuite {
 
     val (balance1, eff1) = notMiner.accountBalances(firstAddress)
     val invalidTxs = Seq(
-      (data(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction .* is from far future"),
+      (data(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction timestamp .* is more than .*ms in the future"),
       (data(fee = 99999), "Fee .* does not exceed minimal value")
     )
 
@@ -259,7 +259,7 @@ class DataTransactionSuite extends BaseTransactionSuite {
   }
 
   test("try to make address with 1000 DataEntries") {
-    val dataSet = 0 to 200 flatMap (i =>
+    val dataSet = 0 until 200 flatMap (i =>
       List(
         IntegerDataEntry(s"int$i", 1000 + i),
         BooleanDataEntry(s"bool$i", false),
@@ -268,14 +268,8 @@ class DataTransactionSuite extends BaseTransactionSuite {
         IntegerDataEntry(s"integer$i", 1000 - i)
       ))
 
-    val dataAllTypes = dataSet.toList
-
-    for (i <- 0 to 900 by 100) {
-      val dataTx = dataAllTypes.slice(i, i + 100)
-      val fee    = calcDataFee(dataTx)
-      val txId   = sender.putData(thirdAddress, dataTx, fee).id
-      nodes.waitForHeightAriseAndTxPresent(txId)
-    }
+    val txIds = dataSet.grouped(100).map(_.toList).map(data => sender.putData(thirdAddress, data, calcDataFee(data)).id)
+    txIds foreach nodes.waitForTransaction
 
     val r = scala.util.Random.nextInt(199)
     sender.getData(thirdAddress, s"int$r") shouldBe IntegerDataEntry(s"int$r", 1000 + r)

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/MassTransferTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/MassTransferTransactionSuite.scala
@@ -126,7 +126,7 @@ class MassTransferTransactionSuite extends BaseTransactionSuite with CancelAfter
 
     val (balance1, eff1) = notMiner.accountBalances(firstAddress)
     val invalidTransfers = Seq(
-      (request(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction .* is from far future"),
+      (request(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction timestamp .* is more than .*ms in the future"),
       (request(transfers = List.fill(MaxTransferCount + 1)(Transfer(secondAddress, 1)), fee = calcMassTransferFee(MaxTransferCount + 1)),
        s"Number of transfers ${MaxTransferCount + 1} is greater than 100"),
       (request(transfers = List(Transfer(secondAddress, -1))), "One of the transfers has negative amount"),

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/SetAssetScriptTransactionSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/SetAssetScriptTransactionSuite.scala
@@ -170,7 +170,7 @@ class SetAssetScriptTransactionSuite extends BaseTransactionSuite {
     val (balance, eff) = notMiner.accountBalances(firstAddress)
 
     val invalidTxs = Seq(
-      (sastx(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction .* is from far future"),
+      (sastx(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction timestamp .* is more than .*ms in the future"),
       (sastx(fee = 9999999), "Fee .* does not exceed minimal value"),
       (sastx(assetId = ByteStr.decodeBase58("9ekQuYn92natMnMq8KqeGK3Nn7cpKd3BvPEGgD6fFyyz9ekQuYn92natMnMq8").get), "invalid.assetId"),
       (sastx(assetId = ByteStr.decodeBase58("9ekQuYn92natMnMq8KqeGK3Nn7cpKd3BvPEGgD6fFyyz").get), "Referenced assetId not found")

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/SponsorshipSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/SponsorshipSuite.scala
@@ -89,7 +89,7 @@ class SponsorshipSuite extends FreeSpec with NodesFromDocker with Matchers with 
             .get
 
         val iTx = invalidTx(timestamp = System.currentTimeMillis + 1.day.toMillis)
-        assertBadRequestAndResponse(sponsor.broadcastRequest(iTx.json()), "Transaction .* is from far future")
+        assertBadRequestAndResponse(sponsor.broadcastRequest(iTx.json()), "Transaction timestamp .* is more than .*ms in the future")
       }
     }
 

--- a/it/src/test/scala/com/wavesplatform/it/sync/transactions/TransferTransactionV1Suite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/transactions/TransferTransactionV1Suite.scala
@@ -54,7 +54,7 @@ class TransferTransactionV1Suite extends BaseTransactionSuite with CancelAfterFa
     val (balance1, eff1) = notMiner.accountBalances(firstAddress)
 
     val invalidTxs = Seq(
-      (invalidTx(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction .* is from far future"),
+      (invalidTx(timestamp = System.currentTimeMillis + 1.day.toMillis), "Transaction timestamp .* is more than .*ms in the future"),
       (invalidTx(fee = 99999), "Fee .* does not exceed minimal value")
     )
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -162,6 +162,8 @@ waves {
     #          1 = 100
     #          2 = 200
     #        }
+    #        max-transaction-time-back-offset = 120m
+    #        max-transaction-time-forward-offset = 90m
     #      }
     #
     #      # List of genesis transactions

--- a/src/main/scala/com/wavesplatform/settings/BlockchainSettings.scala
+++ b/src/main/scala/com/wavesplatform/settings/BlockchainSettings.scala
@@ -20,7 +20,9 @@ case class FunctionalitySettings(featureCheckBlocksPeriod: Int,
                                  resetEffectiveBalancesAtHeight: Int,
                                  blockVersion3AfterHeight: Int,
                                  preActivatedFeatures: Map[Short, Int],
-                                 doubleFeaturesPeriodsAfterHeight: Int) {
+                                 doubleFeaturesPeriodsAfterHeight: Int,
+                                 maxTransactionTimeBackOffset: FiniteDuration,
+                                 maxTransactionTimeForwardOffset: FiniteDuration) {
   val allowLeasedBalanceTransferUntilHeight: Int = blockVersion3AfterHeight
 
   require(featureCheckBlocksPeriod > 0, "featureCheckBlocksPeriod must be greater than 0")
@@ -60,7 +62,9 @@ object FunctionalitySettings {
     resetEffectiveBalancesAtHeight = 462000,
     blockVersion3AfterHeight = 795000,
     preActivatedFeatures = Map.empty,
-    doubleFeaturesPeriodsAfterHeight = 810000
+    doubleFeaturesPeriodsAfterHeight = 810000,
+    maxTransactionTimeBackOffset = 120.minutes,
+    maxTransactionTimeForwardOffset = 90.minutes
   )
 
   val TESTNET = apply(
@@ -76,7 +80,9 @@ object FunctionalitySettings {
     resetEffectiveBalancesAtHeight = 51500,
     blockVersion3AfterHeight = 161700,
     preActivatedFeatures = Map.empty,
-    doubleFeaturesPeriodsAfterHeight = Int.MaxValue
+    doubleFeaturesPeriodsAfterHeight = Int.MaxValue,
+    maxTransactionTimeBackOffset = 120.minutes,
+    maxTransactionTimeForwardOffset = 90.minutes
   )
 
   val configPath = "waves.blockchain.custom.functionality"

--- a/src/main/scala/com/wavesplatform/state/diffs/TransactionDiffer.scala
+++ b/src/main/scala/com/wavesplatform/state/diffs/TransactionDiffer.scala
@@ -40,7 +40,7 @@ object TransactionDiffer extends Instrumented with ScorexLogging {
         .measureForType(tx.builder.typeId) {
           for {
             _ <- CommonValidation.disallowTxFromFuture(settings, currentBlockTimestamp, tx)
-            _ <- CommonValidation.disallowTxFromPast(prevBlockTimestamp, tx)
+            _ <- CommonValidation.disallowTxFromPast(settings, prevBlockTimestamp, tx)
             _ <- CommonValidation.disallowBeforeActivationTime(blockchain, currentBlockHeight, tx)
             _ <- CommonValidation.disallowDuplicateIds(blockchain, settings, currentBlockHeight, tx)
             _ <- CommonValidation.disallowSendingGreaterThanBalance(blockchain, settings, currentBlockTimestamp, tx)

--- a/src/main/scala/com/wavesplatform/utx/UtxPoolImpl.scala
+++ b/src/main/scala/com/wavesplatform/utx/UtxPoolImpl.scala
@@ -11,7 +11,7 @@ import com.wavesplatform.consensus.TransactionsOrdering
 import com.wavesplatform.metrics.Instrumented
 import com.wavesplatform.mining.MultiDimensionalMiningConstraint
 import com.wavesplatform.settings.{FunctionalitySettings, UtxSettings}
-import com.wavesplatform.state.diffs.{CommonValidation, TransactionDiffer}
+import com.wavesplatform.state.diffs.TransactionDiffer
 import com.wavesplatform.state.reader.CompositeBlockchain.composite
 import com.wavesplatform.state.{Blockchain, ByteStr, Diff, Portfolio}
 import com.wavesplatform.transaction.ValidationError.{GenericError, SenderIsBlacklisted}
@@ -60,7 +60,7 @@ class UtxPoolImpl(time: Time, blockchain: Blockchain, fs: FunctionalitySettings,
   private val putRequestStats     = Kamon.counter("utx-pool-put-if-new")
 
   private def removeExpired(currentTs: Long): Unit = {
-    def isExpired(tx: Transaction) = (currentTs - tx.timestamp).millis > CommonValidation.MaxTimePrevBlockOverTransactionDiff
+    def isExpired(tx: Transaction) = (currentTs - tx.timestamp).millis > fs.maxTransactionTimeBackOffset
 
     transactions.values.asScala
       .collect {

--- a/src/test/scala/com/wavesplatform/settings/BlockchainSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/BlockchainSettingsSpecification.scala
@@ -32,6 +32,8 @@ class BlockchainSettingsSpecification extends FlatSpec with Matchers {
         |          20 = 200
         |        }
         |        double-features-periods-after-height = 21
+        |        max-transaction-time-back-offset = 55s
+        |        max-transaction-time-forward-offset = 12d
         |      }
         |      genesis {
         |        timestamp = 1460678400000
@@ -64,6 +66,8 @@ class BlockchainSettingsSpecification extends FlatSpec with Matchers {
     settings.functionalitySettings.blockVersion3AfterHeight should be(18)
     settings.functionalitySettings.preActivatedFeatures should be(Map(19 -> 100, 20 -> 200))
     settings.functionalitySettings.doubleFeaturesPeriodsAfterHeight should be(21)
+    settings.functionalitySettings.maxTransactionTimeBackOffset should be(55.seconds)
+    settings.functionalitySettings.maxTransactionTimeForwardOffset should be(12.days)
     settings.genesisSettings.blockTimestamp should be(1460678400000L)
     settings.genesisSettings.timestamp should be(1460678400000L)
     settings.genesisSettings.signature should be(ByteStr.decodeBase58("BASE58BLKSGNATURE").toOption)
@@ -94,6 +98,8 @@ class BlockchainSettingsSpecification extends FlatSpec with Matchers {
     settings.functionalitySettings.allowMultipleLeaseCancelTransactionUntilTimestamp should be(1492560000000L)
     settings.functionalitySettings.resetEffectiveBalancesAtHeight should be(51500)
     settings.functionalitySettings.blockVersion3AfterHeight should be(161700)
+    settings.functionalitySettings.maxTransactionTimeBackOffset should be(120.minutes)
+    settings.functionalitySettings.maxTransactionTimeForwardOffset should be(90.minutes)
     settings.genesisSettings.blockTimestamp should be(1460678400000L)
     settings.genesisSettings.timestamp should be(1478000000000L)
     settings.genesisSettings.signature should be(
@@ -129,6 +135,8 @@ class BlockchainSettingsSpecification extends FlatSpec with Matchers {
     settings.functionalitySettings.allowInvalidReissueInSameBlockUntilTimestamp should be(1492768800000L)
     settings.functionalitySettings.allowMultipleLeaseCancelTransactionUntilTimestamp should be(1492768800000L)
     settings.functionalitySettings.resetEffectiveBalancesAtHeight should be(462000)
+    settings.functionalitySettings.maxTransactionTimeBackOffset should be(120.minutes)
+    settings.functionalitySettings.maxTransactionTimeForwardOffset should be(90.minutes)
     settings.genesisSettings.blockTimestamp should be(1460678400000L)
     settings.genesisSettings.timestamp should be(1465742577614L)
     settings.genesisSettings.signature should be(

--- a/src/test/scala/com/wavesplatform/settings/TestFunctionalitySettings.scala
+++ b/src/test/scala/com/wavesplatform/settings/TestFunctionalitySettings.scala
@@ -1,6 +1,7 @@
 package com.wavesplatform.settings
 
 import com.wavesplatform.features.BlockchainFeatures
+import scala.concurrent.duration._
 
 object TestFunctionalitySettings {
   val Enabled = FunctionalitySettings(
@@ -16,7 +17,9 @@ object TestFunctionalitySettings {
     resetEffectiveBalancesAtHeight = 0,
     blockVersion3AfterHeight = 0,
     preActivatedFeatures = Map(BlockchainFeatures.SmartAccounts.id -> 0, BlockchainFeatures.SmartAssets.id -> 0, BlockchainFeatures.FairPoS.id -> 0),
-    doubleFeaturesPeriodsAfterHeight = Int.MaxValue
+    doubleFeaturesPeriodsAfterHeight = Int.MaxValue,
+    maxTransactionTimeBackOffset = 120.minutes,
+    maxTransactionTimeForwardOffset = 90.minutes
   )
 
   val Stub: FunctionalitySettings = Enabled.copy(featureCheckBlocksPeriod = 100, blocksForFeatureActivation = 90)

--- a/src/test/scala/com/wavesplatform/state/diffs/BlockDifferTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/BlockDifferTest.scala
@@ -12,6 +12,7 @@ import com.wavesplatform.state.{Blockchain, Diff, EitherExt2}
 import com.wavesplatform.transaction.GenesisTransaction
 import org.scalatest.{FreeSpecLike, Matchers}
 import com.wavesplatform.crypto._
+import scala.concurrent.duration._
 
 class BlockDifferTest extends FreeSpecLike with Matchers with BlockGen with WithState {
 
@@ -123,7 +124,9 @@ class BlockDifferTest extends FreeSpecLike with Matchers with BlockGen with With
       resetEffectiveBalancesAtHeight = 0,
       blockVersion3AfterHeight = 0,
       preActivatedFeatures = Map[Short, Int]((2, ngAtHeight)),
-      doubleFeaturesPeriodsAfterHeight = Int.MaxValue
+      doubleFeaturesPeriodsAfterHeight = Int.MaxValue,
+      maxTransactionTimeBackOffset = 120.minutes,
+      maxTransactionTimeForwardOffset = 90.minutes
     )
     assertNgDiffState(blocks.init, blocks.last, fs)(assertion)
   }

--- a/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTimeTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTimeTest.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.state.diffs
 
 import com.wavesplatform.db.WithState
-import com.wavesplatform.settings.TestFunctionalitySettings
+import com.wavesplatform.settings.TestFunctionalitySettings.Enabled
 import com.wavesplatform.state._
 import com.wavesplatform.{NoShrink, TransactionGen}
 import org.scalacheck.Gen
@@ -19,12 +19,12 @@ class CommonValidationTimeTest extends PropSpec with PropertyChecks with Matcher
       recipient   <- accountGen
       amount      <- positiveLongGen
       fee         <- smallFeeGen
-      transfer1 = createWavesTransfer(master, recipient, amount, fee, prevBlockTs - CommonValidation.MaxTimePrevBlockOverTransactionDiff.toMillis - 1)
+      transfer1 = createWavesTransfer(master, recipient, amount, fee, prevBlockTs - Enabled.maxTransactionTimeBackOffset.toMillis - 1)
         .explicitGet()
     } yield (prevBlockTs, blockTs, height, transfer1)) {
       case (prevBlockTs, blockTs, height, transfer1) =>
-        withStateAndHistory(TestFunctionalitySettings.Enabled) { blockchain: Blockchain =>
-          TransactionDiffer(TestFunctionalitySettings.Enabled, Some(prevBlockTs), blockTs, height)(blockchain, transfer1) should produce("too old")
+        withStateAndHistory(Enabled) { blockchain: Blockchain =>
+          TransactionDiffer(Enabled, Some(prevBlockTs), blockTs, height)(blockchain, transfer1) should produce("too old")
         }
     }
   }
@@ -38,11 +38,11 @@ class CommonValidationTimeTest extends PropSpec with PropertyChecks with Matcher
       recipient   <- accountGen
       amount      <- positiveLongGen
       fee         <- smallFeeGen
-      transfer1 = createWavesTransfer(master, recipient, amount, fee, blockTs + CommonValidation.MaxTimeTransactionOverBlockDiff.toMillis + 1)
+      transfer1 = createWavesTransfer(master, recipient, amount, fee, blockTs + Enabled.maxTransactionTimeForwardOffset.toMillis + 1)
         .explicitGet()
     } yield (prevBlockTs, blockTs, height, transfer1)) {
       case (prevBlockTs, blockTs, height, transfer1) =>
-        val functionalitySettings = TestFunctionalitySettings.Enabled.copy(allowTransactionsFromFutureUntil = blockTs - 1)
+        val functionalitySettings = Enabled.copy(allowTransactionsFromFutureUntil = blockTs - 1)
         withStateAndHistory(functionalitySettings) { blockchain: Blockchain =>
           TransactionDiffer(functionalitySettings, Some(prevBlockTs), blockTs, height)(blockchain, transfer1) should produce("far future")
         }

--- a/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTimeTest.scala
+++ b/src/test/scala/com/wavesplatform/state/diffs/CommonValidationTimeTest.scala
@@ -24,7 +24,8 @@ class CommonValidationTimeTest extends PropSpec with PropertyChecks with Matcher
     } yield (prevBlockTs, blockTs, height, transfer1)) {
       case (prevBlockTs, blockTs, height, transfer1) =>
         withStateAndHistory(Enabled) { blockchain: Blockchain =>
-          TransactionDiffer(Enabled, Some(prevBlockTs), blockTs, height)(blockchain, transfer1) should produce("too old")
+          TransactionDiffer(Enabled, Some(prevBlockTs), blockTs, height)(blockchain, transfer1) should
+            produce("in the past relative to previous block timestamp")
         }
     }
   }
@@ -44,7 +45,8 @@ class CommonValidationTimeTest extends PropSpec with PropertyChecks with Matcher
       case (prevBlockTs, blockTs, height, transfer1) =>
         val functionalitySettings = Enabled.copy(allowTransactionsFromFutureUntil = blockTs - 1)
         withStateAndHistory(functionalitySettings) { blockchain: Blockchain =>
-          TransactionDiffer(functionalitySettings, Some(prevBlockTs), blockTs, height)(blockchain, transfer1) should produce("far future")
+          TransactionDiffer(functionalitySettings, Some(prevBlockTs), blockTs, height)(blockchain, transfer1) should
+            produce("in the future relative to block timestamp")
         }
     }
   }

--- a/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
+++ b/src/test/scala/com/wavesplatform/utx/UtxPoolSpecification.scala
@@ -31,7 +31,8 @@ import scala.concurrent.duration._
 
 class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with PropertyChecks with TransactionGen with NoShrink with WithDB {
 
-  import CommonValidation.{MaxTimePrevBlockOverTransactionDiff => maxAge, ScriptExtraFee => extraFee}
+  import CommonValidation.{ScriptExtraFee => extraFee}
+  import FunctionalitySettings.TESTNET.{maxTransactionTimeBackOffset => maxAge}
 
   private def mkBlockchain(senderAccount: Address, senderBalance: Long) = {
     val config          = ConfigFactory.load()
@@ -344,7 +345,7 @@ class UtxPoolSpecification extends FreeSpec with Matchers with MockFactory with 
           val utxPortfolioBefore = utxPool.portfolio(sender)
           val poolSizeBefore     = utxPool.size
 
-          time.advance(CommonValidation.MaxTimePrevBlockOverTransactionDiff * 2)
+          time.advance(maxAge * 2)
           utxPool.packUnconfirmed(limitByNumber(100))
 
           poolSizeBefore should be > utxPool.size

--- a/waves-devnet.conf
+++ b/waves-devnet.conf
@@ -23,16 +23,20 @@ waves {
         reset-effective-balances-at-height = 4650
         block-version-3-after-height = 0
         pre-activated-features {
-          1 = 0
-          2 = 0
-          3 = 0
-          4 = 0
-          5 = 0
-          6 = 0
-          7 = 0
-          8 = 0
+          1  = 0
+          2  = 0
+          3  = 0
+          4  = 0
+          5  = 0
+          6  = 0
+          7  = 0
+          8  = 0
+          9  = 0
+          10 = 0
         }
         double-features-periods-after-height = 1000000000
+        max-transaction-time-back-offset = 120m
+        max-transaction-time-forward-offset = 90m
       }
       genesis {
         average-block-delay = 60000ms


### PR DESCRIPTION
JIRA: https://wavesplatform.atlassian.net/browse/NODE-1269
Moved two constants from `CommonValidation`:
```
  val MaxTimeTransactionOverBlockDiff: FiniteDuration     = 90.minutes
  val MaxTimePrevBlockOverTransactionDiff: FiniteDuration = 2.hours
```
into config parameters:
```
        max-transaction-time-back-offset = 120m
        max-transaction-time-forward-offset = 90m
```