### PR TITLE
NODE-1441 /blocks/headers/last messes up block height

### DIFF
--- a/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
+++ b/src/main/scala/com/wavesplatform/state/BlockchainUpdaterImpl.scala
@@ -1,5 +1,7 @@
 package com.wavesplatform.state
 
+import java.util.concurrent.locks.{Lock, ReentrantReadWriteLock}
+
 import cats.implicits._
 import com.wavesplatform.account.{Address, Alias}
 import com.wavesplatform.block.Block.BlockId
@@ -32,6 +34,19 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
   import com.wavesplatform.state.BlockchainUpdaterImpl._
   import settings.blockchainSettings.functionalitySettings
 
+  private def inLock[R](l: Lock, f: => R) = {
+    try {
+      l.lock()
+      val res = f
+      res
+    } finally {
+      l.unlock()
+    }
+  }
+  private val lock                     = new ReentrantReadWriteLock
+  private def writeLock[B](f: => B): B = inLock(lock.writeLock(), f)
+  private def readLock[B](f: => B): B  = inLock(lock.readLock(), f)
+
   private lazy val maxBlockReadinessAge = settings.minerSettings.intervalAfterLastBlockThenGenerationIsAllowed.toMillis
 
   private var ngState: Option[NgState]              = Option.empty
@@ -40,12 +55,14 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
   private val service               = monix.execution.Scheduler.singleThread("last-block-info-publisher")
   private val internalLastBlockInfo = ConcurrentSubject.publish[LastBlockInfo](service)
 
-  override def isLastBlockId(id: ByteStr): Boolean = ngState.exists(_.contains(id)) || lastBlock.exists(_.uniqueId == id)
+  override def isLastBlockId(id: ByteStr): Boolean = readLock {
+    ngState.exists(_.contains(id)) || lastBlock.exists(_.uniqueId == id)
+  }
 
   override val lastBlockInfo: Observable[LastBlockInfo] = internalLastBlockInfo.cache(1)
   lastBlockInfo.subscribe()(monix.execution.Scheduler.global) // Start caching
 
-  def blockchainReady: Boolean = {
+  private def blockchainReady: Boolean = {
     val lastBlock = ngState.map(_.base.timestamp).orElse(blockchain.lastBlockTimestamp).get
     lastBlock + maxBlockReadinessAge > time.correctedTime()
   }
@@ -99,7 +116,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
     }
   }
 
-  override def processBlock(block: Block, verify: Boolean = true): Either[ValidationError, Option[DiscardedTransactions]] = {
+  override def processBlock(block: Block, verify: Boolean = true): Either[ValidationError, Option[DiscardedTransactions]] = writeLock {
     val height                             = blockchain.height
     val notImplementedFeatures: Set[Short] = blockchain.activatedFeaturesAt(height).diff(BlockchainFeatures.implemented)
 
@@ -211,7 +228,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
       })
   }
 
