### PR TITLE
 DEX-291 Bad offset for new order books

### DIFF
--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/OrderBookSnapshotsTestSuite.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/OrderBookSnapshotsTestSuite.scala
@@ -1,0 +1,62 @@
+package com.wavesplatform.it.sync.matcher
+
+import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.it.api.SyncHttpApi._
+import com.wavesplatform.it.api.SyncMatcherHttpApi._
+import com.wavesplatform.it.matcher.MatcherSuiteBase
+import com.wavesplatform.it.sync.matcher.config.MatcherDefaultConfig._
+import com.wavesplatform.matcher.model.OrderStatus
+import com.wavesplatform.matcher.queue.QueueEventWithMeta
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
+import org.scalacheck.Gen
+
+import scala.concurrent.duration.DurationInt
+
+class OrderBookSnapshotsTestSuite extends MatcherSuiteBase {
+  private def interval        = 50L
+  private def configOverrides = ConfigFactory.parseString(s"""waves.matcher {
+      |  price-assets = ["WAVES"]
+      |  snapshots-interval = $interval
+      |}""".stripMargin)
+
+  override protected def nodeConfigs: Seq[Config] = Configs.map(configOverrides.withFallback)
+
+  private val (issue1, issue2, assetPair1) = issueAssetPair(aliceAcc, 8, 8)
+  private val assetPair2                   = AssetPair(assetPair1.amountAsset, None)
+
+  private val ordersPackSize = 11
+  private val ordersPack = Gen
+    .containerOfN[Vector, Order](ordersPackSize - 1, orderGen(matcherNode.publicKey, aliceAcc, List(assetPair1)))
+    .sample
+    .get :+ orderGen(matcherNode.publicKey, aliceAcc, List(assetPair2)).sample.get
+
+  "Order books are created with right offsets" in {
+    ordersPack.foreach { order =>
+      matcherNode.placeOrder(order)
+    }
+
+    matcherNode.waitFor[QueueEventWithMeta.Offset]("all events are consumed")(_.getCurrentOffset, _ == ordersPackSize - 1, 300.millis)
+    val allSnapshotOffsets = matcherNode.getAllSnapshotOffsets
+
+    allSnapshotOffsets(assetPair1.key) should be < interval
+
+    // [0;{N}] orders to the assetPair, {N+1} order to assetPair2
+    // the offset of assetPair2's order books should be {N} to be able to process {N+1} after restart
+    // see OrderBookActor.executeCommands
+    allSnapshotOffsets(assetPair2.key) shouldBe (ordersPackSize - 2) // -2 because snapshot offsets are the indexes, those start from 0
+  }
+
+  "All events are processed after restart" in {
+    docker.killAndStartContainer(dockerNodes().head)
+    matcherNode.waitFor[QueueEventWithMeta.Offset]("all events are consumed")(_.getCurrentOffset, _ == ordersPackSize - 1, 300.millis)
+    ordersPack.foreach { order =>
+      matcherNode.orderStatus(order.idStr(), order.assetPair) should not be OrderStatus.NotFound.name
+    }
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    val ids = Seq(issue1, issue2).map(matcherNode.signedIssue).map(_.id)
+    ids.foreach(nodes.waitForTransaction)
+  }
+}

