### PR TITLE
NODE-1453 Added metric to network broadcast

### DIFF
--- a/src/test/scala/com/wavesplatform/http/AssetsBroadcastRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AssetsBroadcastRouteSpec.scala
@@ -14,7 +14,7 @@ import com.wavesplatform.transaction.transfer._
 import com.wavesplatform.transaction.{Proofs, Transaction}
 import com.wavesplatform.utx.UtxPool
 import com.wavesplatform.wallet.Wallet
-import io.netty.channel.group.ChannelGroup
+import io.netty.channel.group.{ChannelGroup, ChannelGroupFuture, ChannelMatcher}
 import org.scalacheck.{Gen => G}
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.prop.PropertyChecks
@@ -155,7 +155,11 @@ class AssetsBroadcastRouteSpec extends RouteSpec("/assets/broadcast/") with Requ
     (alwaysApproveUtx.putIfNew _).when(*).onCall((_: Transaction) => Right((true, Diff.empty))).anyNumberOfTimes()
 
     val alwaysSendAllChannels = stub[ChannelGroup]
-    (alwaysSendAllChannels.writeAndFlush(_: Any)).when(*).onCall((_: Any) => null).anyNumberOfTimes()
+    (alwaysSendAllChannels
+      .writeAndFlush(_: Any, _: ChannelMatcher))
+      .when(*, *)
+      .onCall((_: Any, _: ChannelMatcher) => stub[ChannelGroupFuture])
+      .anyNumberOfTimes()
 
     val route = AssetsBroadcastApiRoute(settings, alwaysApproveUtx, alwaysSendAllChannels).route
 
@@ -209,7 +213,7 @@ class AssetsBroadcastRouteSpec extends RouteSpec("/assets/broadcast/") with Requ
       }
 
       "returns a error if it is not a transfer request" in posting(issueReq.sample.get) ~> check {
-        status shouldNot be(StatusCodes.OK)
+        status shouldBe StatusCodes.BadRequest
       }
     }
 
@@ -246,7 +250,7 @@ class AssetsBroadcastRouteSpec extends RouteSpec("/assets/broadcast/") with Requ
       }
 
       "returns a error if it is not a transfer request" in posting(List(issueReq.sample.get)) ~> check {
-        status shouldNot be(StatusCodes.OK)
+        status shouldBe StatusCodes.BadRequest
       }
     }
 

--- a/src/test/scala/com/wavesplatform/http/AssetsRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/AssetsRouteSpec.scala
@@ -7,7 +7,7 @@ import com.wavesplatform.settings.RestAPISettings
 import com.wavesplatform.state.{Blockchain, Diff}
 import com.wavesplatform.utx.UtxPool
 import com.wavesplatform.{RequestGen, TestTime}
-import io.netty.channel.group.ChannelGroup
+import io.netty.channel.group.{ChannelGroup, ChannelGroupFuture, ChannelMatcher}
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.concurrent.Eventually
 import play.api.libs.json.Writes
@@ -31,7 +31,7 @@ class AssetsRouteSpec extends RouteSpec("/assets") with RequestGen with PathMock
 
   (wallet.privateKeyAccount _).when(senderPrivateKey.toAddress).onCall((_: Address) => Right(senderPrivateKey)).anyNumberOfTimes()
   (utx.putIfNew _).when(*).onCall((_: Transaction) => Right((true, Diff.empty))).anyNumberOfTimes()
-  (allChannels.writeAndFlush(_: Any)).when(*).onCall((_: Any) => null).anyNumberOfTimes()
+  (allChannels.writeAndFlush(_: Any, _: ChannelMatcher)).when(*, *).onCall((_: Any, _: ChannelMatcher) => stub[ChannelGroupFuture]).anyNumberOfTimes()
 
   "/transfer" - {
     val route = AssetsApiRoute(settings, wallet, utx, allChannels, state, new TestTime()).route

--- a/src/test/scala/com/wavesplatform/http/LeaseBroadcastRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/LeaseBroadcastRouteSpec.scala
@@ -25,7 +25,7 @@ class LeaseBroadcastRouteSpec extends RouteSpec("/leasing/broadcast/") with Requ
 
   (utx.putIfNew _).when(*).onCall((t: Transaction) => Left(TransactionValidationError(GenericError("foo"), t))).anyNumberOfTimes()
 
-  "returns StateCheckFiled" - {
+  "returns StateCheckFailed" - {
     val route = LeaseBroadcastApiRoute(settings, utx, allChannels).route
 
     val vt = Table[String, G[_ <: Transaction], (JsValue) => JsValue](

--- a/src/test/scala/com/wavesplatform/http/PaymentRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/PaymentRouteSpec.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.transaction.transfer._
 import com.wavesplatform.utils.Time
 import com.wavesplatform.utx.UtxPool
 import com.wavesplatform.{NoShrink, TestWallet, TransactionGen}
-import io.netty.channel.group.ChannelGroup
+import io.netty.channel.group.{ChannelGroup, ChannelGroupFuture, ChannelMatcher}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.prop.PropertyChecks
 import play.api.libs.json.{JsObject, Json}
@@ -23,9 +23,11 @@ class PaymentRouteSpec
     with TransactionGen
     with NoShrink {
 
-  private val utx = stub[UtxPool]
-  (utx.putIfNew _).when(*).onCall((t: Transaction) => Right((true, Diff.empty))).anyNumberOfTimes()
+  private val utx         = stub[UtxPool]
   private val allChannels = stub[ChannelGroup]
+
+  (utx.putIfNew _).when(*).onCall((t: Transaction) => Right((true, Diff.empty))).anyNumberOfTimes()
+  (allChannels.writeAndFlush(_: Any, _: ChannelMatcher)).when(*, *).onCall((_: Any, _: ChannelMatcher) => stub[ChannelGroupFuture]).anyNumberOfTimes()
 
   "accepts payments" in {
     forAll(accountOrAliasGen.label("recipient"), positiveLongGen.label("amount"), smallFeeGen.label("fee")) {


### PR DESCRIPTION
Added metric `network-broadcast-time` with an additional tag, `object`, that contains type of object being sent, such as `BlockForged`, `LocalScoreChanged`, `RawBytes` etc