-  override def removeAfter(blockId: ByteStr): Either[ValidationError, Seq[Block]] = {
+  override def removeAfter(blockId: ByteStr): Either[ValidationError, Seq[Block]] = writeLock {
     log.info(s"Removing blocks after ${blockId.trim} from blockchain")
 
     val prevNgState = ngState
@@ -231,7 +248,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
     r
   }
 
-  override def processMicroBlock(microBlock: MicroBlock, verify: Boolean = true): Either[ValidationError, Unit] = {
+  override def processMicroBlock(microBlock: MicroBlock, verify: Boolean = true): Either[ValidationError, Unit] = writeLock {
     ngState match {
       case None =>
         Left(MicroBlockAppendError("No base block exists", microBlock))
@@ -278,12 +295,15 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
 
   private def newlyApprovedFeatures = ngState.fold(Map.empty[Short, Int])(_.approvedFeatures.map(_ -> height).toMap)
 
-  override def approvedFeatures: Map[Short, Int] = newlyApprovedFeatures ++ blockchain.approvedFeatures
+  override def approvedFeatures: Map[Short, Int] = readLock {
+    newlyApprovedFeatures ++ blockchain.approvedFeatures
+  }
 
-  override def activatedFeatures: Map[Short, Int] =
+  override def activatedFeatures: Map[Short, Int] = readLock {
     newlyApprovedFeatures.mapValues(_ + functionalitySettings.activationWindowSize(height)) ++ blockchain.activatedFeatures
+  }
 
-  override def featureVotes(height: Int): Map[Short, Int] = {
+  override def featureVotes(height: Int): Map[Short, Int] = readLock {
     val innerVotes = blockchain.featureVotes(height)
     ngState match {
       case Some(ng) if this.height <= height =>
@@ -300,70 +320,92 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
     (s.bestLiquidBlock, s.bestLiquidBlock.bytes().length)
   }
 
-  override def blockHeaderAndSize(blockId: BlockId): Option[(BlockHeader, Int)] =
+  override def blockHeaderAndSize(blockId: BlockId): Option[(BlockHeader, Int)] = readLock {
     liquidBlockHeaderAndSize().filter(_._1.uniqueId == blockId) orElse blockchain.blockHeaderAndSize(blockId)
+  }
 
-  override def height: Int = blockchain.height + ngState.fold(0)(_ => 1)
+  override def height: Int = readLock {
+    blockchain.height + ngState.fold(0)(_ => 1)
+  }
 
-  override def blockBytes(height: Int): Option[Array[Byte]] =
+  override def blockBytes(height: Int): Option[Array[Byte]] = readLock {
     blockchain
       .blockBytes(height)
       .orElse(ngState.collect { case ng if height == blockchain.height + 1 => ng.bestLiquidBlock.bytes() })
+  }
 
-  override def scoreOf(blockId: BlockId): Option[BigInt] =
+  override def scoreOf(blockId: BlockId): Option[BigInt] = readLock {
     blockchain
       .scoreOf(blockId)
       .orElse(ngState.collect { case ng if ng.contains(blockId) => blockchain.score + ng.base.blockScore() })
+  }
 
-  override def heightOf(blockId: BlockId): Option[Int] =
+  override def heightOf(blockId: BlockId): Option[Int] = readLock {
     blockchain
       .heightOf(blockId)
       .orElse(ngState.collect { case ng if ng.contains(blockId) => this.height })
+  }
 
-  override def lastBlockIds(howMany: Int): Seq[BlockId] =
+  override def lastBlockIds(howMany: Int): Seq[BlockId] = readLock {
     ngState.fold(blockchain.lastBlockIds(howMany))(_.bestLiquidBlockId +: blockchain.lastBlockIds(howMany - 1))
+  }
 
-  override def microBlock(id: BlockId): Option[MicroBlock] =
+  override def microBlock(id: BlockId): Option[MicroBlock] = readLock {
     for {
       ng <- ngState
       mb <- ng.microBlock(id)
     } yield mb
+  }
 
-  def lastBlockTimestamp: Option[Long] = ngState.map(_.base.timestamp).orElse(blockchain.lastBlockTimestamp)
+  def lastBlockTimestamp: Option[Long] = readLock {
+    ngState.map(_.base.timestamp).orElse(blockchain.lastBlockTimestamp)
+  }
 
-  def lastBlockId: Option[AssetId] = ngState.map(_.bestLiquidBlockId).orElse(blockchain.lastBlockId)
+  def lastBlockId: Option[AssetId] = readLock {
+    ngState.map(_.bestLiquidBlockId).orElse(blockchain.lastBlockId)
+  }
 
-  def blockAt(height: Int): Option[Block] =
+  def blockAt(height: Int): Option[Block] = readLock {
     if (height == this.height)
       ngState.map(_.bestLiquidBlock)
     else
       blockchain.blockAt(height)
+  }
 
-  override def lastPersistedBlockIds(count: Int): Seq[BlockId] = {
+  override def lastPersistedBlockIds(count: Int): Seq[BlockId] = readLock {
     blockchain.lastBlockIds(count)
   }
 
-  override def microblockIds: Seq[BlockId] = ngState.fold(Seq.empty[BlockId])(_.microBlockIds)
+  override def microblockIds: Seq[BlockId] = readLock {
+    ngState.fold(Seq.empty[BlockId])(_.microBlockIds)
+  }
 
-  override def bestLastBlockInfo(maxTimestamp: Long): Option[BlockMinerInfo] = {
+  override def bestLastBlockInfo(maxTimestamp: Long): Option[BlockMinerInfo] = readLock {
     ngState
       .map(_.bestLastBlockInfo(maxTimestamp))
       .orElse(blockchain.lastBlock.map(b => BlockMinerInfo(b.consensusData, b.timestamp, b.uniqueId)))
   }
 
-  override def score: BigInt = blockchain.score + ngState.fold(BigInt(0))(_.bestLiquidBlock.blockScore())
+  override def score: BigInt = readLock {
+    blockchain.score + ngState.fold(BigInt(0))(_.bestLiquidBlock.blockScore())
+  }
 
-  override def lastBlock: Option[Block] = ngState.map(_.bestLiquidBlock).orElse(blockchain.lastBlock)
+  override def lastBlock: Option[Block] = readLock {
+    ngState.map(_.bestLiquidBlock).orElse(blockchain.lastBlock)
+  }
 
-  override def carryFee: Long = ngState.map(_.carryFee).getOrElse(blockchain.carryFee)
+  override def carryFee: Long = readLock {
+    ngState.map(_.carryFee).getOrElse(blockchain.carryFee)
+  }
 
-  override def blockBytes(blockId: ByteStr): Option[Array[Byte]] =
+  override def blockBytes(blockId: ByteStr): Option[Array[Byte]] = readLock {
     (for {
       ng               <- ngState
       (block, _, _, _) <- ng.totalDiffOf(blockId)
     } yield block.bytes()).orElse(blockchain.blockBytes(blockId))
+  }
 
-  override def blockIdsAfter(parentSignature: ByteStr, howMany: Int): Option[Seq[ByteStr]] = {
+  override def blockIdsAfter(parentSignature: ByteStr, howMany: Int): Option[Seq[ByteStr]] = readLock {
     ngState match {
       case Some(ng) if ng.contains(parentSignature) => Some(Seq.empty[ByteStr])
       case maybeNg =>
@@ -373,7 +415,7 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
     }
   }
 
-  override def parent(block: Block, back: Int): Option[Block] = {
+  override def parent(block: Block, back: Int): Option[Block] = readLock {
     ngState match {
       case Some(ng) if ng.contains(block.reference) =>
         if (back == 1) Some(ng.base) else blockchain.parent(ng.base, back - 1)
@@ -382,64 +424,76 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
     }
   }
 
-  override def blockHeaderAndSize(height: Int): Option[(BlockHeader, Int)] = {
+  override def blockHeaderAndSize(height: Int): Option[(BlockHeader, Int)] = readLock {
     if (height == blockchain.height + 1)
       ngState.map(x => (x.bestLiquidBlock, x.bestLiquidBlock.bytes().length))
     else
       blockchain.blockHeaderAndSize(height)
   }
 
-  override def portfolio(a: Address): Portfolio = {
+  override def portfolio(a: Address): Portfolio = readLock {
     val p = ngState.fold(Portfolio.empty)(_.bestLiquidDiff.portfolios.getOrElse(a, Portfolio.empty))
     blockchain.portfolio(a).combine(p)
   }
 
-  private[this] def portfolioAt(a: Address, mb: ByteStr): Portfolio = {
+  private[this] def portfolioAt(a: Address, mb: ByteStr): Portfolio = readLock {
     val p = ngState.fold(Portfolio.empty)(_.diffFor(mb)._1.portfolios.getOrElse(a, Portfolio.empty))
     blockchain.portfolio(a).combine(p)
   }
 
-  override def transactionInfo(id: AssetId): Option[(Int, Transaction)] =
+  override def transactionInfo(id: AssetId): Option[(Int, Transaction)] = readLock {
     ngState
       .fold(Diff.empty)(_.bestLiquidDiff)
       .transactions
       .get(id)
       .map(t => (t._1, t._2))
       .orElse(blockchain.transactionInfo(id))
+  }
 
   override def addressTransactions(address: Address, types: Set[Type], count: Int, fromId: Option[ByteStr]): Either[String, Seq[(Int, Transaction)]] =
-    addressTransactionsFromDiff(blockchain, ngState.map(_.bestLiquidDiff))(address, types, count, fromId)
+    readLock {
+      addressTransactionsFromDiff(blockchain, ngState.map(_.bestLiquidDiff))(address, types, count, fromId)
+    }
 
-  override def containsTransaction(tx: Transaction): Boolean = ngState.fold(blockchain.containsTransaction(tx)) { ng =>
-    ng.bestLiquidDiff.transactions.contains(tx.id()) || blockchain.containsTransaction(tx)
+  override def containsTransaction(tx: Transaction): Boolean = readLock {
+    ngState.fold(blockchain.containsTransaction(tx)) { ng =>
+      ng.bestLiquidDiff.transactions.contains(tx.id()) || blockchain.containsTransaction(tx)
+    }
   }
 
-  override def assetDescription(id: AssetId): Option[AssetDescription] = ngState.fold(blockchain.assetDescription(id)) { ng =>
-    val diff = ng.bestLiquidDiff
-    CompositeBlockchain.composite(blockchain, diff).assetDescription(id)
+  override def assetDescription(id: AssetId): Option[AssetDescription] = readLock {
+    ngState.fold(blockchain.assetDescription(id)) { ng =>
+      val diff = ng.bestLiquidDiff
+      CompositeBlockchain.composite(blockchain, diff).assetDescription(id)
+    }
   }
 
-  override def resolveAlias(alias: Alias): Either[ValidationError, Address] = ngState.fold(blockchain.resolveAlias(alias)) { ng =>
-    CompositeBlockchain.composite(blockchain, ng.bestLiquidDiff).resolveAlias(alias)
+  override def resolveAlias(alias: Alias): Either[ValidationError, Address] = readLock {
+    ngState.fold(blockchain.resolveAlias(alias)) { ng =>
+      CompositeBlockchain.composite(blockchain, ng.bestLiquidDiff).resolveAlias(alias)
+    }
   }
 
-  override def leaseDetails(leaseId: AssetId): Option[LeaseDetails] = ngState match {
-    case Some(ng) =>
-      blockchain.leaseDetails(leaseId).map(ld => ld.copy(isActive = ng.bestLiquidDiff.leaseState.getOrElse(leaseId, ld.isActive))) orElse
-        ng.bestLiquidDiff.transactions.get(leaseId).collect {
-          case (h, lt: LeaseTransaction, _) =>
-            LeaseDetails(lt.sender, lt.recipient, h, lt.amount, ng.bestLiquidDiff.leaseState(lt.id()))
-        }
-    case None =>
-      blockchain.leaseDetails(leaseId)
+  override def leaseDetails(leaseId: AssetId): Option[LeaseDetails] = readLock {
+    ngState match {
+      case Some(ng) =>
+        blockchain.leaseDetails(leaseId).map(ld => ld.copy(isActive = ng.bestLiquidDiff.leaseState.getOrElse(leaseId, ld.isActive))) orElse
+          ng.bestLiquidDiff.transactions.get(leaseId).collect {
+            case (h, lt: LeaseTransaction, _) =>
+              LeaseDetails(lt.sender, lt.recipient, h, lt.amount, ng.bestLiquidDiff.leaseState(lt.id()))
+          }
+      case None =>
+        blockchain.leaseDetails(leaseId)
+    }
   }
 
-  override def filledVolumeAndFee(orderId: AssetId): VolumeAndFee =
+  override def filledVolumeAndFee(orderId: AssetId): VolumeAndFee = readLock {
     ngState.fold(blockchain.filledVolumeAndFee(orderId))(
       _.bestLiquidDiff.orderFills.get(orderId).orEmpty.combine(blockchain.filledVolumeAndFee(orderId)))
+  }
 
   /** Retrieves Waves balance snapshot in the [from, to] range (inclusive) */
-  override def balanceSnapshots(address: Address, from: Int, to: BlockId): Seq[BalanceSnapshot] = {
+  override def balanceSnapshots(address: Address, from: Int, to: BlockId): Seq[BalanceSnapshot] = readLock {
     val blockchainBlock = blockchain.heightOf(to)
     if (blockchainBlock.nonEmpty || ngState.isEmpty) {
       blockchain.balanceSnapshots(address, from, to)
@@ -449,14 +503,16 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
     }
   }
 
-  override def accountScript(address: Address): Option[Script] = ngState.fold(blockchain.accountScript(address)) { ng =>
-    ng.bestLiquidDiff.scripts.get(address) match {
-      case None      => blockchain.accountScript(address)
-      case Some(scr) => scr
+  override def accountScript(address: Address): Option[Script] = readLock {
+    ngState.fold(blockchain.accountScript(address)) { ng =>
+      ng.bestLiquidDiff.scripts.get(address) match {
+        case None      => blockchain.accountScript(address)
+        case Some(scr) => scr
+      }
     }
   }
 
-  override def hasScript(address: Address): Boolean =
+  override def hasScript(address: Address): Boolean = readLock {
     ngState
       .flatMap(
         _.bestLiquidDiff.scripts
@@ -464,33 +520,42 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
           .map(_.nonEmpty)
       )
       .getOrElse(blockchain.hasScript(address))
+  }
 
-  override def assetScript(asset: AssetId): Option[Script] = ngState.fold(blockchain.assetScript(asset)) { ng =>
-    ng.bestLiquidDiff.assetScripts.get(asset) match {
-      case None      => blockchain.assetScript(asset)
-      case Some(scr) => scr
+  override def assetScript(asset: AssetId): Option[Script] = readLock {
+    ngState.fold(blockchain.assetScript(asset)) { ng =>
+      ng.bestLiquidDiff.assetScripts.get(asset) match {
+        case None      => blockchain.assetScript(asset)
+        case Some(scr) => scr
+      }
     }
   }
 
-  override def hasAssetScript(asset: AssetId): Boolean = ngState.fold(blockchain.hasAssetScript(asset)) { ng =>
-    ng.bestLiquidDiff.assetScripts.get(asset) match {
-      case None    => blockchain.hasAssetScript(asset)
-      case Some(x) => x.nonEmpty
+  override def hasAssetScript(asset: AssetId): Boolean = readLock {
+    ngState.fold(blockchain.hasAssetScript(asset)) { ng =>
+      ng.bestLiquidDiff.assetScripts.get(asset) match {
+        case None    => blockchain.hasAssetScript(asset)
+        case Some(x) => x.nonEmpty
+      }
     }
   }
 
-  override def accountData(acc: Address): AccountDataInfo = ngState.fold(blockchain.accountData(acc)) { ng =>
-    val fromInner = blockchain.accountData(acc)
-    val fromDiff  = ng.bestLiquidDiff.accountData.get(acc).orEmpty
-    fromInner.combine(fromDiff)
+  override def accountData(acc: Address): AccountDataInfo = readLock {
+    ngState.fold(blockchain.accountData(acc)) { ng =>
+      val fromInner = blockchain.accountData(acc)
+      val fromDiff  = ng.bestLiquidDiff.accountData.get(acc).orEmpty
+      fromInner.combine(fromDiff)
+    }
   }
 
-  override def accountData(acc: Address, key: String): Option[DataEntry[_]] = ngState.fold(blockchain.accountData(acc, key)) { ng =>
-    val diffData = ng.bestLiquidDiff.accountData.get(acc).orEmpty
-    diffData.data.get(key).orElse(blockchain.accountData(acc, key))
+  override def accountData(acc: Address, key: String): Option[DataEntry[_]] = readLock {
+    ngState.fold(blockchain.accountData(acc, key)) { ng =>
+      val diffData = ng.bestLiquidDiff.accountData.get(acc).orEmpty
+      diffData.data.get(key).orElse(blockchain.accountData(acc, key))
+    }
   }
 
-  private def changedBalances(pred: Portfolio => Boolean, f: Address => Long): Map[Address, Long] =
+  private def changedBalances(pred: Portfolio => Boolean, f: Address => Long): Map[Address, Long] = readLock {
     ngState
       .fold(Map.empty[Address, Long]) { ng =>
         for {
@@ -498,8 +563,9 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
           if pred(p)
         } yield address -> f(address)
       }
+  }
 
-  override def assetDistribution(assetId: AssetId): AssetDistribution = {
+  override def assetDistribution(assetId: AssetId): AssetDistribution = readLock {
     val fromInner = blockchain.assetDistribution(assetId)
     val fromNg    = AssetDistribution(changedBalances(_.assets.getOrElse(assetId, 0L) != 0, portfolio(_).assets.getOrElse(assetId, 0L)))
 
@@ -509,34 +575,38 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
   override def assetDistributionAtHeight(assetId: AssetId,
                                          height: Int,
                                          count: Int,
-                                         fromAddress: Option[Address]): Either[ValidationError, AssetDistributionPage] = {
+                                         fromAddress: Option[Address]): Either[ValidationError, AssetDistributionPage] = readLock {
     blockchain.assetDistributionAtHeight(assetId, height, count, fromAddress)
   }
 
-  override def wavesDistribution(height: Int): Map[Address, Long] = ngState.fold(blockchain.wavesDistribution(height)) { ng =>
-    val innerDistribution = blockchain.wavesDistribution(height)
-    if (height < this.height) innerDistribution
-    else {
-      innerDistribution ++ changedBalances(_.balance != 0, portfolio(_).balance)
+  override def wavesDistribution(height: Int): Map[Address, Long] = readLock {
+    ngState.fold(blockchain.wavesDistribution(height)) { ng =>
+      val innerDistribution = blockchain.wavesDistribution(height)
+      if (height < this.height) innerDistribution
+      else {
+        innerDistribution ++ changedBalances(_.balance != 0, portfolio(_).balance)
+      }
     }
   }
 
-  override def allActiveLeases: Set[LeaseTransaction] = ngState.fold(blockchain.allActiveLeases) { ng =>
-    val (active, canceled) = ng.bestLiquidDiff.leaseState.partition(_._2)
-    val fromDiff = active.keys
-      .map { id =>
-        ng.bestLiquidDiff.transactions(id)._2
-      }
-      .collect { case lt: LeaseTransaction => lt }
-      .toSet
-    val fromInner = blockchain.allActiveLeases.filterNot(ltx => canceled.keySet.contains(ltx.id()))
-    fromDiff ++ fromInner
+  override def allActiveLeases: Set[LeaseTransaction] = readLock {
+    ngState.fold(blockchain.allActiveLeases) { ng =>
+      val (active, canceled) = ng.bestLiquidDiff.leaseState.partition(_._2)
+      val fromDiff = active.keys
+        .map { id =>
+          ng.bestLiquidDiff.transactions(id)._2
+        }
+        .collect { case lt: LeaseTransaction => lt }
+        .toSet
+      val fromInner = blockchain.allActiveLeases.filterNot(ltx => canceled.keySet.contains(ltx.id()))
+      fromDiff ++ fromInner
+    }
   }
 
   /** Builds a new portfolio map by applying a partial function to all portfolios on which the function is defined.
     *
     * @note Portfolios passed to `pf` only contain Waves and Leasing balances to improve performance */
-  override def collectLposPortfolios[A](pf: PartialFunction[(Address, Portfolio), A]): Map[Address, A] =
+  override def collectLposPortfolios[A](pf: PartialFunction[(Address, Portfolio), A]): Map[Address, A] = readLock {
     ngState.fold(blockchain.collectLposPortfolios(pf)) { ng =>
       val b = Map.newBuilder[Address, A]
       for ((a, p) <- ng.bestLiquidDiff.portfolios if p.lease != LeaseBalance.empty || p.balance != 0) {
@@ -545,28 +615,38 @@ class BlockchainUpdaterImpl(blockchain: Blockchain, portfolioChanged: Observer[A
 
       blockchain.collectLposPortfolios(pf) ++ b.result()
     }
+  }
 
-  override def append(diff: Diff, carry: Long, block: Block): Unit = blockchain.append(diff, carry, block)
+  override def append(diff: Diff, carry: Long, block: Block): Unit = readLock {
+    blockchain.append(diff, carry, block)
+  }
 
-  override def rollbackTo(targetBlockId: AssetId): Either[String, Seq[Block]] = blockchain.rollbackTo(targetBlockId)
+  override def rollbackTo(targetBlockId: AssetId): Either[String, Seq[Block]] = readLock {
+    blockchain.rollbackTo(targetBlockId)
+  }
 
-  override def transactionHeight(id: AssetId): Option[Int] =
+  override def transactionHeight(id: AssetId): Option[Int] = readLock {
     ngState flatMap { ng =>
       ng.bestLiquidDiff.transactions.get(id).map(_._1)
     } orElse blockchain.transactionHeight(id)
-
-  override def balance(address: Address, mayBeAssetId: Option[AssetId]): Long = ngState match {
-    case Some(ng) =>
-      blockchain.balance(address, mayBeAssetId) + ng.bestLiquidDiff.portfolios.getOrElse(address, Portfolio.empty).balanceOf(mayBeAssetId)
-    case None =>
-      blockchain.balance(address, mayBeAssetId)
   }
 
-  override def leaseBalance(address: Address): LeaseBalance = ngState match {
-    case Some(ng) =>
-      cats.Monoid.combine(blockchain.leaseBalance(address), ng.bestLiquidDiff.portfolios.getOrElse(address, Portfolio.empty).lease)
-    case None =>
-      blockchain.leaseBalance(address)
+  override def balance(address: Address, mayBeAssetId: Option[AssetId]): Long = readLock {
+    ngState match {
+      case Some(ng) =>
+        blockchain.balance(address, mayBeAssetId) + ng.bestLiquidDiff.portfolios.getOrElse(address, Portfolio.empty).balanceOf(mayBeAssetId)
+      case None =>
+        blockchain.balance(address, mayBeAssetId)
+    }
+  }
+
+  override def leaseBalance(address: Address): LeaseBalance = readLock {
+    ngState match {
+      case Some(ng) =>
+        cats.Monoid.combine(blockchain.leaseBalance(address), ng.bestLiquidDiff.portfolios.getOrElse(address, Portfolio.empty).lease)
+      case None =>
+        blockchain.leaseBalance(address)
+    }
   }
 }
 

--- a/src/main/scala/com/wavesplatform/state/NgState.scala
+++ b/src/main/scala/com/wavesplatform/state/NgState.scala
@@ -1,7 +1,6 @@
 package com.wavesplatform.state
 
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.{Lock, ReentrantReadWriteLock}
 
 import cats.kernel.Monoid
 import com.google.common.cache.CacheBuilder
@@ -11,14 +10,15 @@ import com.wavesplatform.block.{Block, MicroBlock}
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.transaction.{DiscardedMicroBlocks, Transaction}
 
+import scala.collection.mutable.{ListBuffer => MList, Map => MMap}
+
+/* This is not thread safe, used only from BlockchainUpdaterImpl */
 class NgState(val base: Block, val baseBlockDiff: Diff, val baseBlockCarry: Long, val approvedFeatures: Set[Short]) extends ScorexLogging {
 
   private val MaxTotalDiffs = 3
 
-  private val state = new SynchronizedAppendState[MicroBlock, BlockId, (Diff, Long, Long)](_.totalResBlockSig)
-
-  private def microDiffs = state.mapping // microDiff, carryFee, timestamp
-  private def micros     = state.stack   // fresh head
+  private val microDiffs: MMap[BlockId, (Diff, Long, Long)] = MMap.empty  // microDiff, carryFee, timestamp
+  private val micros: MList[MicroBlock]                     = MList.empty // fresh head
 
   private val totalBlockDiffCache = CacheBuilder
     .newBuilder()
@@ -110,48 +110,9 @@ class NgState(val base: Block, val baseBlockDiff: Diff, val baseBlockCarry: Long
   }
 
   def append(m: MicroBlock, diff: Diff, microblockCarry: Long, timestamp: Long): Unit = {
-    state.append(m, (diff, microblockCarry, timestamp))
+    microDiffs.put(m.totalResBlockSig, (diff, microblockCarry, timestamp))
+    micros.prepend(m)
   }
 
   def carryFee: Long = baseBlockCarry + microDiffs.values.map(_._2).sum
-}
-
-/**
-  * Allow atomically appends to state
-  * Return internal stack and mapping state without dirty reads
-  */
-private class SynchronizedAppendState[T, K, V](toKey: T => K) {
-  private def inLock[R](l: Lock, f: => R) = {
-    try {
-      l.lock()
-      val res = f
-      res
-    } finally {
-      l.unlock()
-    }
-  }
-  private val lock                     = new ReentrantReadWriteLock
-  private def writeLock[B](f: => B): B = inLock(lock.writeLock(), f)
-  private def readLock[B](f: => B): B  = inLock(lock.readLock(), f)
-
-  @volatile private var internalStack = List.empty[T]
-  @volatile private var internalMap   = Map.empty[K, V]
-
-  /**
-    * Stack state
-    */
-  def stack: List[T] = readLock(internalStack)
-
-  /**
-    * Mapping state
-    */
-  def mapping: Map[K, V] = readLock(internalMap)
-
-  /**
-    * Atomically appends to state both stack and map
-    */
-  def append(t: T, v: V): Unit = writeLock {
-    internalStack = t :: internalStack
-    internalMap = internalMap.updated(toKey(t), v)
-  }
 }

--- a/src/test/scala/com/wavesplatform/state/NgStateTest.scala
+++ b/src/test/scala/com/wavesplatform/state/NgStateTest.scala
@@ -1,9 +1,9 @@
-package com.wavesplatform.transaction
+package com.wavesplatform.state
 
 import com.wavesplatform.common.utils.EitherExt2
 import com.wavesplatform.history._
 import com.wavesplatform.state.diffs._
-import com.wavesplatform.state.{Diff, NgState}
+import com.wavesplatform.transaction.GenesisTransaction
 import com.wavesplatform.transaction.transfer._
 import com.wavesplatform.{NoShrink, TransactionGen}
 import org.scalacheck.Gen


### PR DESCRIPTION
`BlockchainUpdaterImpl` is not thread safe and gets accessed from both appender and API threads. The solution is to add read/write locks.
As `NgState` is used only from inside `BlockchainUpdaterImpl` we can move locks employed by `NgState` up to `BlockchainUpdaterImpl`