### PR TITLE
DEX-313 Ability to blacklist an asset, but allow a pair with this asset

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -258,8 +258,12 @@ waves {
     # Blacklisted addresses
     blacklisted-addresses: []
 
-    # Whitelist of the asset pairs. Empty whitelist means that all pairs are allowed
-    #
+    # * yes - only "allowed-asset-pairs" are allowed to trade. Other pairs are blacklisted.
+    # * no  - "allowed-asset-pairs" are permitted to trade. If a pair is not in "allowed-asset-pairs",
+    #         it's checked by "blacklisted-assets" and "blacklisted-names".
+    white-list-only = no
+
+    # Example:
     # allowed-asset-pairs = [
     #  "WAVES-8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS"
     # ]

--- a/src/main/scala/com/wavesplatform/matcher/Matcher.scala
+++ b/src/main/scala/com/wavesplatform/matcher/Matcher.scala
@@ -98,10 +98,13 @@ class Matcher(actorSystem: ActorSystem,
 
   private def validateOrder(o: Order) =
     for {
-      _ <- OrderValidator.matcherSettingsAware(matcherPublicKey,
-                                               blacklistedAddresses,
-                                               matcherSettings.blacklistedAssets.map(AssetPair.extractAssetId(_).get),
-                                               matcherSettings.allowedAssetPairs)(o)
+      _ <- OrderValidator.matcherSettingsAware(
+        matcherPublicKey,
+        blacklistedAddresses,
+        matcherSettings.whiteListOnly,
+        matcherSettings.blacklistedAssets.map(AssetPair.extractAssetId(_).get),
+        matcherSettings.allowedAssetPairs
+      )(o)
       _ <- OrderValidator.timeAware(time)(o)
       _ <- OrderValidator.blockchainAware(
         blockchain,

--- a/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
+++ b/src/main/scala/com/wavesplatform/matcher/MatcherSettings.scala
@@ -42,6 +42,7 @@ case class MatcherSettings(enable: Boolean,
                            balanceWatchingBufferInterval: FiniteDuration,
                            eventsQueue: EventsQueueSettings,
                            disableExtraFeeForScript: Boolean,
+                           whiteListOnly: Boolean,
                            allowedAssetPairs: Set[AssetPair],
                            exchangeTransactionBroadcast: ExchangeTransactionBroadcastSettings)
 
@@ -105,6 +106,7 @@ object MatcherSettings {
       res fold (ex => throw new Exception(ex.getMessage), identity)
     }
 
+    val whiteListOnly            = config.as[Boolean]("white-list-only")
     val allowedAssetPairs        = config.as[Set[String]]("allowed-asset-pairs").map(getAssetPairFromString)
     val disableExtraFeeForScript = config.as[Boolean]("disable-extra-fee-for-script")
     val broadcastUntilConfirmed  = config.as[ExchangeTransactionBroadcastSettings]("exchange-transaction-broadcast")
@@ -135,6 +137,7 @@ object MatcherSettings {
       balanceWatchingBufferInterval,
       eventsQueue,
       disableExtraFeeForScript,
+      whiteListOnly,
       allowedAssetPairs,
       broadcastUntilConfirmed
     )

--- a/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
@@ -37,6 +37,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |    blacklisted-addresses = [
         |      3N5CBq8NYBMBU3UVS3rfMgaQEpjZrkWcBAD
         |    ]
+        |    white-list-only = yes
         |    order-book-snapshot-http-cache {
         |      cache-timeout = 11m
         |      depth-ranges = [1, 5, 333]
@@ -95,6 +96,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.blacklistedAssets shouldBe Set("a")
     settings.blacklistedNames.map(_.pattern.pattern()) shouldBe Seq("b")
     settings.blacklistedAddresses shouldBe Set("3N5CBq8NYBMBU3UVS3rfMgaQEpjZrkWcBAD")
+    settings.whiteListOnly shouldBe true
     settings.orderBookSnapshotHttpCache shouldBe OrderBookSnapshotHttpCache.Settings(
       cacheTimeout = 11.minutes,
       depthRanges = List(1, 5, 333)


### PR DESCRIPTION
* whitelist functionality is decoupled from "allowed-asset-pairs";
* "white-list-only" setting (see the application.conf for further information);
* updated unit tests;