### PR TITLE
 DEX-308 Storage for MatcherActor's known pairs

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -225,6 +225,11 @@ waves {
     # Snapshots creation interval (in events)
     snapshots-interval = 1000000
 
+    # During recovery we looking for nearest offset to start:
+    # If the latest processed offset is 2025331, we start from truncate(2025331 / snapshots-interval) = 2000000.
+    # This option allows to replay events from earlier offset, startOffset = 2000000 - replay-additional-events-during-recovery
+    # replay-additional-events-during-recovery = 2000000
+
     # Make snapshots after recovery at start
     make-snapshots-at-start = no
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -225,10 +225,11 @@ waves {
     # Snapshots creation interval (in events)
     snapshots-interval = 1000000
 
-    # During recovery we looking for nearest offset to start:
-    # If the latest processed offset is 2025331, we start from truncate(2025331 / snapshots-interval) = 2000000.
-    # This option allows to replay events from earlier offset, startOffset = 2000000 - replay-additional-events-during-recovery
-    # replay-additional-events-during-recovery = 2000000
+    # During recovery determine the offset to start:
+    # If the oldest snapshot has 2025331 offset, we start from startOldestOffset = truncate(2025331 / snapshots-interval * snapshots-interval) = 2000000.
+    # This option allows to limit events from the newest snapshot also. For example, the newest snapshot was done at 3092345. startNewestOffset = 3092345 - limit-events-during-recovery
+    # If this option is defined, the maximum wins = max(startOldestOffset, startNewestOffset), otherwise we start from startOldestOffset
+    # limit-events-during-recovery = 2000000
 
     # Make snapshots after recovery at start
     make-snapshots-at-start = no

--- a/src/main/scala/com/wavesplatform/matcher/AddressActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/AddressActor.scala
@@ -7,8 +7,9 @@ import akka.pattern.pipe
 import com.wavesplatform.account.Address
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.matcher.Matcher.StoreEvent
-import com.wavesplatform.matcher.OrderDB.orderInfoOrdering
 import com.wavesplatform.matcher.api.SavingEventsDisabled
+import com.wavesplatform.matcher.db.OrderDB
+import com.wavesplatform.matcher.db.OrderDB.orderInfoOrdering
 import com.wavesplatform.matcher.model.Events.{OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.matcher.model.{LimitOrder, OrderInfo, OrderStatus, OrderValidator}
 import com.wavesplatform.matcher.queue.QueueEvent

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -15,7 +15,7 @@ import com.wavesplatform.common.utils.EitherExt2
 import com.wavesplatform.db._
 import com.wavesplatform.matcher.Matcher.Status
 import com.wavesplatform.matcher.api.{MatcherApiRoute, OrderBookSnapshotHttpCache}
-import com.wavesplatform.matcher.db.OrderDB
+import com.wavesplatform.matcher.db.{AssetPairsDB, OrderDB}
 import com.wavesplatform.matcher.market.OrderBookActor.MarketStatus
 import com.wavesplatform.matcher.market.{ExchangeTransactionBroadcastActor, MatcherActor, MatcherTransactionWriter, OrderBookActor}
 import com.wavesplatform.matcher.model.{ExchangeTransactionCreator, OrderBook, OrderValidator}
@@ -142,9 +142,12 @@ class Matcher(actorSystem: ActorSystem,
 
   private val snapshotsRestore = Promise[Unit]()
 
+  private lazy val assetPairsDb = AssetPairsDB(db)
+
   lazy val matcher: ActorRef = actorSystem.actorOf(
     MatcherActor.props(
-      matcherSettings, {
+      matcherSettings,
+      assetPairsDb, {
         case Left(msg) =>
           log.error(s"Can't start matcher: $msg")
           forceStopApplication(ErrorStartingMatcher)

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -15,6 +15,7 @@ import com.wavesplatform.common.utils.EitherExt2
 import com.wavesplatform.db._
 import com.wavesplatform.matcher.Matcher.Status
 import com.wavesplatform.matcher.api.{MatcherApiRoute, OrderBookSnapshotHttpCache}
+import com.wavesplatform.matcher.db.OrderDB
 import com.wavesplatform.matcher.market.OrderBookActor.MarketStatus
 import com.wavesplatform.matcher.market.{ExchangeTransactionBroadcastActor, MatcherActor, MatcherTransactionWriter, OrderBookActor}
 import com.wavesplatform.matcher.model.{ExchangeTransactionCreator, OrderBook, OrderValidator}

--- a/src/main/scala/com/wavesplatform/matcher/MatcherKeys.scala
+++ b/src/main/scala/com/wavesplatform/matcher/MatcherKeys.scala
@@ -69,4 +69,8 @@ object MatcherKeys {
       xs => QueueEventWithMeta(idx, Longs.fromByteArray(xs.take(8)), QueueEvent.fromBytes(xs.drop(8))),
       QueueEventWithMeta.toBytes(_).drop(8)
     )
+
+  val AssetPairsPrefix: Short = 23
+  def assetPair(pair: AssetPair): Key[Unit] =
+    Key("matcher-asset-pair", bytes(AssetPairsPrefix, pair.bytes), _ => (), _ => Array.emptyByteArray)
 }

--- a/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
+++ b/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
@@ -27,6 +27,7 @@ case class MatcherSettings(enable: Boolean,
                            journalDataDir: String,
                            snapshotsDataDir: String,
                            snapshotsInterval: Int,
+                           limitEventsDuringRecovery: Option[Int],
                            snapshotsLoadingTimeout: FiniteDuration,
                            startEventsProcessingTimeout: FiniteDuration,
                            orderBooksRecoveringTimeout: FiniteDuration,
@@ -92,6 +93,9 @@ object MatcherSettings {
     val eventsQueue         = config.as[EventsQueueSettings](s"events-queue")
     val recoverOrderHistory = !new File(dataDirectory).exists()
 
+    val limitEventsDuringRecovery = config.getAs[Int]("limit-events-during-recovery")
+    require(limitEventsDuringRecovery.forall(_ >= snapshotsInterval), "limit-events-during-recovery should be >= snapshotsInterval")
+
     def getAssetPairFromString(source: String): AssetPair = {
       val sourceArr = source.split("-")
       val res = sourceArr match {
@@ -117,6 +121,7 @@ object MatcherSettings {
       journalDirectory,
       snapshotsDirectory,
       snapshotsInterval,
+      limitEventsDuringRecovery,
       snapshotsLoadingTimeout,
       startEventsProcessingTimeout,
       orderBooksRecoveringTimeout,

--- a/src/main/scala/com/wavesplatform/matcher/db/AssetPairsDB.scala
+++ b/src/main/scala/com/wavesplatform/matcher/db/AssetPairsDB.scala
@@ -1,0 +1,26 @@
+package com.wavesplatform.matcher.db
+
+import com.wavesplatform.database.DBExt
+import com.wavesplatform.matcher.MatcherKeys
+import com.wavesplatform.transaction.assets.exchange.AssetPair
+import org.iq80.leveldb.DB
+
+trait AssetPairsDB {
+  def add(pair: AssetPair): Unit
+  def remove(pair: AssetPair): Unit
+  def all(): Set[AssetPair]
+}
+
+object AssetPairsDB {
+  def apply(db: DB): AssetPairsDB = new AssetPairsDB {
+    override def add(pair: AssetPair): Unit    = db.readWrite(_.put(MatcherKeys.assetPair(pair), ()))
+    override def remove(pair: AssetPair): Unit = db.readWrite(_.delete(MatcherKeys.assetPair(pair)))
+    override def all(): Set[AssetPair] = db.readOnly { ro =>
+      val r = Set.newBuilder[AssetPair]
+      ro.iterateOver(MatcherKeys.AssetPairsPrefix) { pair =>
+        r += AssetPair.fromBytes(pair.getKey.drop(2))
+      }
+      r.result()
+    }
+  }
+}

--- a/src/main/scala/com/wavesplatform/matcher/db/OrderDB.scala
+++ b/src/main/scala/com/wavesplatform/matcher/db/OrderDB.scala
@@ -1,10 +1,11 @@
-package com.wavesplatform.matcher
+package com.wavesplatform.matcher.db
 
 import com.wavesplatform.account.Address
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.database.DBExt
 import com.wavesplatform.matcher.model.OrderInfo.FinalOrderInfo
 import com.wavesplatform.matcher.model.{OrderInfo, OrderStatus}
+import com.wavesplatform.matcher.{MatcherKeys, MatcherSettings}
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
 import com.wavesplatform.utils.ScorexLogging
 import org.iq80.leveldb.DB

--- a/src/main/scala/com/wavesplatform/matcher/queue/QueueEventWithMeta.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/QueueEventWithMeta.scala
@@ -5,9 +5,9 @@ import com.google.common.primitives.Longs
 case class QueueEventWithMeta(offset: QueueEventWithMeta.Offset, timestamp: Long, event: QueueEvent) {
   override def toString: String = {
     val eventStr = event match {
-      case QueueEvent.Placed(o)           => s"Placed(${o.idStr()})"
-      case QueueEvent.Canceled(_, id)     => s"Canceled($id)"
-      case QueueEvent.OrderBookDeleted(p) => s"OrderBookDeleted(${p.key})"
+      case QueueEvent.Placed(o)               => s"Placed(${o.idStr()}, ${o.assetPair.key})"
+      case QueueEvent.Canceled(assetPair, id) => s"Canceled($id, ${assetPair.key})"
+      case QueueEvent.OrderBookDeleted(p)     => s"OrderBookDeleted(${p.key})"
     }
     s"QueueEventWithMeta(offset=$offset, ts=$timestamp, $eventStr)"
   }

--- a/src/main/scala/com/wavesplatform/matcher/util/WorkingStash.scala
+++ b/src/main/scala/com/wavesplatform/matcher/util/WorkingStash.scala
@@ -1,0 +1,19 @@
+package com.wavesplatform.matcher.util
+
+import akka.actor.{Actor, ActorRef}
+
+import scala.collection.immutable.Queue
+
+// Because the Akka's one doesn't work during actor start, e.g.: https://stackoverflow.com/questions/45305757/akka-unstashall-not-replaying-the-messages
+trait WorkingStash {
+  this: Actor =>
+
+  private var stashedMessages = Queue.empty[(ActorRef, Any)]
+
+  def stash(sender: ActorRef, message: Any): Unit = stashedMessages = stashedMessages.enqueue(sender -> message)
+
+  def unstashAll(): Unit = {
+    stashedMessages.foreach { case (sender, message) => self.tell(message, sender) }
+    stashedMessages = Queue.empty
+  }
+}

--- a/src/test/scala/com/wavesplatform/WithDB.scala
+++ b/src/test/scala/com/wavesplatform/WithDB.scala
@@ -32,4 +32,15 @@ trait WithDB extends BeforeAndAfterEach {
     } finally {
       TestHelpers.deleteRecursively(path)
     }
+
+  protected def tempDb(f: DB => Any): Any = {
+    val path = Files.createTempDirectory("lvl-temp").toAbsolutePath
+    val db   = LevelDBFactory.factory.open(path.toFile, new Options().createIfMissing(true))
+    try {
+      f(db)
+    } finally {
+      db.close()
+      TestHelpers.deleteRecursively(path)
+    }
+  }
 }

--- a/src/test/scala/com/wavesplatform/matcher/AddressActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/AddressActorSpecification.scala
@@ -9,6 +9,7 @@ import com.wavesplatform.NTPTime
 import com.wavesplatform.account.{Address, PrivateKeyAccount, PublicKeyAccount}
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.matcher.AddressActor.{BalanceUpdated, PlaceOrder}
+import com.wavesplatform.matcher.db.EmptyOrderDB
 import com.wavesplatform.matcher.model.LimitOrder
 import com.wavesplatform.matcher.queue.{QueueEvent, QueueEventWithMeta}
 import com.wavesplatform.state.{LeaseBalance, Portfolio}

--- a/src/test/scala/com/wavesplatform/matcher/db/AssetPairsDBSpec.scala
+++ b/src/test/scala/com/wavesplatform/matcher/db/AssetPairsDBSpec.scala
@@ -1,0 +1,46 @@
+package com.wavesplatform.matcher.db
+
+import com.wavesplatform.matcher.MatcherTestData
+import com.wavesplatform.transaction.assets.exchange.AssetPair
+import com.wavesplatform.{NoShrink, WithDB}
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FreeSpec, Matchers}
+
+class AssetPairsDBSpec extends FreeSpec with Matchers with WithDB with MatcherTestData with PropertyChecks with NoShrink {
+
+  private val fixedAssetPairGen = assetPairGen.filterNot(x => x.amountAsset.isEmpty && x.priceAsset.isEmpty)
+
+  "Default AssetPairsDB implementation" - {
+    "stores and reads all asset pairs" in {
+      val g = Gen.containerOf[Set, AssetPair](fixedAssetPairGen)
+      forAll(g) { assetPairs =>
+        test { apdb =>
+          assetPairs.foreach(apdb.add)
+          apdb.all() shouldBe assetPairs
+        }
+      }
+    }
+
+    "removes asset pair" in {
+      val g = for {
+        xs <- Gen.nonEmptyContainerOf[Vector, AssetPair](fixedAssetPairGen)
+        indexGen = Gen.choose(0, xs.size - 1)
+        is <- Gen.nonEmptyListOf(indexGen)
+      } yield (xs.toSet, is.toSet.map(xs.apply))
+
+      forAll(g) {
+        case (assetPairs, toRemove) =>
+          test { apdb =>
+            assetPairs.foreach(apdb.add)
+            toRemove.foreach(apdb.remove)
+            apdb.all() shouldBe (assetPairs -- toRemove)
+          }
+      }
+    }
+
+  }
+
+  private def test(f: AssetPairsDB => Any): Any = tempDb(db => f(AssetPairsDB(db)))
+
+}

--- a/src/test/scala/com/wavesplatform/matcher/db/EmptyOrderDB.scala
+++ b/src/test/scala/com/wavesplatform/matcher/db/EmptyOrderDB.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.matcher
+package com.wavesplatform.matcher.db
 
 import com.wavesplatform.account.Address
 import com.wavesplatform.common.state.ByteStr

--- a/src/test/scala/com/wavesplatform/matcher/db/OrderDBSpec.scala
+++ b/src/test/scala/com/wavesplatform/matcher/db/OrderDBSpec.scala
@@ -1,9 +1,10 @@
-package com.wavesplatform.matcher.model
+package com.wavesplatform.matcher.db
 
-import com.wavesplatform.{NoShrink, WithDB}
 import com.wavesplatform.account.PrivateKeyAccount
-import com.wavesplatform.matcher.{MatcherTestData, OrderDB}
+import com.wavesplatform.matcher.MatcherTestData
+import com.wavesplatform.matcher.model.{OrderInfo, OrderStatus}
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
+import com.wavesplatform.{NoShrink, WithDB}
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FreeSpec, Matchers}

--- a/src/test/scala/com/wavesplatform/matcher/db/TestOrderDB.scala
+++ b/src/test/scala/com/wavesplatform/matcher/db/TestOrderDB.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.matcher
+package com.wavesplatform.matcher.db
 
 import com.wavesplatform.account.Address
 import com.wavesplatform.common.state.ByteStr

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderBookActorSpecification.scala
@@ -142,7 +142,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       tp.receiveN(2)
 
       orderBook ! SaveSnapshot(Long.MaxValue)
-      tp.expectMsgType[OrderBookSnapshotUpdated]
+      tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
       orderBook ! RestartActor
       tp.expectMsgType[OrderBookRecovered]
 
@@ -159,7 +159,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       tp.receiveN(3)
 
       actor ! SaveSnapshot(Long.MaxValue)
-      tp.expectMsgType[OrderBookSnapshotUpdated]
+      tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
       actor ! RestartActor
       tp.expectMsgType[OrderBookRecovered]
 
@@ -183,7 +183,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       tp.receiveN(4)
 
       actor ! SaveSnapshot(Long.MaxValue)
-      tp.expectMsgType[OrderBookSnapshotUpdated]
+      tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
       actor ! RestartActor
       tp.expectMsgType[OrderBookRecovered]
 
@@ -210,7 +210,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       tp.receiveN(6)
 
       actor ! SaveSnapshot(Long.MaxValue)
-      tp.expectMsgType[OrderBookSnapshotUpdated]
+      tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
       actor ! RestartActor
       tp.expectMsgType[OrderBookRecovered]
 
@@ -237,7 +237,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       }
 
       actor ! SaveSnapshot(Long.MaxValue)
-      tp.expectMsgType[OrderBookSnapshotUpdated]
+      tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
       actor ! RestartActor
       tp.expectMsgType[OrderBookRecovered]
 
@@ -265,7 +265,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       tp.receiveN(10)
 
       actor ! SaveSnapshot(10)
-      tp.expectMsg(OrderBookSnapshotUpdated(pair, 10))
+      tp.expectMsg(OrderBookSnapshotUpdateCompleted(pair, Some(10)))
 
       (11 to 20).foreach { i =>
         actor ! wrap(i, buy(pair, 100000000, 0.00041))
@@ -273,7 +273,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       tp.receiveN(10)
 
       actor ! SaveSnapshot(20)
-      tp.expectMsg(OrderBookSnapshotUpdated(pair, 20))
+      tp.expectMsg(OrderBookSnapshotUpdateCompleted(pair, Some(20)))
     }
 
     "don't do a snapshot if there is no changes" in obcTest { (pair, actor, tp) =>
@@ -284,7 +284,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
 
       actor ! SaveSnapshot(10)
       actor ! SaveSnapshot(10)
-      tp.expectMsgType[OrderBookSnapshotUpdated]
+      tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
       tp.expectNoMessage(200.millis)
     }
 
@@ -295,7 +295,7 @@ class OrderBookActorSpecification extends MatcherSpec("OrderBookActor") with NTP
       tp.receiveN(10)
 
       actor ! SaveSnapshot(10)
-      tp.expectMsgType[OrderBookSnapshotUpdated]
+      tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
     }
   }
 }

--- a/src/test/scala/com/wavesplatform/matcher/matching/ReservedBalanceSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/matching/ReservedBalanceSpecification.scala
@@ -4,6 +4,7 @@ import akka.actor.Props
 import akka.pattern.ask
 import akka.util.Timeout
 import com.wavesplatform.account.PublicKeyAccount
+import com.wavesplatform.matcher.db.TestOrderDB
 import com.wavesplatform.matcher.market.MatcherSpecLike
 import com.wavesplatform.matcher.model.Events.{OrderAdded, OrderExecuted}
 import com.wavesplatform.matcher.model.{LimitOrder, OrderHistoryStub}

--- a/src/test/scala/com/wavesplatform/matcher/model/OrderHistoryStub.scala
+++ b/src/test/scala/com/wavesplatform/matcher/model/OrderHistoryStub.scala
@@ -4,7 +4,8 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import com.wavesplatform.account.Address
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.matcher.queue.QueueEventWithMeta
-import com.wavesplatform.matcher.{AddressActor, TestOrderDB}
+import com.wavesplatform.matcher.AddressActor
+import com.wavesplatform.matcher.db.TestOrderDB
 import com.wavesplatform.utils.Time
 
 import scala.collection.mutable

--- a/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
@@ -21,6 +21,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |    min-order-fee = 100000
         |    order-match-tx-fee = 100000
         |    snapshots-interval = 999
+        |    limit-events-during-recovery = 48879
         |    make-snapshots-at-start = yes
         |    snapshots-loading-timeout = 423s
         |    start-events-processing-timeout = 543s
@@ -84,6 +85,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.journalDataDir should be("/waves/matcher/journal")
     settings.snapshotsDataDir should be("/waves/matcher/snapshots")
     settings.snapshotsInterval should be(999)
+    settings.limitEventsDuringRecovery should be(Some(48879))
     settings.makeSnapshotsAtStart should be(true)
     settings.snapshotsLoadingTimeout should be(423.seconds)
     settings.startEventsProcessingTimeout should be(543.seconds)


### PR DESCRIPTION
* AssetPairsDB to store, delete and retrieve known asset pairs in MatcherActor;
* A setting to not replay events from the stone age;
* MatcherActor uses AssetPairsDB;
* Added WorkingStash instead of Akka's Stash;
* Fixed unit tests;

MatcherTool:
* ma-migrate to migrate asset pairs from Akka Persistence to own DB;
* ma-inspect to inspect own DB;
* ob-compact to delete stale snapshots of order books;
* dex-compact to compact DEX's LevelDB;