### PR TITLE
DEX-294 Ability to disable the producer

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/DisableProducerTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/DisableProducerTestSuite.scala
@@ -1,0 +1,72 @@
+package com.wavesplatform.it.sync.matcher
+
+import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.common.state.ByteStr
+import com.wavesplatform.it.api.SyncHttpApi.{sync => _, _}
+import com.wavesplatform.it.api.SyncMatcherHttpApi._
+import com.wavesplatform.it.matcher.MatcherSuiteBase
+import com.wavesplatform.it.sync._
+import com.wavesplatform.it.sync.matcher.config.MatcherDefaultConfig._
+import com.wavesplatform.it.util._
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order, OrderType}
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+class DisableProducerTestSuite extends MatcherSuiteBase {
+  private def matcherConfig                       = ConfigFactory.parseString(s"""waves.matcher.events-queue {
+       |  local.enable-storing  = no
+       |  kafka.producer.enable = no
+       |}""".stripMargin)
+  override protected def nodeConfigs: Seq[Config] = Configs.map(matcherConfig.withFallback)
+  private def orderVersion                        = (Random.nextInt(2) + 1).toByte
+
+  "check no events are written to queue" - {
+    // Alice issues new asset
+    val aliceAsset =
+      aliceNode
+        .issue(aliceAcc.address, "DisconnectCoin", "Alice's coin for disconnect tests", someAssetAmount, 0, reissuable = false, smartIssueFee, 2)
+        .id
+    matcherNode.waitForTransaction(aliceAsset)
+
+    val aliceWavesPair = AssetPair(ByteStr.decodeBase58(aliceAsset).toOption, None)
+    // check assets's balances
+    matcherNode.assertAssetBalance(aliceAcc.address, aliceAsset, someAssetAmount)
+    matcherNode.assertAssetBalance(matcherAcc.address, aliceAsset, 0)
+
+    "place an order and wait some time" in {
+      // Alice places sell order
+      val order1 =
+        matcherNode.prepareOrder(aliceAcc, aliceWavesPair, OrderType.SELL, 500, 2.waves * Order.PriceConstant, matcherFee, orderVersion, 20.days)
+
+      matcherNode
+        .expectIncorrectOrderPlacement(
+          order1,
+          expectedStatusCode = 501,
+          expectedStatus = "Disabled",
+          expectedMessage = Some("This functionality is disabled, contact with admins")
+        )
+
+      // Alice places buy order
+      val order2 =
+        matcherNode.prepareOrder(aliceAcc, aliceWavesPair, OrderType.BUY, 500, 2.waves * Order.PriceConstant, matcherFee, orderVersion, 21.days)
+
+      matcherNode
+        .expectIncorrectOrderPlacement(
+          order2,
+          expectedStatusCode = 501,
+          expectedStatus = "Disabled",
+          expectedMessage = Some("This functionality is disabled, contact with admins")
+        )
+
+      Thread.sleep(5000)
+      matcherNode.getCurrentOffset should be(-1)
+      matcherNode.getLastOffset should be(-1)
+
+      docker.killAndStartContainer(dockerNodes().head)
+
+      matcherNode.getCurrentOffset should be(-1)
+      matcherNode.getLastOffset should be(-1)
+    }
+  }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -274,6 +274,9 @@ waves {
       type = "local" # Other possible values: kafka
 
       local {
+        # If "no" - no events will be written to the queue. Useful for debugging
+        enable-storing = yes
+
         # Interval between reads from the disk
         polling-interval = 20ms
 
@@ -304,6 +307,9 @@ waves {
 
         # Producer-related settings
         producer {
+          # If "no" - no events will be written to the queue. Useful for debugging
+          enable = yes
+
           # Buffer for pushed events
           buffer-size = 100
         }

--- a/src/main/scala/com/wavesplatform/matcher/AddressActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/AddressActor.scala
@@ -8,7 +8,7 @@ import com.wavesplatform.account.Address
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.matcher.Matcher.StoreEvent
 import com.wavesplatform.matcher.OrderDB.orderInfoOrdering
-import com.wavesplatform.matcher.api.Disabled
+import com.wavesplatform.matcher.api.SavingEventsDisabled
 import com.wavesplatform.matcher.model.Events.{OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.matcher.model.{LimitOrder, OrderInfo, OrderStatus, OrderValidator}
 import com.wavesplatform.matcher.queue.QueueEvent
@@ -150,7 +150,7 @@ class AddressActor(
         Future.successful(error)
       case Success(r) =>
         r match {
-          case None    => promisedResponse.tryComplete(Success(Disabled))
+          case None    => promisedResponse.tryComplete(Success(SavingEventsDisabled))
           case Some(x) => log.info(s"Stored $x")
         }
         promisedResponse.future

--- a/src/main/scala/com/wavesplatform/matcher/AddressActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/AddressActor.scala
@@ -8,6 +8,7 @@ import com.wavesplatform.account.Address
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.matcher.Matcher.StoreEvent
 import com.wavesplatform.matcher.OrderDB.orderInfoOrdering
+import com.wavesplatform.matcher.api.Disabled
 import com.wavesplatform.matcher.model.Events.{OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.matcher.model.{LimitOrder, OrderInfo, OrderStatus, OrderValidator}
 import com.wavesplatform.matcher.queue.QueueEvent
@@ -147,8 +148,11 @@ class AddressActor(
       case Failure(e) =>
         log.error(s"Error persisting $event", e)
         Future.successful(error)
-      case Success(x) =>
-        log.info(s"Stored $x")
+      case Success(r) =>
+        r match {
+          case None    => promisedResponse.tryComplete(Success(Disabled))
+          case Some(x) => log.info(s"Stored $x")
+        }
         promisedResponse.future
     }
   }

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -300,7 +300,7 @@ class Matcher(actorSystem: ActorSystem,
 }
 
 object Matcher extends ScorexLogging {
-  type StoreEvent = QueueEvent => Future[QueueEventWithMeta]
+  type StoreEvent = QueueEvent => Future[Option[QueueEventWithMeta]]
 
   def apply(actorSystem: ActorSystem,
             time: Time,

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -504,7 +504,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
     withAssetPair(p) { pair =>
       unavailableOrderBookBarrier(pair) {
         complete(storeEvent(QueueEvent.OrderBookDeleted(pair)).map {
-          case None => Disabled
+          case None => SavingEventsDisabled
           case _    => SimpleResponse(StatusCodes.Accepted, "Deleting order book")
         })
       }

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -503,7 +503,10 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   def orderBookDelete: Route = (path("orderbook" / AssetPairPM) & delete & withAuth) { p =>
     withAssetPair(p) { pair =>
       unavailableOrderBookBarrier(pair) {
-        complete(storeEvent(QueueEvent.OrderBookDeleted(pair)).map(_ => SimpleResponse(StatusCodes.Accepted, "Deleting order book")))
+        complete(storeEvent(QueueEvent.OrderBookDeleted(pair)).map {
+          case None => Disabled
+          case _    => SimpleResponse(StatusCodes.Accepted, "Deleting order book")
+        })
       }
     }
   }

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
@@ -37,6 +37,8 @@ case class SimpleResponse(code: StatusCode, message: String) extends WrappedMatc
 
 case class NotImplemented(message: String) extends WrappedMatcherResponse(C.NotImplemented, message)
 
+case object Disabled extends WrappedMatcherResponse(C.NotImplemented, "This functionality is disabled, contact with admins")
+
 case object InvalidSignature extends WrappedMatcherResponse(C.BadRequest, "Invalid signature")
 
 case object OperationTimedOut

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherResponse.scala
@@ -37,7 +37,9 @@ case class SimpleResponse(code: StatusCode, message: String) extends WrappedMatc
 
 case class NotImplemented(message: String) extends WrappedMatcherResponse(C.NotImplemented, message)
 
-case object Disabled extends WrappedMatcherResponse(C.NotImplemented, "This functionality is disabled, contact with admins")
+case object SavingEventsDisabled
+    extends WrappedMatcherResponse(C.NotImplemented,
+                                   Json.obj("status" -> "Disabled", "message" -> "This functionality is disabled, contact with admins"))
 
 case object InvalidSignature extends WrappedMatcherResponse(C.BadRequest, "Invalid signature")
 

--- a/src/main/scala/com/wavesplatform/matcher/queue/KafkaMatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/KafkaMatcherQueue.scala
@@ -23,7 +23,11 @@ class KafkaMatcherQueue(settings: Settings)(implicit mat: ActorMaterializer) ext
 
   private val duringShutdown = new AtomicBoolean(false)
 
-  private val producer: Producer = if (settings.producer.enable) new KafkaProducer(settings, duringShutdown.get()) else IgnoreProducer
+  private val producer: Producer = {
+    val r = if (settings.producer.enable) new KafkaProducer(settings, duringShutdown.get()) else IgnoreProducer
+    log.info(s"Choosing ${r.getClass.getName} producer")
+    r
+  }
 
   private val consumerControl = new AtomicReference[Consumer.Control](Consumer.NoopControl)
   private val consumerSettings = {

--- a/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
@@ -17,7 +17,11 @@ class LocalMatcherQueue(settings: Settings, store: LocalQueueStore, time: Time)(
 
   private var lastUnreadOffset: QueueEventWithMeta.Offset = 0
   private val timer                                       = new Timer("local-dex-queue", true)
-  private val producer: Producer                          = if (settings.enableStoring) new LocalProducer(store, time) else IgnoreProducer
+  private val producer: Producer = {
+    val r = if (settings.enableStoring) new LocalProducer(store, time) else IgnoreProducer
+    log.info(s"Choosing ${r.getClass.getName} producer")
+    r
+  }
 
   override def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Unit): Unit = {
     if (settings.cleanBeforeConsume) store.dropUntil(fromOffset)

--- a/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/LocalMatcherQueue.scala
@@ -4,7 +4,8 @@ import java.util.concurrent.Executors
 import java.util.{Timer, TimerTask}
 
 import com.wavesplatform.matcher.LocalQueueStore
-import com.wavesplatform.matcher.queue.LocalMatcherQueue.Settings
+import com.wavesplatform.matcher.queue.LocalMatcherQueue._
+import com.wavesplatform.matcher.queue.MatcherQueue.{IgnoreProducer, Producer}
 import com.wavesplatform.utils.{ScorexLogging, Time}
 
 import scala.concurrent.duration.FiniteDuration
@@ -16,7 +17,7 @@ class LocalMatcherQueue(settings: Settings, store: LocalQueueStore, time: Time)(
 
   private var lastUnreadOffset: QueueEventWithMeta.Offset = 0
   private val timer                                       = new Timer("local-dex-queue", true)
-  private val thread                                      = Executors.newSingleThreadExecutor()
+  private val producer: Producer                          = if (settings.enableStoring) new LocalProducer(store, time) else IgnoreProducer
 
   override def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Unit): Unit = {
     if (settings.cleanBeforeConsume) store.dropUntil(fromOffset)
@@ -39,27 +40,35 @@ class LocalMatcherQueue(settings: Settings, store: LocalQueueStore, time: Time)(
     )
   }
 
-  override def storeEvent(event: QueueEvent): Future[QueueEventWithMeta] = {
-    val p = Promise[QueueEventWithMeta]
-    // Need to guarantee the order
-    thread.submit(new Runnable {
-      override def run(): Unit = {
-        val ts     = time.correctedTime()
-        val offset = store.enqueue(event, time.correctedTime())
-        p.success(QueueEventWithMeta(offset, ts, event))
-      }
-    })
-    p.future
-  }
+  override def storeEvent(event: QueueEvent): Future[Option[QueueEventWithMeta]] = producer.storeEvent(event)
 
   override def lastEventOffset: Future[QueueEventWithMeta.Offset] = Future.successful(store.newestOffset.getOrElse(-1L))
 
   override def close(timeout: FiniteDuration): Unit = {
     timer.cancel()
-    thread.shutdown()
+    producer.close(timeout)
   }
 }
 
 object LocalMatcherQueue {
-  case class Settings(pollingInterval: FiniteDuration, maxElementsPerPoll: Int, cleanBeforeConsume: Boolean)
+  case class Settings(enableStoring: Boolean, pollingInterval: FiniteDuration, maxElementsPerPoll: Int, cleanBeforeConsume: Boolean)
+
+  private class LocalProducer(store: LocalQueueStore, time: Time)(implicit ec: ExecutionContext) extends Producer {
+    private val thread = Executors.newSingleThreadExecutor()
+
+    override def storeEvent(event: QueueEvent): Future[Option[QueueEventWithMeta]] = {
+      val p = Promise[QueueEventWithMeta]
+      // Need to guarantee the order
+      thread.submit(new Runnable {
+        override def run(): Unit = {
+          val ts     = time.correctedTime()
+          val offset = store.enqueue(event, time.correctedTime())
+          p.success(QueueEventWithMeta(offset, ts, event))
+        }
+      })
+      p.future.map(Some(_))
+    }
+
+    override def close(timeout: FiniteDuration): Unit = thread.shutdown()
+  }
 }

--- a/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
@@ -5,11 +5,32 @@ import scala.concurrent.duration.FiniteDuration
 
 trait MatcherQueue {
   def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Unit): Unit
-  def storeEvent(payload: QueueEvent): Future[QueueEventWithMeta]
+
+  /**
+    * @return Depending on settings and result:
+    *         Future.successful(None)    if storing is disabled
+    *         Future.successful(Some(x)) if storing is enabled and it was successful
+    *         Future.failed(error)       if storing is enabled and it was failed
+    */
+  def storeEvent(payload: QueueEvent): Future[Option[QueueEventWithMeta]]
 
   /**
     * @return -1 if topic is empty or even it doesn't exist
     */
   def lastEventOffset: Future[QueueEventWithMeta.Offset]
   def close(timeout: FiniteDuration): Unit
+}
+
+object MatcherQueue {
+  private val stored: Future[Option[QueueEventWithMeta]] = Future.successful(None)
+
+  private[queue] trait Producer {
+    def storeEvent(event: QueueEvent): Future[Option[QueueEventWithMeta]]
+    def close(timeout: FiniteDuration): Unit
+  }
+
+  private[queue] object IgnoreProducer extends Producer {
+    override def storeEvent(event: QueueEvent): Future[Option[QueueEventWithMeta]] = stored
+    override def close(timeout: FiniteDuration): Unit                              = {}
+  }
 }

--- a/src/test/scala/com/wavesplatform/matcher/AddressActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/AddressActorSpecification.scala
@@ -191,7 +191,7 @@ class AddressActorSpecification
           _ => false,
           event => {
             eventsProbe.ref ! event
-            Future.successful(QueueEventWithMeta(0, 0, event))
+            Future.successful(Some(QueueEventWithMeta(0, 0, event)))
           }
         )))
     f(

--- a/src/test/scala/com/wavesplatform/matcher/model/OrderHistoryStub.scala
+++ b/src/test/scala/com/wavesplatform/matcher/model/OrderHistoryStub.scala
@@ -27,7 +27,7 @@ class OrderHistoryStub(system: ActorSystem, time: Time) {
             time,
             new TestOrderDB(100),
             _ => false,
-            e => Future.successful(QueueEventWithMeta(0, 0, e)),
+            e => Future.successful(Some(QueueEventWithMeta(0, 0, e))),
           )))
     )
 

--- a/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
@@ -44,6 +44,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |      type = "kafka"
         |
         |      local {
+        |        enable-storing = no
         |        polling-interval = 1d
         |        max-elements-per-poll = 99
         |        clean-before-consume = no
@@ -58,7 +59,10 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |          max-backoff = 2d
         |        }
         |
-        |        producer.buffer-size = 200
+        |        producer {
+        |          enable = no
+        |          buffer-size = 200
+        |        }
         |      }
         |    }
         |    exchange-transaction-broadcast {
@@ -94,11 +98,11 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.balanceWatchingBufferInterval should be(33.seconds)
     settings.eventsQueue shouldBe EventsQueueSettings(
       tpe = "kafka",
-      local = LocalMatcherQueue.Settings(1.day, 99, cleanBeforeConsume = false),
+      local = LocalMatcherQueue.Settings(enableStoring = false, 1.day, 99, cleanBeforeConsume = false),
       kafka = KafkaMatcherQueue.Settings(
         "some-events",
         KafkaMatcherQueue.ConsumerSettings(100, 11.seconds, 2.days),
-        KafkaMatcherQueue.ProducerSettings(200)
+        KafkaMatcherQueue.ProducerSettings(enable = false, 200)
       )
     )
     settings.exchangeTransactionBroadcast shouldBe ExchangeTransactionBroadcastSettings(


### PR DESCRIPTION
* Producer implementations extracted from LocalMatcherQueue and KafkaMatcherQueue into MatcherQueue.Producer with IgnoreProducer;
* MatcherQueue.storeEvent returned Future[QueueEventWithMeta], now it is Future[Option[QueueEventWithMeta]]. See docs for further information;
* New configuration sections: local.enable-storing and kafka.producer.enable;