### PR TITLE
DEX-288 Switch matching rules during work

### DIFF
--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -75,32 +75,55 @@ waves.matcher {
 
   # Restrictions for the orders. Empty list means that there are no restrictions on the orders
   #
-  #  Default values for the pairs:
+  # Example:
   #
-  #   min-amount = 0.00000001,
-  #   max-amount = 1000000000
-  #   step-size  = 0.00000001
-  #   min-price  = 0.00000001,
-  #   max-price  = 1000000
-  #   tick-size  = 0.00000001
-  #   merge-small-prices = no
+  # order-restrictions = {
+  #   "WAVES-8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS": {
+  #     min-amount  = 0.001
+  #     max-amount  = 1000000
+  #     step-amount = 0.00000001
+  #     min-price   = 0.001
+  #     max-price   = 100000
+  #     step-price  = 0.00000001
+  #   },
+  #   ...
+  # }
+  order-restrictions = {}
+
+  # Matching rules' dictionary for asset pairs: pair -> rules.
+  #
+  # Rule:
+  #
+  # {
+  #   start-offset = 100   # start offset to apply the rule
+  #   merge-prices = yes   # merge prices by tick size?
+  #   tick-size    = 0.002 # required when "merge-prices" = yes, otherwise ignored
+  # }
+  #
+  # * Rules must be sorted in ascending order of "start-offset";
+  # * A next rule should have greater "start-offset" than the previous one;
   #
   # Example:
   #
-  # order-restrictions = [
-  #   {
-  #     pair = "WAVES-8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS",
-  #     min-amount = 0.001,
-  #     max-amount = 1000000
-  #     step-size = 0.001
-  #     min-price = 0.001,
-  #     max-price = 100000,
-  #     tick-size = 0.002,
-  #     merge-small-prices = yes
-  #   },
-  #   ...
-  # ]
-  order-restrictions = []
+  # matching-rules = {
+  #   "WAVES-8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS": [
+  #     {
+  #       start-offset = 100
+  #       merge-prices = yes
+  #       tick-size    = 0.002
+  #     },
+  #     {
+  #       start-offset = 500
+  #       merge-prices = yes
+  #       tick-size    = 0.0025
+  #     },
+  #     {
+  #       start-offset = 1000
+  #       merge-prices = no
+  #     }
+  #   ]
+  # }
+  matching-rules = {}
 
   # Disable charging of additional fee for new orders from scripted accounts or for smart assets
   disable-extra-fee-for-script = no
@@ -439,5 +462,3 @@ akka {
     }
   }
 }
-
-include "dex-base.conf"

--- a/dex/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -20,9 +20,10 @@ import com.wavesplatform.matcher.history.HistoryRouter
 import com.wavesplatform.matcher.market.OrderBookActor.MarketStatus
 import com.wavesplatform.matcher.market.{ExchangeTransactionBroadcastActor, MatcherActor, MatcherTransactionWriter, OrderBookActor}
 import com.wavesplatform.matcher.model.MatcherModel.Normalization
-import com.wavesplatform.matcher.model.{ExchangeTransactionCreator, OrderBook, OrderValidator}
+import com.wavesplatform.matcher.model.{ExchangeTransactionCreator, MatchingRules, OrderBook, OrderValidator}
 import com.wavesplatform.matcher.queue._
 import com.wavesplatform.matcher.settings.MatcherSettings
+import com.wavesplatform.matcher.settings.MatcherSettings.RawMatchingRules
 import com.wavesplatform.state.VolumeAndFee
 import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
@@ -81,24 +82,29 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
     orderBooksSnapshotCache.invalidate(assetPair)
   }
 
