### PR TITLE
SC-139 ScriptParseError(Can't parse script bytes starting with [3,4,0…

### DIFF
--- a/lang/jvm/src/test/scala/com/wavesplatform/lang/compiler/ContractCompilerTest.scala
+++ b/lang/jvm/src/test/scala/com/wavesplatform/lang/compiler/ContractCompilerTest.scala
@@ -454,7 +454,7 @@ class ContractCompilerTest extends PropSpec with PropertyChecks with Matchers wi
   }
 
   property("expression matching case with non-existing type should produce error message with suitable types") {
-    val ctx = Monoid.combine(compilerContext, cmpCtx)
+    val ctx           = Monoid.combine(compilerContext, cmpCtx)
     val verifierTypes = WavesContext.verifierInput.types.map(_.name)
 
     val expr = {
@@ -477,7 +477,7 @@ class ContractCompilerTest extends PropSpec with PropertyChecks with Matchers wi
   }
 
   ignore("matching case with union type containing non-existing type should produce error message with suitable types") {
-    val ctx = Monoid.combine(compilerContext, cmpCtx)
+    val ctx           = Monoid.combine(compilerContext, cmpCtx)
     val verifierTypes = WavesContext.verifierInput.types.map(_.name)
 
     val expr = {

--- a/src/main/scala/com/wavesplatform/transaction/smart/script/ScriptReader.scala
+++ b/src/main/scala/com/wavesplatform/transaction/smart/script/ScriptReader.scala
@@ -19,7 +19,7 @@ object ScriptReader {
       a <- {
         if (versionByte == 0)
           Right((ContentType.parseId(bytes(1)), StdLibVersion.parseVersion(bytes(2)), 3))
-        else if (versionByte == StdLibVersion.V1.toByte || versionByte == StdLibVersion.V2.toByte)
+        else if (versionByte == StdLibVersion.V1.toByte || versionByte == StdLibVersion.V2.toByte || versionByte == StdLibVersion.V3.toByte)
           Right((ContentType.Expression, StdLibVersion(versionByte.toInt), 1))
         else Left(ScriptParseError(s"Can't parse script bytes starting with [${bytes(0).toInt},${bytes(1).toInt},${bytes(2).toInt}]"))
       }

--- a/src/test/scala/com/wavesplatform/transaction/smart/script/ScriptReaderTest.scala
+++ b/src/test/scala/com/wavesplatform/transaction/smart/script/ScriptReaderTest.scala
@@ -1,6 +1,7 @@
 package com.wavesplatform.transaction.smart.script
 
 import com.wavesplatform.common.utils._
+import com.wavesplatform.lang.StdLibVersion
 import com.wavesplatform.lang.StdLibVersion._
 import com.wavesplatform.lang.v1.Serde
 import com.wavesplatform.lang.v1.testing.TypedScriptGen
@@ -24,6 +25,21 @@ class ScriptReaderTest extends PropSpec with PropertyChecks with Matchers with T
     forAll(contractGen) { sc =>
       val allBytes = ContractScript.apply(V3, sc).explicitGet().bytes().arr
       ScriptReader.fromBytes(allBytes).explicitGet().expr shouldBe sc
+    }
+  }
+
+  property("should parse expression with all supported std lib version") {
+    val scriptEthList =
+      StdLibVersion.SupportedVersions.map { version =>
+        ScriptCompiler.compile(s"""
+                                  |{-# STDLIB_VERSION ${version} #-}
+                                  |  true
+                                  """.stripMargin)
+      }
+    scriptEthList.foreach(_ shouldBe 'right)
+
+    scriptEthList.foreach { scriptEth =>
+      ScriptReader.fromBytes(scriptEth.explicitGet()._1.bytes()) shouldBe 'right
     }
   }
 }


### PR DESCRIPTION
…]) when issue Smart Asset or decompile script