### PR TITLE
DEX-237 Processing gap in MultipleMatchersTestSuite and MatcherRecoveryTestSuite

### DIFF
--- a/it/src/main/scala/com/wavesplatform/it/api/AsyncMatcherHttpApi.scala
+++ b/it/src/main/scala/com/wavesplatform/it/api/AsyncMatcherHttpApi.scala
@@ -274,10 +274,10 @@ object AsyncMatcherHttpApi extends Assertions {
     def getAllSnapshotOffsets: Future[Map[String, QueueEventWithMeta.Offset]] =
       matcherGetWithApiKey("/matcher/debug/allSnapshotOffsets").as[Map[String, QueueEventWithMeta.Offset]]
 
-    def waitForStableOffset(confirmations: Int, maxTries: Int, interval: FiniteDuration): Future[Either[Unit, QueueEventWithMeta.Offset]] = {
-      def loop(n: Int, currConfirmations: Int, currOffset: QueueEventWithMeta.Offset): Future[Either[Unit, QueueEventWithMeta.Offset]] =
-        if (currConfirmations >= confirmations) Future.successful(Right(currOffset))
-        else if (n > maxTries) Future.successful(Left(()))
+    def waitForStableOffset(confirmations: Int, maxTries: Int, interval: FiniteDuration): Future[QueueEventWithMeta.Offset] = {
+      def loop(n: Int, currConfirmations: Int, currOffset: QueueEventWithMeta.Offset): Future[QueueEventWithMeta.Offset] =
+        if (currConfirmations >= confirmations) Future.successful(currOffset)
+        else if (n > maxTries) Future.failed(new IllegalStateException(s"Offset is not stable: $maxTries tries is out"))
         else
           GlobalTimer.instance
             .sleep(interval)

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherRestartTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/MatcherRestartTestSuite.scala
@@ -1,6 +1,7 @@
 package com.wavesplatform.it.sync.matcher
 
 import com.typesafe.config.Config
+import com.wavesplatform.it.api.OrderBookResponse
 import com.wavesplatform.it.api.SyncHttpApi._
 import com.wavesplatform.it.api.SyncMatcherHttpApi._
 import com.wavesplatform.it.matcher.MatcherSuiteBase
@@ -65,8 +66,8 @@ class MatcherRestartTestSuite extends MatcherSuiteBase {
         matcherNode.placeOrder(aliceAcc, aliceWavesPair, OrderType.SELL, 500, 2.waves * Order.PriceConstant, matcherFee, orderVersion, 5.minutes)
       aliceSecondOrder.status shouldBe "OrderAccepted"
 
-      val orders2 = matcherNode.orderBook(aliceWavesPair)
-      orders2.asks.head.amount shouldBe 1000
+      val orders2 =
+        matcherNode.waitFor[OrderBookResponse]("Top ask has 1000 amount")(_.orderBook(aliceWavesPair), _.asks.head.amount == 1000, 1.second)
       orders2.asks.head.price shouldBe 2.waves * Order.PriceConstant
 
       val cancel = matcherNode.cancelOrder(aliceAcc, aliceWavesPair, firstOrder)

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/MultipleMatchersTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/MultipleMatchersTestSuite.scala
@@ -21,11 +21,12 @@ class MultipleMatchersTestSuite extends MatcherSuiteBase {
       |  snapshots-interval = 51
       |}""".stripMargin)
 
+  private def matcher1NodeConfig = Default.last
   private def matcher2NodeConfig = ConfigFactory.parseString("""waves.network.node-name = node11
-      |akka.kafka.consumer.kafka-clients.group.id = 1""".stripMargin).withFallback(Default.last)
+      |akka.kafka.consumer.kafka-clients.group.id = 1""".stripMargin).withFallback(matcher1NodeConfig)
 
   override protected def nodeConfigs: Seq[Config] =
-    List(Default.last, matcher2NodeConfig, Default(2 + Random.nextInt(Default.size - 2)))
+    (List(matcher1NodeConfig, matcher2NodeConfig) ++ Random.shuffle(Default.init).take(1))
       .zip(Seq(matcherConfig, matcherConfig, minerEnabled))
       .map { case (n, o) => o.withFallback(n) }
       .map(configOverrides.withFallback)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -643,6 +643,8 @@ akka {
       kafka-clients {
         bootstrap.servers = ${akka.kafka.consumer.kafka-clients.bootstrap.servers}
 
+        acks = all
+
         # Buffer messages into a batch for this duration
         linger.ms = 5
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -603,7 +603,9 @@ akka {
         group.id = "0"
         auto.offset.reset = "earliest"
         enable.auto.commit = false
-        # max.poll.records = 10 # Should be <= ${waves.matcher.events-queue.kafka.consumer.buffer-size}
+        session.timeout.ms = 10000
+        max.poll.interval.ms = 11000
+        max.poll.records = 100 # Should be <= ${waves.matcher.events-queue.kafka.consumer.buffer-size}
       }
 
       # Time to wait for pending requests when a partition is closed

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -40,8 +40,8 @@
     <logger name="com.wavesplatform.network.PeerSynchronizer" level="DEBUG"/>
     <logger name="com.wavesplatform.transaction.smart" level="INFO"/>
 
-    <!--<logger name="org.apache.kafka" level="INFO"/>-->
-    <logger name="org.apache.kafka.common.network.Selector" level="DEBUG"/>
+    <logger name="org.apache.kafka" level="INFO"/>
+    <logger name="org.apache.kafka.common.network.Selector" level="DEBUG"/> <!-- https://issues.apache.org/jira/browse/KAFKA-5133 -->
 
     <logger name="org.aspectj" level="INFO"/>
     <logger name="org.asynchttpclient" level="INFO"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -40,7 +40,8 @@
     <logger name="com.wavesplatform.network.PeerSynchronizer" level="DEBUG"/>
     <logger name="com.wavesplatform.transaction.smart" level="INFO"/>
 
-    <logger name="org.apache.kafka" level="INFO"/>
+    <!--<logger name="org.apache.kafka" level="INFO"/>-->
+    <logger name="org.apache.kafka.common.network.Selector" level="DEBUG"/>
 
     <logger name="org.aspectj" level="INFO"/>
     <logger name="org.asynchttpclient" level="INFO"/>

--- a/waves-testnet.conf
+++ b/waves-testnet.conf
@@ -33,7 +33,7 @@ waves {
   # Matcher settings
   matcher {
     # Enable/disable matcher
-    enable = yes
+    enable = no
 
     # Matcher's account address
     # account = ""


### PR DESCRIPTION
* Possible fix for consumers pausing;
* MultipleMatchersTestSuite non-conflict containers creation;
* Logging of refused connections with kafka;
* Matcher should be disabled on testnet by default;
* MatcherRecoveryTestSuite, MultipleMatchersTestSuite - wait until all events are processed;
* MultipleMatchersTestSuite - wait until offsets are equal;
* MatcherRestartTestSuite - wait until an order is present in the orderbook;
* Improved logs: showing when connection to Kafka is broken (DEBUG level);