### PR TITLE
NODE-1477 Removed `carryFeeHistory` DB key

### DIFF
--- a/src/main/scala/com/wavesplatform/database/Keys.scala
+++ b/src/main/scala/com/wavesplatform/database/Keys.scala
@@ -88,7 +88,7 @@ object Keys {
   def aliasIsDisabled(alias: Alias): Key[Boolean] =
     Key("alias-is-disabled", bytes(AliasIsDisabledPrefix, alias.bytes.arr), Option(_).exists(_(0) == 1), if (_) Array[Byte](1) else Array[Byte](0))
 
-  val carryFeeHistory: Key[Seq[Int]]   = historyKey("carry-fee-history", 44, Array())
+  /* 44: carryFeeHistory, obsolete */
   def carryFee(height: Int): Key[Long] = Key("carry-fee", h(45, height), Option(_).fold(0L)(Longs.fromByteArray), Longs.toByteArray)
 
   def assetScriptHistory(asset: IssuedAsset): Key[Seq[Int]] = historyKey("asset-script-history", 46, asset.id.arr)

--- a/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
+++ b/src/main/scala/com/wavesplatform/database/LevelDBWriter.scala
@@ -402,7 +402,7 @@ class LevelDBWriter(writableDB: DB,
     }
 
     rw.put(Keys.carryFee(height), carry)
-    expiredKeys ++= updateHistory(rw, Keys.carryFeeHistory, threshold, Keys.carryFee)
+    expiredKeys += Keys.carryFee(threshold - 1).keyBytes
 
     expiredKeys.foreach(rw.delete(_, "expired-keys"))
 
@@ -529,7 +529,6 @@ class LevelDBWriter(writableDB: DB,
           rw.delete(Keys.blockHeaderAndSizeAt(h))
           rw.delete(Keys.heightOf(discardedHeader.signerData.signature))
           rw.delete(Keys.carryFee(currentHeight))
-          rw.filterHistory(Keys.carryFeeHistory, currentHeight)
 
           if (activatedFeatures.get(BlockchainFeatures.DataTransaction.id).contains(currentHeight)) {
             DisableHijackedAliases.revert(rw)


### PR DESCRIPTION
Instead of keeping the history, I'm just removing carry fee record for blocks below the threshold.