--- a/it/src/test/scala/com/wavesplatform/it/sync/matcher/config/MatcherDefaultConfig.scala
+++ b/it/src/test/scala/com/wavesplatform/it/sync/matcher/config/MatcherDefaultConfig.scala
@@ -32,6 +32,7 @@ object MatcherDefaultConfig {
                                      |  order-match-tx-fee = 300000
                                      |  blacklisted-assets = ["$ForbiddenAssetId"]
                                      |  balance-watching.enable = yes
+                                     |  snapshots-interval = 10
                                      |  rest-order-limit=$orderLimit
                                      |}""".stripMargin)
 

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -72,7 +72,7 @@ class Matcher(actorSystem: ActorSystem,
     orderBooksSnapshotCache.invalidate(assetPair)
   }
 
-  private def orderBookProps(pair: AssetPair, matcherActor: ActorRef): Props = OrderBookActor.props(
+  private def orderBookProps(pair: AssetPair, matcherActor: ActorRef, startOffset: QueueEventWithMeta.Offset): Props = OrderBookActor.props(
     matcherActor,
     addressActors,
     pair,
@@ -80,7 +80,8 @@ class Matcher(actorSystem: ActorSystem,
     marketStatuses.put(pair, _),
     matcherSettings,
     transactionCreator.createTransaction,
-    time
+    time,
+    startOffset
   )
 
   private val matcherQueue: MatcherQueue = settings.matcherSettings.eventsQueue.tpe match {

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -147,11 +147,11 @@ class Matcher(actorSystem: ActorSystem,
           log.error(s"Can't start matcher: $msg")
           forceStopApplication(ErrorStartingMatcher)
 
-        case Right((self, oldestSnapshotOffset)) =>
-          currentOffset = oldestSnapshotOffset
+        case Right((self, processedOffset)) =>
+          currentOffset = processedOffset
           snapshotsRestore.trySuccess(())
           matcherQueue.startConsume(
-            oldestSnapshotOffset + 1,
+            processedOffset + 1,
             eventWithMeta => {
               log.debug(s"Consumed $eventWithMeta")
 

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -288,7 +288,6 @@ class Matcher(actorSystem: ActorSystem,
   private def waitOffsetReached(lastQueueOffset: QueueEventWithMeta.Offset, deadline: Deadline): Future[Unit] = {
     val p = Promise[Unit]()
 
-    // TODO Женя
     def loop(): Unit = {
       if (currentOffset >= lastQueueOffset) p.trySuccess(())
       else if (deadline.isOverdue())

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -548,8 +548,8 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   @ApiOperation(value = "Get the oldest snapshot's offset in the queue", notes = "", httpMethod = "GET")
   def getOldestSnapshotOffset: Route = (path("debug" / "oldestSnapshotOffset") & get & withAuth) {
     complete {
-      (matcher ? GetSnapshotOffsets).mapTo[SnapshotOffsetsResponse].map { x =>
-        StatusCodes.OK -> x.offsets.valuesIterator.min
+      (matcher ? GetSnapshotOffsets).mapTo[SnapshotOffsetsResponse].map { response =>
+        StatusCodes.OK -> response.offsets.valuesIterator.collect { case Some(x) => x }.min
       }
     }
   }
@@ -560,9 +560,8 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
     complete {
       (matcher ? GetSnapshotOffsets).mapTo[SnapshotOffsetsResponse].map { x =>
         val js = Json.obj(
-          x.offsets.map {
-            case (assetPair, offset) =>
-              assetPair.key -> Json.toJsFieldJsValueWrapper(offset)
+          x.offsets.collect {
+            case (assetPair, Some(offset)) => assetPair.key -> Json.toJsFieldJsValueWrapper(offset)
           }.toSeq: _*
         )
 

--- a/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
@@ -166,8 +166,11 @@ class MatcherActor(settings: MatcherSettings,
         childrenNames.get(ref).fold(m)(m.updated(_, Left(())))
       }
 
-    case OrderBookSnapshotUpdated(assetPair, eventNr) =>
+    case OrderBookRecovered(assetPair, eventNr) =>
       snapshotsState = snapshotsState.updated(assetPair, eventNr, lastProcessedNr, settings.snapshotsInterval)
+
+    case OrderBookSnapshotUpdated(assetPair, eventNr) =>
+      snapshotsState = snapshotsState.updated(assetPair, Some(eventNr), lastProcessedNr, settings.snapshotsInterval)
   }
 
   override def receiveRecover: Receive = {
@@ -185,29 +188,32 @@ class MatcherActor(settings: MatcherSettings,
     case RecoveryCompleted =>
       if (orderBooks.get().isEmpty) {
         log.info("Recovery completed!")
-        recoveryCompletedWithEventNr(Right((self, -1)))
+        recoveryCompletedWithEventNr(Right((self, -1L)))
       } else {
         val obs = orderBooks.get()
         log.info(s"Recovery completed, waiting order books to restore: ${obs.keys.mkString(", ")}")
-        context.become(collectOrderBooks(obs.size, Long.MaxValue, Long.MinValue, Map.empty))
+        context.become(collectOrderBooks(obs.size, None, -1L, Map.empty))
       }
   }
 
   private def collectOrderBooks(restOrderBooksNumber: Long,
-                                oldestEventNr: Long,
+                                oldestEventNr: Option[Long],
                                 newestEventNr: Long,
-                                currentOffsets: Map[AssetPair, EventOffset]): Receive = {
-    case OrderBookSnapshotUpdated(assetPair, snapshotEventNr) =>
-      log.info(s"Last snapshot for $assetPair did at $snapshotEventNr")
-
+                                currentOffsets: Map[AssetPair, Option[EventOffset]]): Receive = {
+    case OrderBookRecovered(assetPair, snapshotEventNr) =>
       val updatedRestOrderBooksNumber = restOrderBooksNumber - 1
-      val updatedOldestEventNr        = if (snapshotEventNr > -1) math.min(oldestEventNr, snapshotEventNr) else oldestEventNr
-      val updatedNewestEventNr        = math.max(newestEventNr, snapshotEventNr)
-      val updatedCurrentOffsets       = if (snapshotEventNr > -1) currentOffsets.updated(assetPair, snapshotEventNr) else currentOffsets
+
+      val updatedOldestSnapshotOffset = (oldestEventNr, snapshotEventNr) match {
+        case (Some(oldestNr), Some(orderBookNr)) => Some(math.min(oldestNr, orderBookNr))
+        case (oldestNr, orderBookNr)             => oldestNr.orElse(orderBookNr)
+      }
+
+      val updatedNewestEventNr  = math.max(newestEventNr, snapshotEventNr.getOrElse(-1L))
+      val updatedCurrentOffsets = currentOffsets.updated(assetPair, snapshotEventNr)
 
       if (updatedRestOrderBooksNumber > 0)
-        context.become(collectOrderBooks(updatedRestOrderBooksNumber, updatedOldestEventNr, updatedNewestEventNr, updatedCurrentOffsets))
-      else becomeWorking(updatedOldestEventNr, updatedNewestEventNr, updatedCurrentOffsets)
+        context.become(collectOrderBooks(updatedRestOrderBooksNumber, updatedOldestSnapshotOffset, updatedNewestEventNr, updatedCurrentOffsets))
+      else becomeWorking(updatedOldestSnapshotOffset, updatedNewestEventNr, updatedCurrentOffsets)
 
     case Terminated(ref) =>
       context.stop(self)
@@ -221,8 +227,17 @@ class MatcherActor(settings: MatcherSettings,
     case _ => stash()
   }
 
-  private def becomeWorking(oldestEventNr: EventOffset, newestEventNr: EventOffset, currentOffsets: Map[AssetPair, EventOffset]): Unit = {
+  private def becomeWorking(oldestEventNr: Option[EventOffset],
+                            newestEventNr: EventOffset,
+                            currentOffsets: Map[AssetPair, Option[EventOffset]]): Unit = {
     context.become(receiveCommand)
+
+    // If oldestEventNr <= snapshotsInterval, there could be a situation:
+    // 1. There was an event with offset=N for order book X
+    // 2. A snapshot for X wasn't created at the moment of last event, but it was created for order book Y at offset=N+2
+    // 3. After restart we ignore the event with offset=N, starting from offset=N+1
+    // So we need to start from the nearest snapshot interval start point
+    val processedEventNr = oldestEventNr.fold(0L)(_ / settings.snapshotsInterval * settings.snapshotsInterval) - 1L
 
     snapshotsState = SnapshotsState(
       currentOffsets = currentOffsets,
@@ -230,11 +245,11 @@ class MatcherActor(settings: MatcherSettings,
       interval = settings.snapshotsInterval
     )
 
-    log.info(s"All snapshots are loaded, oldestEventNr: $oldestEventNr, newestEventNr: $newestEventNr")
+    log.info(s"All snapshots are loaded, oldestEventNr: $oldestEventNr, processedEventNr: $processedEventNr, newestEventNr: $newestEventNr")
     log.trace(s"Expecting snapshots at: ${snapshotsState.nearestSnapshotOffsets}")
 
     unstashAll()
-    recoveryCompletedWithEventNr(Right((self, oldestEventNr)))
+    recoveryCompletedWithEventNr(Right((self, processedEventNr)))
   }
 
   private def snapshotsCommands: Receive = {
@@ -329,7 +344,7 @@ object MatcherActor {
   case object GetMarkets
 
   case object GetSnapshotOffsets
-  case class SnapshotOffsetsResponse(offsets: Map[AssetPair, EventOffset])
+  case class SnapshotOffsetsResponse(offsets: Map[AssetPair, Option[EventOffset]])
 
   case class MatcherRecovered(oldestEventNr: Long)
 

--- a/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
@@ -201,9 +201,9 @@ class MatcherActor(settings: MatcherSettings,
       log.info(s"Last snapshot for $assetPair did at $snapshotEventNr")
 
       val updatedRestOrderBooksNumber = restOrderBooksNumber - 1
-      val updatedOldestEventNr        = math.min(oldestEventNr, snapshotEventNr)
+      val updatedOldestEventNr        = if (snapshotEventNr > -1) math.min(oldestEventNr, snapshotEventNr) else oldestEventNr
       val updatedNewestEventNr        = math.max(newestEventNr, snapshotEventNr)
-      val updatedCurrentOffsets       = currentOffsets.updated(assetPair, snapshotEventNr)
+      val updatedCurrentOffsets       = if (snapshotEventNr > -1) currentOffsets.updated(assetPair, snapshotEventNr) else currentOffsets
 
       if (updatedRestOrderBooksNumber > 0)
         context.become(collectOrderBooks(updatedRestOrderBooksNumber, updatedOldestEventNr, updatedNewestEventNr, updatedCurrentOffsets))

--- a/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
@@ -32,8 +32,8 @@ class MatcherActor(settings: MatcherSettings,
 
   private var tradedPairs: Map[AssetPair, MarketData] = Map.empty
   private var childrenNames: Map[ActorRef, AssetPair] = Map.empty
-  private var lastSnapshotSequenceNr: Long            = 0L
-  private var lastProcessedNr: Long                   = 0L
+  private var lastSnapshotSequenceNr: Long            = -1L
+  private var lastProcessedNr: Long                   = -1L
 
   private var snapshotsState = SnapshotsState.empty
 
@@ -124,6 +124,7 @@ class MatcherActor(settings: MatcherSettings,
     case GetSnapshotOffsets => sender() ! SnapshotOffsetsResponse(snapshotsState.snapshotOffsets)
 
     case request: QueueEventWithMeta =>
+      log.info(s"Got $request")
       request.event match {
         case QueueEvent.OrderBookDeleted(assetPair) =>
           // autoCreate = false for case, when multiple OrderBookDeleted(A1-A2) events happen one after another

--- a/src/main/scala/com/wavesplatform/matcher/market/SnapshotsState.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/SnapshotsState.scala
@@ -2,64 +2,66 @@ package com.wavesplatform.matcher.market
 
 import com.wavesplatform.matcher.queue.QueueEventWithMeta.{Offset => EventOffset}
 import com.wavesplatform.transaction.assets.exchange.AssetPair
-import com.wavesplatform.utils.doWhile
 
 import scala.collection.immutable.SortedSet
 
 /**
-  * nearestSnapshotOffsets should be a PriorityQueue
+  * @param snapshotOffsets        Map of pair -> current snapshot offset
+  * @param nearestSnapshotOffsets Nearest (pair, offset) to do snapshot
+  * @note nearestSnapshotOffsets should be a PriorityQueue
   */
-case class SnapshotsState private (startOffsetToSnapshot: EventOffset,
-                                   snapshotOffsets: Map[AssetPair, EventOffset],
-                                   nearestSnapshotOffsets: SortedSet[(AssetPair, EventOffset)]) {
+case class SnapshotsState private (snapshotOffsets: Map[AssetPair, EventOffset], nearestSnapshotOffsets: SortedSet[(AssetPair, EventOffset)]) {
   import SnapshotsState._
 
   val nearestSnapshotOffset: Option[(AssetPair, EventOffset)] = nearestSnapshotOffsets.headOption // Caching log(N) operations
 
+  /**
+    * @return Some(assetPairX, stateWithoutThisAssetPairX) - if it is time to do a snapshot for assetPairX
+    *         None - if we shouldn't do a snapshot at this offset
+    */
   def requiredSnapshot(offset: EventOffset): Option[(AssetPair, SnapshotsState)] =
-    if (offset > startOffsetToSnapshot) nearestSnapshotOffset.collect {
-      case (assetPair, nearestSnapshotNr) if offset >= nearestSnapshotNr =>
+    nearestSnapshotOffset.collect {
+      case (assetPair, x) if offset >= x =>
         assetPair -> copy(nearestSnapshotOffsets = this.nearestSnapshotOffsets.tail)
-    } else None
-
-  def updated(assetPair: AssetPair, snapshotEventNr: EventOffset, lastGlobalEventNr: EventOffset, interval: EventOffset): SnapshotsState = {
-    val nextSnapshotOffset = {
-      val z = (snapshotEventNr / interval) * interval + snapshotOffset(assetPair, interval)
-      doWhile(z)(_ <= lastGlobalEventNr)(_ + interval)
     }
 
+  def updated(assetPair: AssetPair, currSnapshotOffset: EventOffset, lastProcessedOffset: EventOffset, interval: EventOffset): SnapshotsState = {
+    val nextOffset         = nextSnapshotOffset(assetPair, currSnapshotOffset, lastProcessedOffset, interval)
+    val newSnapshotOffsets = if (currSnapshotOffset > -1) snapshotOffsets.updated(assetPair, currSnapshotOffset) else snapshotOffsets
     copy(
-      snapshotOffsets = snapshotOffsets.updated(assetPair, snapshotEventNr),
-      nearestSnapshotOffsets = nearestSnapshotOffsets + (assetPair -> nextSnapshotOffset)
+      snapshotOffsets = newSnapshotOffsets,
+      nearestSnapshotOffsets = nearestSnapshotOffsets + (assetPair -> nextOffset)
     )
   }
 }
 
 object SnapshotsState {
   val empty = SnapshotsState(
-    startOffsetToSnapshot = Long.MinValue,
     snapshotOffsets = Map.empty,
     nearestSnapshotOffsets = SortedSet.empty(Ordering.by[(AssetPair, EventOffset), (EventOffset, String)] {
       case (assetPair, offset) => (offset, assetPair.key)
     })
   )
 
-  def apply(startOffsetToSnapshot: Long,
-            currentOffsets: Map[AssetPair, EventOffset],
-            lastProcessedNr: EventOffset,
-            interval: EventOffset): SnapshotsState = empty.copy(
-    startOffsetToSnapshot = startOffsetToSnapshot,
-    snapshotOffsets = currentOffsets,
+  def apply(currentOffsets: Map[AssetPair, EventOffset], lastProcessedOffset: EventOffset, interval: EventOffset): SnapshotsState = empty.copy(
+    snapshotOffsets = currentOffsets.filter { case (_, offset) => offset > -1 },
     nearestSnapshotOffsets = empty.nearestSnapshotOffsets ++ currentOffsets.map { // ++ to preserve ordering
-      case (assetPair, o) =>
-        val nextSnapshotOffset = {
-          val z = (o / interval) * interval + snapshotOffset(assetPair, interval)
-          doWhile(z)(_ <= lastProcessedNr)(_ + interval)
-        }
-
-        assetPair -> (o + nextSnapshotOffset)
+      case (assetPair, currSnapshotOffset) => assetPair -> nextSnapshotOffset(assetPair, currSnapshotOffset, lastProcessedOffset, interval)
     }
   )
 
-  private def snapshotOffset(assetPair: AssetPair, interval: EventOffset): Long = math.abs(assetPair.key.hashCode % interval)
+  private def nextSnapshotOffset(assetPair: AssetPair,
+                                 currSnapshotOffset: EventOffset,
+                                 lastProcessedOffset: EventOffset,
+                                 interval: EventOffset): EventOffset = {
+    val z                       = snapshotOffset(assetPair, interval)
+    val currIntervalStartOffset = (lastProcessedOffset / interval) * interval
+    val r                       = currIntervalStartOffset + z
+    if (r == currSnapshotOffset) r + interval else r
+  }
+
+  /**
+    * @return An offset for assetPair's snapshot E [0; interval]
+    */
+  private def snapshotOffset(assetPair: AssetPair, interval: EventOffset): EventOffset = math.abs(assetPair.key.hashCode % interval)
 }

--- a/src/main/scala/com/wavesplatform/matcher/model/EventSerializers.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/EventSerializers.scala
@@ -80,8 +80,9 @@ object EventSerializers {
       JsSuccess(jv.as[Map[String, (Long, Long)]])
   }
 
+  // Remove nullable for "n" in the future. It's a hack for old snapshots
   implicit val snapshotFormat: Format[Snapshot] = Format(
-    ((JsPath \ "n").readNullable[Long].map(_.getOrElse(-1L)) and (JsPath \ "o").read[OrderBook.Snapshot])(Snapshot),
+    ((JsPath \ "n").readNullable[Long] and (JsPath \ "o").read[OrderBook.Snapshot])(Snapshot),
     Writes[Snapshot](s => Json.obj("n" -> s.eventNr, "o" -> s.orderBook))
   )
 }

--- a/src/test/scala/com/wavesplatform/matcher/SnapshotUtils.scala
+++ b/src/test/scala/com/wavesplatform/matcher/SnapshotUtils.scala
@@ -1,0 +1,19 @@
+package com.wavesplatform.matcher
+
+import akka.actor.ActorSystem
+import akka.persistence.inmemory.extension.{InMemorySnapshotStorage, StorageExtension}
+import akka.persistence.serialization.Snapshot
+import akka.serialization.SerializationExtension
+import akka.testkit.TestProbe
+
+object SnapshotUtils {
+  def provideSnapshot(actorName: String, snapshot: Snapshot)(implicit system: ActorSystem): Unit = {
+    val snapshotBytes = SerializationExtension(system).serialize(snapshot).get
+    val p             = TestProbe()
+    p.send(
+      StorageExtension(system).snapshotStorage,
+      InMemorySnapshotStorage.Save(actorName, 0, 0, snapshotBytes)
+    )
+    p.expectMsg(akka.actor.Status.Success(""))
+  }
+}

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
@@ -3,11 +3,12 @@ package com.wavesplatform.matcher.market
 import java.util.concurrent.ConcurrentHashMap
 
 import akka.actor.{ActorRef, Props}
+import akka.persistence.serialization.Snapshot
 import akka.testkit.{ImplicitSender, TestProbe}
 import com.wavesplatform.NTPTime
 import com.wavesplatform.OrderOps._
 import com.wavesplatform.common.state.ByteStr
-import com.wavesplatform.matcher.MatcherTestData
+import com.wavesplatform.matcher.{MatcherTestData, SnapshotUtils}
 import com.wavesplatform.matcher.api.AlreadyProcessed
 import com.wavesplatform.matcher.fixtures.RestartableActor
 import com.wavesplatform.matcher.fixtures.RestartableActor.RestartActor
@@ -30,7 +31,12 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
 
   private def update(ap: AssetPair)(snapshot: OrderBook.AggregatedSnapshot): Unit = obc.put(ap, snapshot)
 
-  private def obcTest(f: (AssetPair, ActorRef, TestProbe) => Unit): Unit = {
+  private def obcTest(f: (AssetPair, ActorRef, TestProbe) => Unit): Unit = obcTestWithPrepare(_ => ()) { (pair, actor, probe) =>
+    probe.expectMsg(OrderBookSnapshotUpdated(pair, -1))
+    f(pair, actor, probe)
+  }
+
+  private def obcTestWithPrepare(prepare: AssetPair => Unit)(f: (AssetPair, ActorRef, TestProbe) => Unit): Unit = {
     obc.clear()
     md.clear()
     val b = ByteStr(new Array[Byte](32))
@@ -38,6 +44,8 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
 
     val tp   = TestProbe()
     val pair = AssetPair(Some(b), None)
+    prepare(pair)
+
     val actor = system.actorOf(
       Props(
         new OrderBookActor(
@@ -51,12 +59,27 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
           -1
         ) with RestartableActor))
 
-    tp.expectMsg(OrderBookSnapshotUpdated(pair, -1))
-
     f(pair, actor, tp)
   }
 
   "OrderBookActor" should {
+    "recover from snapshot - 1" in obcTestWithPrepare { p =>
+      SnapshotUtils.provideSnapshot(
+        OrderBookActor.name(p),
+        Snapshot(OrderBookActor.Snapshot(-1, OrderBook.empty.snapshot))
+      )
+    } { (pair, _, tp) =>
+      tp.expectMsg(OrderBookSnapshotUpdated(pair, -1))
+    }
+
+    "recover from snapshot - 2" in obcTestWithPrepare { p =>
+      SnapshotUtils.provideSnapshot(
+        OrderBookActor.name(p),
+        Snapshot(OrderBookActor.Snapshot(50, OrderBook.empty.snapshot))
+      )
+    } { (pair, _, tp) =>
+      tp.expectMsg(OrderBookSnapshotUpdated(pair, 50))
+    }
 
     "place buy and sell order to the order book and preserve it after restart" in obcTest { (pair, orderBook, tp) =>
       val ord1 = buy(pair, 10 * Order.PriceConstant, 100)

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
@@ -55,8 +55,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
           update(pair),
           p => Option(md.get(p)),
           txFactory,
-          ntpTime,
-          -1
+          ntpTime
         ) with RestartableActor))
 
     f(pair, actor, tp)

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
@@ -47,7 +47,8 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
           update(pair),
           p => Option(md.get(p)),
           txFactory,
-          ntpTime
+          ntpTime,
+          -1
         ) with RestartableActor))
 
     tp.expectMsg(OrderBookSnapshotUpdated(pair, -1))


### PR DESCRIPTION
OrderBookActor:
* Snapshot.eventNr is optional for better readability and stronger compiler guarantees;
* New event OrderBookRecovered with optional eventNr (opposite to OrderBookSnapshotUpdated);

SnapshotsState - simpler and more readable implementation;

Other:
* Unit tests;
* KafkaTopicInfo - fixed implementation with better logs and lesser parameters;
* Integration test: OrderBookSnapshotsTestSuite;