### PR TITLE
DEX-202 Stop DEX when recovery fails

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -229,6 +229,12 @@ waves {
     # Make snapshots after recovery at start
     make-snapshots-at-start = no
 
+    # Maximum time to recover all order books from snapshots
+    snapshots-loading-timeout = 10m
+
+    # Maximum time to recover events those observed at start
+    start-events-processing-timeout = 20m
+
     # Maximum allowed amount of orders retrieved via REST
     rest-order-limit = 100
 
@@ -586,7 +592,7 @@ akka {
 
       # If enabled, log stack traces before waking up the KafkaConsumer to give
       # some indication why the KafkaConsumer is not honouring the `poll-timeout`
-      wakeup-debug = true
+      wakeup-debug = false
 
       # Fully qualified config path which holds the dispatcher configuration
       # to be used by the KafkaConsumerActor. Some blocking may occur.
@@ -615,7 +621,7 @@ akka {
       # Timeout for akka.kafka.Metadata requests
       # This value is used instead of Kafka's default from `default.api.timeout.ms`
       # which is 1 minute.
-      metadata-request-timeout = 5s
+      metadata-request-timeout = 1m
     }
 
     producer {

--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -106,7 +106,7 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
     maybeUtx = Some(utxStorage)
 
     matcher = if (settings.matcherSettings.enable) {
-      Matcher(actorSystem, time, wallet, utxStorage, allChannels, blockchainUpdater, portfolioChanged, settings, () => shutdownInProgress)
+      Matcher(actorSystem, time, wallet, utxStorage, allChannels, blockchainUpdater, portfolioChanged, settings)
     } else None
 
     val knownInvalidBlocks = new InvalidBlockStorageImpl(settings.synchronizationSettings.invalidBlocksStorage)
@@ -274,7 +274,7 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
         classOf[LeaseApiRoute],
         classOf[AliasApiRoute]
       )
-      val combinedRoute = CompositeHttpService(actorSystem, apiTypes, apiRoutes, settings.restAPISettings).loggingCompositeRoute
+      val combinedRoute = CompositeHttpService(apiTypes, apiRoutes, settings.restAPISettings)(actorSystem).loggingCompositeRoute
       val httpFuture    = Http().bindAndHandle(combinedRoute, settings.restAPISettings.bindAddress, settings.restAPISettings.port)
       serverBinding = Await.result(httpFuture, 20.seconds)
       log.info(s"REST API was bound on ${settings.restAPISettings.bindAddress}:${settings.restAPISettings.port}")

--- a/src/main/scala/com/wavesplatform/api/http/ApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/api/http/ApiRoute.scala
@@ -12,7 +12,7 @@ import play.api.libs.json.{JsResultException, Reads}
 
 trait ApiRoute extends Directives with CommonApiFunctions with ApiMarshallers {
   val settings: RestAPISettings
-  val route: Route
+  def route: Route
 
   private lazy val apiKeyHash = Base58.decode(settings.apiKeyHash).toOption
 

--- a/src/main/scala/com/wavesplatform/api/http/CompositeHttpService.scala
+++ b/src/main/scala/com/wavesplatform/api/http/CompositeHttpService.scala
@@ -9,11 +9,11 @@ import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LoggingMagnet}
 import akka.http.scaladsl.server.{Directive0, Route, RouteResult}
 import akka.stream.ActorMaterializer
-import com.wavesplatform.settings.RestAPISettings
 import com.wavesplatform.api.http.swagger.SwaggerDocService
+import com.wavesplatform.settings.RestAPISettings
 import com.wavesplatform.utils.ScorexLogging
 
-case class CompositeHttpService(system: ActorSystem, apiTypes: Set[Class[_]], routes: Seq[ApiRoute], settings: RestAPISettings)
+case class CompositeHttpService(apiTypes: Set[Class[_]], routes: Seq[ApiRoute], settings: RestAPISettings)(implicit system: ActorSystem)
     extends ScorexLogging {
 
   val swaggerService = new SwaggerDocService(system, ActorMaterializer()(system), apiTypes, settings)

--- a/src/main/scala/com/wavesplatform/matcher/LocalQueueStore.scala
+++ b/src/main/scala/com/wavesplatform/matcher/LocalQueueStore.scala
@@ -52,6 +52,12 @@ class LocalQueueStore(db: DB) {
         }
   }
 
+  def newestOffset: Option[QueueEventWithMeta.Offset] = {
+    val idx      = newestIdx.get()
+    val eventKey = lpqElement(idx)
+    eventKey.parse(db.get(eventKey.keyBytes)).map(_.offset)
+  }
+
   def dropUntil(offset: QueueEventWithMeta.Offset): Unit = db.readWrite { rw =>
     val oldestIdx = math.max(db.get(lqOldestIdx), 0)
     (oldestIdx until offset).foreach { offset =>

--- a/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
+++ b/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
@@ -26,6 +26,8 @@ case class MatcherSettings(enable: Boolean,
                            journalDataDir: String,
                            snapshotsDataDir: String,
                            snapshotsInterval: Int,
+                           snapshotsLoadingTimeout: FiniteDuration,
+                           startEventsProcessingTimeout: FiniteDuration,
                            makeSnapshotsAtStart: Boolean,
                            priceAssets: Seq[String],
                            maxTimestampDiff: FiniteDuration,
@@ -56,21 +58,23 @@ object MatcherSettings {
   }
 
   def fromConfig(config: Config): MatcherSettings = {
-    val enabled              = config.as[Boolean](s"$configPath.enable")
-    val account              = config.as[String](s"$configPath.account")
-    val bindAddress          = config.as[String](s"$configPath.bind-address")
-    val port                 = config.as[Int](s"$configPath.port")
-    val minOrderFee          = config.as[Long](s"$configPath.min-order-fee")
-    val orderMatchTxFee      = config.as[Long](s"$configPath.order-match-tx-fee")
-    val dataDirectory        = config.as[String](s"$configPath.data-directory")
-    val journalDirectory     = config.as[String](s"$configPath.journal-directory")
-    val snapshotsDirectory   = config.as[String](s"$configPath.snapshots-directory")
-    val snapshotsInterval    = config.as[Int](s"$configPath.snapshots-interval")
-    val makeSnapshotsAtStart = config.as[Boolean](s"$configPath.make-snapshots-at-start")
-    val maxOrdersPerRequest  = config.as[Int](s"$configPath.rest-order-limit")
-    val orderTimestampDrift  = config.as[FiniteDuration](s"$configPath.order-timestamp-drift")
-    val baseAssets           = config.as[List[String]](s"$configPath.price-assets")
-    val maxTimestampDiff     = config.as[FiniteDuration](s"$configPath.max-timestamp-diff")
+    val enabled                      = config.as[Boolean](s"$configPath.enable")
+    val account                      = config.as[String](s"$configPath.account")
+    val bindAddress                  = config.as[String](s"$configPath.bind-address")
+    val port                         = config.as[Int](s"$configPath.port")
+    val minOrderFee                  = config.as[Long](s"$configPath.min-order-fee")
+    val orderMatchTxFee              = config.as[Long](s"$configPath.order-match-tx-fee")
+    val dataDirectory                = config.as[String](s"$configPath.data-directory")
+    val journalDirectory             = config.as[String](s"$configPath.journal-directory")
+    val snapshotsDirectory           = config.as[String](s"$configPath.snapshots-directory")
+    val snapshotsInterval            = config.as[Int](s"$configPath.snapshots-interval")
+    val snapshotsLoadingTimeout      = config.as[FiniteDuration](s"$configPath.snapshots-loading-timeout")
+    val startEventsProcessingTimeout = config.as[FiniteDuration](s"$configPath.start-events-processing-timeout")
+    val makeSnapshotsAtStart         = config.as[Boolean](s"$configPath.make-snapshots-at-start")
+    val maxOrdersPerRequest          = config.as[Int](s"$configPath.rest-order-limit")
+    val orderTimestampDrift          = config.as[FiniteDuration](s"$configPath.order-timestamp-drift")
+    val baseAssets                   = config.as[List[String]](s"$configPath.price-assets")
+    val maxTimestampDiff             = config.as[FiniteDuration](s"$configPath.max-timestamp-diff")
 
     val blacklistedAssets = config.as[List[String]](s"$configPath.blacklisted-assets")
     val blacklistedNames  = config.as[List[String]](s"$configPath.blacklisted-names").map(_.r)
@@ -95,6 +99,8 @@ object MatcherSettings {
       journalDirectory,
       snapshotsDirectory,
       snapshotsInterval,
+      snapshotsLoadingTimeout,
+      startEventsProcessingTimeout,
       makeSnapshotsAtStart,
       baseAssets,
       maxTimestampDiff,

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -64,8 +64,8 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   private val timer      = Kamon.timer("matcher.api-requests")
   private val placeTimer = timer.refine("action" -> "place")
 
-  override def route: Route = matcherStatusBarrier {
-    pathPrefix("matcher") {
+  override lazy val route: Route = pathPrefix("matcher") {
+    matcherStatusBarrier {
       getMatcherPublicKey ~ getOrderBook ~ marketStatus ~ place ~ getAssetPairAndPublicKeyOrderHistory ~ getPublicKeyOrderHistory ~
         getAllOrderHistory ~ tradableBalance ~ reservedBalance ~ orderStatus ~
         historyDelete ~ cancel ~ cancelAll ~ orderbooks ~ orderBookDelete ~ getTransactionsByOrder ~ forceCancelOrder ~

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -16,7 +16,7 @@ import com.wavesplatform.matcher.market.MatcherActor.{GetMarkets, GetSnapshotOff
 import com.wavesplatform.matcher.market.OrderBookActor._
 import com.wavesplatform.matcher.model._
 import com.wavesplatform.matcher.queue.{QueueEvent, QueueEventWithMeta}
-import com.wavesplatform.matcher.{AddressActor, AssetPairBuilder}
+import com.wavesplatform.matcher.{AddressActor, AssetPairBuilder, Matcher}
 import com.wavesplatform.metrics.TimerExt
 import com.wavesplatform.settings.{RestAPISettings, WavesSettings}
 import com.wavesplatform.state.ByteStr
@@ -48,7 +48,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
                            orderValidator: Order => Either[String, Order],
                            orderBookSnapshot: OrderBookSnapshotHttpCache,
                            wavesSettings: WavesSettings,
-                           isDuringShutdown: () => Boolean,
+                           matcherStatus: () => Matcher.Status,
                            db: DB,
                            time: Time,
                            currentOffset: () => QueueEventWithMeta.Offset)
@@ -64,7 +64,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   private val timer      = Kamon.timer("matcher.api-requests")
   private val placeTimer = timer.refine("action" -> "place")
 
-  override lazy val route: Route = shutdownBarrier {
+  override def route: Route = matcherStatusBarrier {
     pathPrefix("matcher") {
       getMatcherPublicKey ~ getOrderBook ~ marketStatus ~ place ~ getAssetPairAndPublicKeyOrderHistory ~ getPublicKeyOrderHistory ~
         getAllOrderHistory ~ tradableBalance ~ reservedBalance ~ orderStatus ~
@@ -73,7 +73,11 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
     }
   }
 
-  private def shutdownBarrier: Directive0 = if (isDuringShutdown()) complete(DuringShutdown) else pass
+  private def matcherStatusBarrier: Directive0 = matcherStatus() match {
+    case Matcher.Status.Working  => pass
+    case Matcher.Status.Starting => complete(DuringStart)
+    case Matcher.Status.Stopping => complete(DuringShutdown)
+  }
 
   private def unavailableOrderBookBarrier(p: AssetPair): Directive0 = orderBook(p) match {
     case Some(Left(_)) => complete(OrderBookUnavailable)
@@ -160,7 +164,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
     ))
   def marketStatus: Route = (path("orderbook" / AssetPairPM / "status") & get) { p =>
     withAssetPair(p, redirectToInverse = true) { pair =>
-      getMarketStatus(pair).fold(complete(StatusCodes.NotFound -> Json.obj("message" -> "Invalid asset pair"))) { ms =>
+      getMarketStatus(pair).fold(complete(StatusCodes.NotFound -> Json.obj("message" -> "There is no information about this asset pair"))) { ms =>
         complete(StatusCodes.OK -> ms)
       }
     }

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
@@ -61,7 +61,7 @@ case object OrderBookUnavailable extends WrappedMatcherResponse(C.ServiceUnavail
 
 case object DuringStart extends WrappedMatcherResponse(C.ServiceUnavailable, "System is starting")
 
-case object DuringShutdown extends WrappedMatcherResponse(C.ServiceUnavailable, "System is going shutdown")
+case object DuringShutdown extends WrappedMatcherResponse(C.ServiceUnavailable, "System is shutting down")
 
 case class GetOrderBookResponse(orderBookResult: OrderBookResult) extends MatcherResponse(C.OK, OrderBookResult.toJson(orderBookResult))
 

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
@@ -59,6 +59,8 @@ case class OrderCancelRejected(message: String)
 
 case object OrderBookUnavailable extends WrappedMatcherResponse(C.ServiceUnavailable, "Order book is unavailable. Please contact the administrator")
 
+case object DuringStart extends WrappedMatcherResponse(C.ServiceUnavailable, "System is starting")
+
 case object DuringShutdown extends WrappedMatcherResponse(C.ServiceUnavailable, "System is going shutdown")
 
 case class GetOrderBookResponse(orderBookResult: OrderBookResult) extends MatcherResponse(C.OK, OrderBookResult.toJson(orderBookResult))

--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -122,6 +122,7 @@ class OrderBookActor(owner: ActorRef,
 
   override def receiveRecover: Receive = {
     case RecoveryCompleted =>
+      updateMarketStatus(MarketStatus(lastTrade, orderBook.bestBid, orderBook.bestAsk))
       updateSnapshot(orderBook.aggregatedSnapshot)
       owner ! OrderBookSnapshotUpdated(assetPair, lastProcessedOffset)
       log.debug(s"Recovery completed: $orderBook")

--- a/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
@@ -52,6 +52,8 @@ class LocalMatcherQueue(settings: Settings, store: LocalQueueStore, time: Time)(
     p.future
   }
 
+  override def lastEventOffset: Future[QueueEventWithMeta.Offset] = Future.successful(store.newestOffset.getOrElse(-1L))
+
   override def close(timeout: FiniteDuration): Unit = {
     timer.cancel()
     thread.shutdown()

--- a/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
@@ -6,5 +6,10 @@ import scala.concurrent.duration.FiniteDuration
 trait MatcherQueue {
   def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Unit): Unit
   def storeEvent(payload: QueueEvent): Future[QueueEventWithMeta]
+
+  /**
+    * @return -1 if topic is empty or even it doesn't exist
+    */
+  def lastEventOffset: Future[QueueEventWithMeta.Offset]
   def close(timeout: FiniteDuration): Unit
 }

--- a/src/main/scala/com/wavesplatform/utils/ApplicationStopReason.scala
+++ b/src/main/scala/com/wavesplatform/utils/ApplicationStopReason.scala
@@ -2,5 +2,6 @@ package com.wavesplatform.utils
 
 sealed abstract class ApplicationStopReason(val code: Int)
 case object Default              extends ApplicationStopReason(1)
+case object CanNotStartMatcher   extends ApplicationStopReason(10)
 case object UnsupportedFeature   extends ApplicationStopReason(38)
 case object PasswordNotSpecified extends ApplicationStopReason(61)

--- a/src/main/scala/com/wavesplatform/utils/ApplicationStopReason.scala
+++ b/src/main/scala/com/wavesplatform/utils/ApplicationStopReason.scala
@@ -2,6 +2,6 @@ package com.wavesplatform.utils
 
 sealed abstract class ApplicationStopReason(val code: Int)
 case object Default              extends ApplicationStopReason(1)
-case object CanNotStartMatcher   extends ApplicationStopReason(10)
+case object ErrorStartingMatcher extends ApplicationStopReason(10)
 case object UnsupportedFeature   extends ApplicationStopReason(38)
 case object PasswordNotSpecified extends ApplicationStopReason(61)

--- a/src/package/systemd.service
+++ b/src/package/systemd.service
@@ -11,7 +11,7 @@ ExecStart=/usr/share/${{app_name}}/bin/${{exec}} \
   -- /etc/${{app_name}}/waves.conf
 Restart=always
 RestartSec=${{retryTimeout}}
-RestartPreventExitStatus=38 61
+RestartPreventExitStatus=10 38 61
 SuccessExitStatus=143
 User=${{daemon_user}}
 PermissionsStartOnly=true

--- a/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
@@ -22,6 +22,8 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |    order-match-tx-fee = 100000
         |    snapshots-interval = 999
         |    make-snapshots-at-start = yes
+        |    snapshots-loading-timeout = 423s
+        |    start-events-processing-timeout = 543s
         |    rest-order-limit = 100
         |    order-timestamp-drift = 10m
         |    price-assets = [
@@ -75,6 +77,8 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.snapshotsDataDir should be("/waves/matcher/snapshots")
     settings.snapshotsInterval should be(999)
     settings.makeSnapshotsAtStart should be(true)
+    settings.snapshotsLoadingTimeout should be(423.seconds)
+    settings.startEventsProcessingTimeout should be(543.seconds)
     settings.maxOrdersPerRequest should be(100)
     settings.orderTimestampDrift should be(10.minutes.toMillis)
     settings.priceAssets should be(Seq("WAVES", "8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS", "DHgwrRvVyqJsepd32YbBqUeDH4GJ1N984X8QoekjgH8J"))


### PR DESCRIPTION
* Respond with ServiceUnavailable during start and shutdown;
* Status is working when all events from Kafka are processed;
* Stop DEX when it can't be recovered at start;

Conditions:
* Timeout to recover order books;
* If one order book is failed to start;