-  private def orderBookProps(pair: AssetPair, matcherActor: ActorRef): Props = {
+  private def normalizeTickSize(assetPair: AssetPair, tickSize: Double): Long =
+    Normalization.normalizePrice(tickSize, context.blockchain, assetPair).max(1)
 
-    val normalizedTickSize = settings.orderRestrictions.get(pair).withFilter(_.mergeSmallPrices).map { restrictions =>
-      Normalization.normalizePrice(restrictions.tickSize, context.blockchain, pair).max(1)
-    }
+  private def convert(assetPair: AssetPair, rawMatchingRules: RawMatchingRules): MatchingRules =
+    MatchingRules(
+      rawMatchingRules.startOffset,
+      tickSize =
+        if (rawMatchingRules.mergePrices) OrderBook.TickSize.Enabled(normalizeTickSize(assetPair, rawMatchingRules.tickSize))
+        else OrderBook.TickSize.Disabled
+    )
 
+  private def orderBookProps(assetPair: AssetPair, matcherActor: ActorRef): Props =
     OrderBookActor.props(
       matcherActor,
       addressActors,
-      pair,
-      updateOrderBookCache(pair),
-      marketStatuses.put(pair, _),
+      assetPair,
+      updateOrderBookCache(assetPair),
+      marketStatuses.put(assetPair, _),
       settings,
       transactionCreator.createTransaction,
       context.time,
-      normalizedTickSize
+      settings.matchingRules.get(assetPair).map(_.map(convert(assetPair, _))).getOrElse(MatchingRules.DefaultNel)
     )
-  }
 
   private val matcherQueue: MatcherQueue = settings.eventsQueue.tpe match {
     case "local" =>

--- a/dex/src/main/scala/com/wavesplatform/matcher/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/matcher/error/MatcherError.scala
@@ -257,7 +257,7 @@ object MatcherError {
         denied,
         e"The order's amount (${'assetPair -> ord.assetPair}, ${'amount -> formatValue(Denormalization
           .denormalizeAmountAndFee(ord.amount, amountAssetDecimals))}) does not meet matcher requirements: max amount = ${'maxAmount -> formatValue(
-          amtSettings.maxAmount)}, min amount = ${'minAmount                                                                         -> formatValue(amtSettings.minAmount)}, step size = ${'stepSize -> formatValue(amtSettings.stepSize)}"
+          amtSettings.maxAmount)}, min amount = ${'minAmount                                                                         -> formatValue(amtSettings.minAmount)}, step amount = ${'stepAmount -> formatValue(amtSettings.stepAmount)}"
       )
 
   case class OrderInvalidPrice(ord: Order, prcSettings: OrderRestrictionsSettings, amountAssetDecimals: Int, priceAssetDecimals: Int)
@@ -267,8 +267,7 @@ object MatcherError {
         denied,
         e"The order's price (${'assetPair -> ord.assetPair}, ${'price -> formatValue(Denormalization
           .denormalizePrice(ord.price, amountAssetDecimals, priceAssetDecimals))}) does not meet matcher requirements: max price = ${'maxPrice -> formatValue(
-          prcSettings.maxPrice)}, min price = ${'minPrice                                                                                      -> formatValue(prcSettings.minPrice)}, tick size = ${'tickSize -> formatValue(
-          prcSettings.tickSize)}, merge small prices = ${'mergeSmallPrices                                                                     -> prcSettings.mergeSmallPrices}"
+          prcSettings.maxPrice)}, min price = ${'minPrice                                                                                      -> formatValue(prcSettings.minPrice)}, step price = ${'stepPrice -> formatValue(prcSettings.stepPrice)}"
       )
 
   case class OrderRestrictionsNotFound(assetPair: AssetPair)

--- a/dex/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.matcher.market
 
 import akka.actor.{ActorRef, Props}
 import akka.persistence._
+import cats.data.NonEmptyList
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.matcher.api._
 import com.wavesplatform.matcher.market.MatcherActor.{ForceStartOrderBook, OrderBookCreated, SaveSnapshot}
