### PR TITLE
DEX-304 Order books' snapshots are created too often

### DIFF
--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -75,11 +75,12 @@ class OrderBookActor(owner: ActorRef,
 
   private def snapshotsCommands: Receive = {
     case SaveSnapshotSuccess(metadata) =>
-      val snapshotOffsetId = savingSnapshot.getOrElse(throw new IllegalStateException("Impossible"))
-      log.info(s"Snapshot has been saved at offset $snapshotOffsetId: $metadata")
-      owner ! OrderBookSnapshotUpdated(assetPair, snapshotOffsetId)
-      lastSavedSnapshotOffset = Some(snapshotOffsetId)
+      val snapshotOffset = savingSnapshot.getOrElse(throw new IllegalStateException("Impossible"))
+      log.info(s"Snapshot has been saved at offset $snapshotOffset: $metadata")
+      owner ! OrderBookSnapshotUpdated(assetPair, snapshotOffset)
+      lastSavedSnapshotOffset = Some(snapshotOffset)
       savingSnapshot = None
+      deleteSnapshots(SnapshotSelectionCriteria.Latest.copy(maxSequenceNr = metadata.sequenceNr - 1))
 
     case SaveSnapshotFailure(metadata, reason) =>
       savingSnapshot = None

--- a/src/main/scala/com/wavesplatform/matcher/market/SnapshotsState.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/SnapshotsState.scala
@@ -56,14 +56,15 @@ object SnapshotsState {
       }
     )
 
-  private def nextSnapshotOffset(assetPair: AssetPair,
-                                 currSnapshotOffset: EventOffset,
-                                 lastProcessedOffset: EventOffset,
-                                 interval: EventOffset): EventOffset = {
+  def nextSnapshotOffset(assetPair: AssetPair,
+                         currSnapshotOffset: EventOffset,
+                         lastProcessedOffset: EventOffset,
+                         interval: EventOffset): EventOffset = {
+    val prevOffset              = math.max(currSnapshotOffset, lastProcessedOffset)
     val z                       = snapshotOffset(assetPair, interval)
-    val currIntervalStartOffset = (lastProcessedOffset / interval) * interval
+    val currIntervalStartOffset = (prevOffset / interval) * interval
     val r                       = currIntervalStartOffset + z
-    if (r == currSnapshotOffset) r + interval else r
+    if (r <= prevOffset) r + interval else r
   }
 
   /**

--- a/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
@@ -255,7 +255,7 @@ class MatcherActorSpecification
         }
       }
 
-      "received a lot of messages and tries to maintain a snapshot's offset" in snapshotTest(pair23) { (matcherActor, probes) =>
+      "received a lot of messages and skipped the middle offset" in snapshotTest(pair23) { (matcherActor, probes) =>
         val eventSender = TestProbe()
         val probe       = probes.head
         sendBuyOrders(eventSender, matcherActor, pair23, 0 to 30)
@@ -265,7 +265,7 @@ class MatcherActorSpecification
         probe.expectNoMessage(200.millis)
 
         sendBuyOrders(eventSender, matcherActor, pair23, 31 to 45)
-        probe.expectMsg(OrderBookSnapshotUpdated(pair23, 31))
+        probe.expectMsg(OrderBookSnapshotUpdated(pair23, 43))
         probe.expectNoMessage(200.millis)
       }
     }
@@ -358,7 +358,7 @@ class MatcherActorSpecification
             probe.ref ! event
           }
       }
-      context.parent ! OrderBookSnapshotUpdated(assetPair, -1)
+      context.parent ! OrderBookRecovered(assetPair, None)
     })
 
     (props, probe)

--- a/src/test/scala/com/wavesplatform/matcher/market/SnapshotStateSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/SnapshotStateSpecification.scala
@@ -1,0 +1,30 @@
+package com.wavesplatform.matcher.market
+
+import com.wavesplatform.NoShrink
+import com.wavesplatform.common.state.ByteStr
+import com.wavesplatform.transaction.assets.exchange.AssetPair
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, PropSpecLike}
+
+class SnapshotStateSpecification extends PropSpecLike with GeneratorDrivenPropertyChecks with Matchers with NoShrink {
+  property("nextSnapshotOffset generates greater offsets than old and last processed") {
+    val assetPair = AssetPair(
+      Some(ByteStr("asset1".getBytes())),
+      Some(ByteStr("asset2".getBytes()))
+    )
+
+    val g = for {
+      interval            <- Gen.choose(1, 1000L).label("interval")
+      currSnapshotOffset  <- Gen.choose(-1, 1000L).label("currSnapshotOffset")
+      lastProcessedOffset <- Gen.choose(-1, 1000L).label("lastProcessedOffset")
+    } yield (currSnapshotOffset, lastProcessedOffset, interval)
+
+    forAll(g) {
+      case (currSnapshotOffset, lastProcessedOffset, interval) =>
+        val nextOffset = SnapshotsState.nextSnapshotOffset(assetPair, currSnapshotOffset, lastProcessedOffset, interval)
+        nextOffset should be > currSnapshotOffset
+        nextOffset should be > lastProcessedOffset
+    }
+  }
+}


### PR DESCRIPTION
* Fixed a bug with next snapshot's offset calculation;
* Removing old snapshots of Order book when the new one is created;