### PR TITLE
DEX-303 Ability to run extension projects without packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,26 @@ java -jar node/target/waves-all*.jar path/to/config/file
 
 **Note.** For OSX - homebrew is preferable choice. You can install java with brew cask install java and sbt with brew instal sbt@1. Build/Test steps are common for any OS \(but you should use ‘\' instead of '/' in windows\). {% endprettyhint %}
 
+## 9. Running an extension project locally during development
 
+For example we run `DEX`.
+
+### SBT
+
+`sbt "dex/run /path/to/configuration"`
+
+### IntelliJ IDEA
+
+1. Click on `Add configuration` (or `Edit configurations...`)
+2. Click on `+` to add a new configuration, choose `Application`
+3. Specify:
+
+    * Main class: `com.wavesplatform.Application`
+    * Program arguments: `/path/to/configuration`
+    * Use classpath of module: `dex`
+
+4. Click on `OK`
+5. Run this configuration
 
 # Waves [![Build Status](https://travis-ci.org/wavesplatform/Waves.svg?branch=master)](https://travis-ci.org/wavesplatform/Waves)
 

--- a/dex/build.sbt
+++ b/dex/build.sbt
@@ -1,4 +1,4 @@
-enablePlugins(ExtensionPackaging)
+enablePlugins(RunApplicationSettings, ExtensionPackaging)
 
 resolvers += "dnvriend" at "http://dl.bintray.com/dnvriend/maven"
 libraryDependencies ++= Dependencies.matcher

--- a/grpc-server/build.sbt
+++ b/grpc-server/build.sbt
@@ -6,4 +6,4 @@ inConfig(Compile)(Seq(
   PB.targets += scalapb.gen(flatPackage = true) -> sourceManaged.value
 ))
 
-enablePlugins(ExtensionPackaging)
+enablePlugins(RunApplicationSettings, ExtensionPackaging)

--- a/node/build.sbt
+++ b/node/build.sbt
@@ -4,7 +4,7 @@ import com.typesafe.sbt.packager.Keys.executableScriptName
 import com.typesafe.sbt.packager.archetypes.TemplateWriter
 import sbtassembly.MergeStrategy
 
-enablePlugins(JavaServerAppPackaging, UniversalDeployPlugin, JDebPackaging, SystemdPlugin, GitVersioning)
+enablePlugins(RunApplicationSettings, JavaServerAppPackaging, UniversalDeployPlugin, JDebPackaging, SystemdPlugin, GitVersioning)
 
 val versionSource = Def.task {
   // WARNING!!!
@@ -43,8 +43,6 @@ coverageExcludedPackages := ""
 
 inConfig(Compile)(
   Seq(
-    mainClass := Some("com.wavesplatform.Application"),
-    discoveredMainClasses := (mainClass in Compile).value.toSeq,
     sourceGenerators += versionSource,
     PB.targets += scalapb.gen(flatPackage = true) -> sourceManaged.value,
     PB.deleteTargetDirectory := false,

--- a/node/src/main/scala/com/wavesplatform/Application.scala
+++ b/node/src/main/scala/com/wavesplatform/Application.scala
@@ -219,6 +219,7 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings, con
     extensions = settings.extensions.map { extensionClassName =>
       val extensionClass = Class.forName(extensionClassName).asInstanceOf[Class[Extension]]
       val ctor           = extensionClass.getConstructor(classOf[Context])
+      log.info(s"Enable extension: $extensionClassName")
       ctor.newInstance(extensionContext)
     }
 

--- a/project/RunApplicationSettings.scala
+++ b/project/RunApplicationSettings.scala
@@ -1,0 +1,12 @@
+import sbt.Keys._
+import sbt._
+
+object RunApplicationSettings extends AutoPlugin {
+  override def projectSettings: Seq[Def.Setting[_]] =
+    inConfig(Compile)(
+      Seq(
+        mainClass := Some("com.wavesplatform.Application"),
+        discoveredMainClasses := (mainClass in Compile).value.toSeq,
+        run / fork := true
+      ))
+}


### PR DESCRIPTION
Common: dex, grpc-server are able to run from SBT;
README.md: contains instructions to run an extension project from SBT and IntelliJ IDEA;

SBT:
* RunApplicationSettings - add it to your project if you want to run it from SBT;