@@ -25,7 +26,7 @@ class OrderBookActor(owner: ActorRef,
                      updateMarketStatus: MarketStatus => Unit,
                      createTransaction: CreateTransaction,
                      time: Time,
-                     normalizedTickSize: Option[Long] = None)
+                     var matchingRules: NonEmptyList[MatchingRules])
     extends PersistentActor
     with ScorexLogging {
 
@@ -43,10 +44,13 @@ class OrderBookActor(owner: ActorRef,
 
   private var lastTrade = Option.empty[LastTrade]
 
+  private def actualRules: MatchingRules = matchingRules.head
+
   private def fullCommands: Receive = executeCommands orElse snapshotsCommands
 
   private def executeCommands: Receive = {
     case request: QueueEventWithMeta =>
+      matchingRules = MatchingRules.skipOutdated(request.offset, matchingRules)
       lastProcessedOffset match {
         case Some(lastProcessed) if request.offset <= lastProcessed => sender() ! AlreadyProcessed
         case _ =>
@@ -55,7 +59,7 @@ class OrderBookActor(owner: ActorRef,
             case x: QueueEvent.Placed   => onAddOrder(request, x.order)
             case x: QueueEvent.Canceled => onCancelOrder(request, x.orderId)
             case _: QueueEvent.OrderBookDeleted =>
-              sender() ! GetOrderBookResponse(OrderBookResult(time.correctedTime(), assetPair, Seq(), Seq()))
+              sender() ! GetOrderBookResponse(OrderBookResult(time.correctedTime(), assetPair, Seq.empty, Seq.empty))
               updateSnapshot(OrderBook.AggregatedSnapshot())
               processEvents(orderBook.cancelAll(request.timestamp))
               context.stop(self)
@@ -112,7 +116,7 @@ class OrderBookActor(owner: ActorRef,
   }
 
   private def onCancelOrder(event: QueueEventWithMeta, orderIdToCancel: ByteStr): Unit =
-    cancelTimer.measure(orderBook.cancel(orderIdToCancel, event.timestamp, normalizedTickSize) match {
+    cancelTimer.measure(orderBook.cancel(orderIdToCancel, event.timestamp, actualRules.tickSize) match {
       case Some(cancelEvent) =>
         processEvents(List(cancelEvent))
       case None =>
@@ -121,7 +125,7 @@ class OrderBookActor(owner: ActorRef,
 
   private def onAddOrder(eventWithMeta: QueueEventWithMeta, order: Order): Unit = addTimer.measure {
     log.trace(s"Applied $eventWithMeta, trying to match ...")
-    processEvents(orderBook.add(order, eventWithMeta.timestamp, normalizedTickSize))
+    processEvents(orderBook.add(order, eventWithMeta.timestamp, actualRules.tickSize))
   }
 
   override def receiveCommand: Receive = fullCommands
@@ -129,8 +133,10 @@ class OrderBookActor(owner: ActorRef,
   override def receiveRecover: Receive = {
     case RecoveryCompleted =>
       lastProcessedOffset match {
-        case None    => log.debug("Recovery completed")
-        case Some(x) => log.debug(s"Recovery completed at $x: $orderBook")
+        case None => log.debug("Recovery completed")
+        case Some(x) =>
+          log.debug(s"Recovery completed at $x: $orderBook")
+          matchingRules = MatchingRules.skipOutdated(x, matchingRules)
       }
 
       processEvents(orderBook.allOrders.map(lo => OrderAdded(lo, lo.order.timestamp)))
@@ -165,8 +171,18 @@ object OrderBookActor {
             settings: MatcherSettings,
             createTransaction: CreateTransaction,
             time: Time,
-            normalizedTickSize: Option[Long] = None): Props =
-    Props(new OrderBookActor(parent, addressActor, assetPair, updateSnapshot, updateMarketStatus, createTransaction, time, normalizedTickSize))
+            matchingRules: NonEmptyList[MatchingRules]): Props =
+    Props(
+      new OrderBookActor(
+        parent,
+        addressActor,
+        assetPair,
+        updateSnapshot,
+        updateMarketStatus,
+        createTransaction,
+        time,
+        matchingRules
+      ))
 
   def name(assetPair: AssetPair): String = assetPair.toString
 

--- a/dex/src/main/scala/com/wavesplatform/matcher/model/MatchingRules.scala
+++ b/dex/src/main/scala/com/wavesplatform/matcher/model/MatchingRules.scala
@@ -1,0 +1,22 @@
+package com.wavesplatform.matcher.model
+
+import cats.data.NonEmptyList
+import com.wavesplatform.matcher.model.OrderBook.TickSize
+import com.wavesplatform.matcher.queue.QueueEventWithMeta
+
+case class MatchingRules(startOffset: QueueEventWithMeta.Offset, tickSize: TickSize)
+
+object MatchingRules {
+  val Default                                 = MatchingRules(0L, TickSize.Disabled)
+  val DefaultNel: NonEmptyList[MatchingRules] = NonEmptyList.one(Default)
+
+  def skipOutdated(currOffset: QueueEventWithMeta.Offset, rules: NonEmptyList[MatchingRules]): NonEmptyList[MatchingRules] =
+    if (currOffset > rules.head.startOffset)
+      rules.tail match {
+        case x :: xs =>
+          if (currOffset == x.startOffset) NonEmptyList(x, xs)
+          else if (currOffset > x.startOffset) skipOutdated(currOffset, NonEmptyList(x, xs))
+          else rules
+        case _ => rules
+      } else rules
+}

--- a/dex/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
@@ -105,7 +105,6 @@ object OrderValidator {
                                      orderRestrictions: Map[AssetPair, OrderRestrictionsSettings]): Result[Order] = {
     if (!(orderRestrictions contains order.assetPair)) lift(order)
     else {
-
       val (amountAssetDecimals, priceAssetDecimals) = decimalsPair
       val restrictions                              = orderRestrictions(order.assetPair)
 
@@ -115,11 +114,11 @@ object OrderValidator {
       lift(order)
         .ensure(MatcherError.OrderInvalidAmount(order, restrictions, amountAssetDecimals)) { o =>
           normalizeAmount(restrictions.minAmount) <= o.amount && o.amount <= normalizeAmount(restrictions.maxAmount) &&
-          BigDecimal(o.amount).remainder(normalizeAmount(restrictions.stepSize).max(1)) == 0
+          o.amount % normalizeAmount(restrictions.stepAmount).max(1) == 0
         }
         .ensure(MatcherError.OrderInvalidPrice(order, restrictions, amountAssetDecimals, priceAssetDecimals)) { o =>
           normalizePrice(restrictions.minPrice) <= o.price && o.price <= normalizePrice(restrictions.maxPrice) &&
-          (restrictions.mergeSmallPrices || BigDecimal(o.price).remainder(normalizePrice(restrictions.tickSize).max(1)) == 0)
+          o.price % normalizePrice(restrictions.stepPrice).max(1) == 0
         }
     }
   }

--- a/dex/src/main/scala/com/wavesplatform/matcher/settings/OrderRestrictionsSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/matcher/settings/OrderRestrictionsSettings.scala
@@ -3,53 +3,48 @@ package com.wavesplatform.matcher.settings
 import cats.data.NonEmptyList
 import cats.implicits._
 import com.wavesplatform.settings.utils.ConfigSettingsValidator
-import com.wavesplatform.settings.utils.ConfigSettingsValidator.ErrorsListOr
-import com.wavesplatform.transaction.assets.exchange.AssetPair
-import com.wavesplatform.transaction.assets.exchange.AssetPair._
+import com.wavesplatform.settings.utils.ConfigSettingsValidator.{ErrorsListOr, _}
 import monix.eval.Coeval
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 import play.api.libs.json.{JsObject, Json}
-import com.wavesplatform.settings.utils.ConfigSettingsValidator._
 
-case class OrderRestrictionsSettings(stepSize: Double,
+case class OrderRestrictionsSettings(stepAmount: Double,
                                      minAmount: Double,
                                      maxAmount: Double,
-                                     tickSize: Double,
+                                     stepPrice: Double,
                                      minPrice: Double,
-                                     maxPrice: Double,
-                                     mergeSmallPrices: Boolean) {
+                                     maxPrice: Double) {
 
   import OrderRestrictionsSettings._
 
   def getJson: Coeval[JsObject] = Coeval.evalOnce {
     Json.obj(
-      "stepSize"         -> formatValue(stepSize),
-      "minAmount"        -> formatValue(minAmount),
-      "maxAmount"        -> formatValue(maxAmount),
-      "tickSize"         -> formatValue(tickSize),
-      "minPrice"         -> formatValue(minPrice),
-      "maxPrice"         -> formatValue(maxPrice),
-      "mergeSmallPrices" -> mergeSmallPrices
+      "stepAmount" -> formatValue(stepAmount),
+      "minAmount"  -> formatValue(minAmount),
+      "maxAmount"  -> formatValue(maxAmount),
+      "stepPrice"  -> formatValue(stepPrice),
+      "minPrice"   -> formatValue(minPrice),
+      "maxPrice"   -> formatValue(maxPrice)
     )
   }
 }
 
 object OrderRestrictionsSettings {
 
-  val stepSizeDefault, tickSizeDefault, minAmountDefault, minPriceDefault = 0.00000001
-  val maxAmountDefault                                                    = 1000000000
-  val maxPriceDefault                                                     = 1000000
+  val stepAmountDefault, stepPriceDefault, minAmountDefault, minPriceDefault = 0.00000001
+  val maxAmountDefault                                                       = 1000000000
+  val maxPriceDefault                                                        = 1000000
 
   def formatValue(value: Double): String = new java.text.DecimalFormat("#.########").format(value)
 
-  implicit val orderRestrictionsSettingsReader: ValueReader[(AssetPair, OrderRestrictionsSettings)] = { (cfg, path) =>
+  implicit val orderRestrictionsSettingsReader: ValueReader[OrderRestrictionsSettings] = { (cfg, path) =>
     val cfgValidator = ConfigSettingsValidator(cfg)
 
-    def validateSizeMinMax(sizeSettingName: String,
+    def validateSizeMinMax(stepSettingName: String,
                            minSettingName: String,
                            maxSettingName: String,
-                           sizeDefaultValue: Double,
+                           stepDefaultValue: Double,
                            minDefaultValue: Double,
                            maxDefaultValue: Double): ErrorsListOr[(Double, Double, Double)] = {
 
@@ -57,24 +52,19 @@ object OrderRestrictionsSettings {
         cfgValidator.validateByPredicateWithDefault[Double](settingName)(_ > 0, s"required 0 < value", defaultValue)
 
       (
-        validateSetting(sizeSettingName, sizeDefaultValue),
+        validateSetting(stepSettingName, stepDefaultValue),
         validateSetting(minSettingName, minDefaultValue),
         validateSetting(maxSettingName, maxDefaultValue)
       ).mapN(Tuple3.apply)
         .ensure(NonEmptyList(s"Required $minSettingName < $maxSettingName", Nil)) { case (_, min, max) => min < max }
     }
 
-    lazy val validateAssetPair        = cfgValidator.validate[AssetPair](s"$path.pair")
-    lazy val validateMergeSmallPrices = cfgValidator.validateWithDefault(s"$path.merge-small-prices", false)
-
     (
-      validateAssetPair,
-      validateSizeMinMax(s"$path.step-size", s"$path.min-amount", s"$path.max-amount", stepSizeDefault, minAmountDefault, maxAmountDefault),
-      validateSizeMinMax(s"$path.tick-size", s"$path.min-price", s"$path.max-price", tickSizeDefault, minPriceDefault, maxPriceDefault),
-      validateMergeSmallPrices
+      validateSizeMinMax(s"$path.step-amount", s"$path.min-amount", s"$path.max-amount", stepAmountDefault, minAmountDefault, maxAmountDefault),
+      validateSizeMinMax(s"$path.step-price", s"$path.min-price", s"$path.max-price", stepPriceDefault, minPriceDefault, maxPriceDefault),
     ) mapN {
-      case (assetPair, (stepSize, minAmount, maxAmount), (tickSize, minPrice, maxPrice), mergeSmallPrices) =>
-        assetPair -> OrderRestrictionsSettings(stepSize, minAmount, maxAmount, tickSize, minPrice, maxPrice, mergeSmallPrices)
+      case ((stepAmount, minAmount, maxAmount), (stepPrice, minPrice, maxPrice)) =>
+        OrderRestrictionsSettings(stepAmount, minAmount, maxAmount, stepPrice, minPrice, maxPrice)
     } getValueOrThrowErrors
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
@@ -11,7 +11,7 @@ import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.matcher.market.MatcherActor.{ForceStartOrderBook, GetMarkets, MarketData, SaveSnapshot}
 import com.wavesplatform.matcher.market.MatcherActorSpecification.{FailAtStartActor, NothingDoActor, RecoveringActor}
 import com.wavesplatform.matcher.market.OrderBookActor.{OrderBookRecovered, OrderBookSnapshotUpdated}
-import com.wavesplatform.matcher.model.{Events, ExchangeTransactionCreator, OrderBook}
+import com.wavesplatform.matcher.model.{Events, ExchangeTransactionCreator, MatchingRules, OrderBook}
 import com.wavesplatform.matcher.queue.QueueEventWithMeta
 import com.wavesplatform.matcher.{MatcherTestData, SnapshotUtils}
 import com.wavesplatform.state.{AssetDescription, Blockchain}
@@ -377,7 +377,8 @@ class MatcherActorSpecification
           matcherSettings,
           doNothingOnRecovery,
           ob,
-          (assetPair, matcher) => OrderBookActor.props(matcher, addressActor, assetPair, _ => {}, _ => {}, matcherSettings, txFactory, ntpTime),
+          (assetPair, matcher) =>
+            OrderBookActor.props(matcher, addressActor, assetPair, _ => {}, _ => {}, matcherSettings, txFactory, ntpTime, MatchingRules.DefaultNel),
           blockchain.assetDescription
         )
       ))

--- a/dex/src/test/scala/com/wavesplatform/matcher/model/MatchingRulesSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/matcher/model/MatchingRulesSpecification.scala
@@ -1,0 +1,66 @@
+package com.wavesplatform.matcher.model
+
+import cats.data.NonEmptyList
+import com.wavesplatform.NoShrink
+import com.wavesplatform.matcher.MatcherTestData
+import com.wavesplatform.matcher.model.OrderBook.TickSize
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
+
+class MatchingRulesSpecification extends PropSpec with PropertyChecks with Matchers with MatcherTestData with NoShrink {
+  property("skipOutdated: rules.head.startOffset <= currentOffset < rules(1).startOffset") {
+    val g = for {
+      currOffset <- currOffsetGen
+      rules      <- rulesChainGen(5)
+    } yield (currOffset, rules)
+
+    forAll(g) {
+      case (currOffset, rules) =>
+        val updatedRules = MatchingRules.skipOutdated(currOffset, rules)
+        updatedRules.toList match {
+          case first :: Nil =>
+            withClue(s"first.startOffset=${first.startOffset}, currOffset=$currOffset") {
+              first.startOffset shouldBe <=(currOffset)
+            }
+          case first :: second :: _ =>
+            withClue(s"first.startOffset=${first.startOffset}, currOffset=$currOffset") {
+              first.startOffset shouldBe <=(currOffset)
+            }
+            withClue(s"currOffset=$currOffset, second.startOffset=${second.startOffset}") {
+              currOffset shouldBe <(second.startOffset)
+            }
+          case xs => throw new IllegalStateException(s"$xs")
+        }
+    }
+  }
+
+  private val currOffsetGen = Gen.choose(0L, Long.MaxValue)
+
+  private def nextRulesGen(prevRules: MatchingRules): Gen[Option[MatchingRules]] =
+    if (prevRules.startOffset == Long.MaxValue) Gen.const(None)
+    else
+      for {
+        startOffset <- Gen.choose(prevRules.startOffset + 1, Long.MaxValue)
+        disabled    <- Arbitrary.arbBool.arbitrary
+        tickSize    <- if (disabled) Gen.const(TickSize.Disabled) else Gen.choose(1, Long.MaxValue).map(TickSize.Enabled)
+      } yield Some(MatchingRules(startOffset, tickSize))
+
+  private val firstRuleGen: Gen[MatchingRules] = for {
+    disabled <- Arbitrary.arbBool.arbitrary
+    tickSize <- if (disabled) Gen.const(TickSize.Disabled) else Gen.choose(1, Long.MaxValue).map(TickSize.Enabled)
+  } yield MatchingRules(0L, tickSize)
+
+  private def rulesChainGen(maxNumber: Int): Gen[NonEmptyList[MatchingRules]] = {
+    def loop(rest: Int, acc: Gen[NonEmptyList[MatchingRules]]): Gen[NonEmptyList[MatchingRules]] =
+      if (rest == 0) acc
+      else
+        for {
+          xs <- acc
+          x  <- nextRulesGen(xs.head)
+          r  <- x.fold(Gen.const(xs))(x => loop(rest - 1, Gen.const(x :: xs)))
+        } yield r
+
+    Gen.lzy(loop(maxNumber, firstRuleGen.map(NonEmptyList.one)).map(_.reverse))
+  }
+}

--- a/node/src/main/scala/com/wavesplatform/settings/utils/ConfigOps.scala
+++ b/node/src/main/scala/com/wavesplatform/settings/utils/ConfigOps.scala
@@ -1,6 +1,6 @@
 package com.wavesplatform.settings.utils
 
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, Validated}
 import cats.implicits._
 import com.typesafe.config.Config
 import net.ceedubs.ficus.readers.ValueReader
@@ -17,8 +17,8 @@ object ConfigOps {
       cfgValidator.validateList[T](path).map(_.toSet) valueOr throwErrors
     }
 
-    def getValidatedMap[T, U](path: String)(implicit tupleReader: ValueReader[(T, U)]): Map[T, U] = {
-      cfgValidator.validateList[(T, U)](path).map(_.toMap) valueOr throwErrors
+    def getValidatedMap[K, V: ValueReader](path: String)(keyReader: String => Validated[String, K]): Map[K, V] = {
+      cfgValidator.validateMap(path)(keyReader) valueOr throwErrors
     }
 
     def getValidatedByPredicate[T: ValueReader](path: String)(predicate: T => Boolean, errorMsg: String): T = {


### PR DESCRIPTION
* OrderBook and OrderBookActor works with rules. Worked with normalizedTickSize before, thus wasn't able to preserve matching results after restart.
* OrderBookActor is able to switch rules during the work.

MatcherSettings:
* "order-restrictions" now is a dictionary pair->rules (was a list) and used only during validation;
* "matching-rules" are rules to update a functionality of matching engine. See the application.conf in DEX for further information;