### PR TITLE
SC-323 tests for transactions/address and stateChanges/address APIs

### DIFF
--- a/node-it/src/test/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
@@ -349,8 +349,11 @@ object AsyncHttpApi extends Assertions {
                  "version"  -> version))
     }
 
-    def debugStateChange(invokeScriptTransactionId: String): Future[DebugStateChanges] =
+    def debugStateChanges(invokeScriptTransactionId: String): Future[DebugStateChanges] =
       get(s"/debug/stateChanges/info/$invokeScriptTransactionId").as[DebugStateChanges]
+
+    def debugStateChangesByAddress(address: String, limit: Int = 10000): Future[Seq[DebugStateChanges]] =
+      get(s"/debug/stateChanges/address/$address/limit/$limit").as[Seq[DebugStateChanges]]
 
     def assetBalance(address: String, asset: String): Future[AssetBalance] =
       get(s"/assets/balance/$address/$asset").as[AssetBalance]

--- a/node-it/src/test/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/api/AsyncHttpApi.scala
@@ -193,11 +193,11 @@ object AsyncHttpApi extends Assertions {
 
     def transactionInfo(txId: String): Future[TransactionInfo] = get(s"/transactions/info/$txId").as[TransactionInfo]
 
-    def transactionsByAddress(address: String, limit: Int): Future[Seq[Seq[TransactionInfo]]] =
-      get(s"/transactions/address/$address/limit/$limit").as[Seq[Seq[TransactionInfo]]]
+    def transactionsByAddress(address: String, limit: Int): Future[Seq[TransactionInfo]] =
+      get(s"/transactions/address/$address/limit/$limit").as[Seq[Seq[TransactionInfo]]].map(_.flatten)
 
-    def transactionsByAddress(address: String, limit: Int, after: String): Future[Seq[Seq[TransactionInfo]]] = {
-      get(s"/transactions/address/$address/limit/$limit?after=$after").as[Seq[Seq[TransactionInfo]]]
+    def transactionsByAddress(address: String, limit: Int, after: String): Future[Seq[TransactionInfo]] = {
+      get(s"/transactions/address/$address/limit/$limit?after=$after").as[Seq[Seq[TransactionInfo]]].map(_.flatten)
     }
 
     def assetDistributionAtHeight(asset: String, height: Int, limit: Int, maybeAfter: Option[String] = None): Future[AssetDistributionPage] = {

--- a/node-it/src/test/scala/com/wavesplatform/it/api/SyncHttpApi.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/api/SyncHttpApi.scala
@@ -212,10 +212,10 @@ object SyncHttpApi extends Assertions {
     def transactionInfo(txId: String): TransactionInfo =
       sync(async(n).transactionInfo(txId))
 
-    def transactionsByAddress(address: String, limit: Int): Seq[Seq[TransactionInfo]] =
+    def transactionsByAddress(address: String, limit: Int): Seq[TransactionInfo] =
       sync(async(n).transactionsByAddress(address, limit))
 
-    def transactionsByAddress(address: String, limit: Int, after: String): Seq[Seq[TransactionInfo]] =
+    def transactionsByAddress(address: String, limit: Int, after: String): Seq[TransactionInfo] =
       sync(async(n).transactionsByAddress(address, limit, after))
 
     def scriptCompile(code: String): CompiledScript =

--- a/node-it/src/test/scala/com/wavesplatform/it/api/SyncHttpApi.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/api/SyncHttpApi.scala
@@ -198,8 +198,12 @@ object SyncHttpApi extends Assertions {
     def reissue(sourceAddress: String, assetId: String, quantity: Long, reissuable: Boolean, fee: Long): Transaction =
       sync(async(n).reissue(sourceAddress, assetId, quantity, reissuable, fee))
 
-    def debugStateChange(transactionId:String): DebugStateChanges ={
-      sync(async(n).debugStateChange(transactionId))
+    def debugStateChanges(transactionId:String): DebugStateChanges ={
+      sync(async(n).debugStateChanges(transactionId))
+    }
+
+    def debugStateChangesByAddress(address:String, limit: Int): Seq[DebugStateChanges] ={
+      sync(async(n).debugStateChangesByAddress(address, limit))
     }
 
     def payment(sourceAddress: String, recipient: String, amount: Long, fee: Long): Transaction =

--- a/node-it/src/test/scala/com/wavesplatform/it/api/model.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/api/model.scala
@@ -91,6 +91,18 @@ object Transaction {
   implicit val transactionFormat: Format[Transaction] = Json.format
 }
 
+trait TxInfo {
+  def `type`: Int
+  def id: String
+  def fee: Long
+  def timestamp: Long
+  def sender: Option[String]
+  def height: Int
+  def minSponsoredAssetFee: Option[Long]
+  def recipient: Option[String]
+  def script: Option[String]
+}
+
 case class TransactionInfo(`type`: Int,
                            id: String,
                            fee: Long,
@@ -99,7 +111,7 @@ case class TransactionInfo(`type`: Int,
                            height: Int,
                            minSponsoredAssetFee: Option[Long],
                            recipient: Option[String],
-                           script: Option[String])
+                           script: Option[String]) extends TxInfo
 object TransactionInfo {
   implicit val format: Format[TransactionInfo] = Json.format
 }
@@ -134,7 +146,16 @@ object StateChangesDetails {
   implicit val stateChangeResponseFormat: Format[StateChangesDetails] = Json.format[StateChangesDetails]
 }
 
-case class DebugStateChanges(stateChanges: StateChangesDetails)
+case class DebugStateChanges(`type`: Int,
+                             id: String,
+                             fee: Long,
+                             timestamp: Long,
+                             sender: Option[String],
+                             height: Int,
+                             minSponsoredAssetFee: Option[Long],
+                             recipient: Option[String],
+                             script: Option[String],
+                             stateChanges: Option[StateChangesDetails]) extends TxInfo
 object DebugStateChanges{
   implicit val debugStateChanges: Format[DebugStateChanges] = Json.format
 }

--- a/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/HodlContractTransactionSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/HodlContractTransactionSuite.scala
@@ -151,18 +151,18 @@ class HodlContractTransactionSuite extends BaseTransactionSuite with CancelAfter
     sender.getData(contract.address, caller.address) shouldBe IntegerDataEntry(caller.address, 0.01.waves)
     (balanceAfter - balanceBefore) shouldBe -1.49.waves
 
-    val stateChangeInfo = sender.debugStateChange(invokeScriptId).stateChanges
+    val stateChangesInfo = sender.debugStateChanges(invokeScriptId).stateChanges
 
-    val stateChangeData = stateChangeInfo.data.head
-    stateChangeInfo.data.length shouldBe 1
-    stateChangeData.`type` shouldBe "integer"
-    stateChangeData.value shouldBe 0.01.waves
+    val stateChangesData = stateChangesInfo.get.data.head
+    stateChangesInfo.get.data.length shouldBe 1
+    stateChangesData.`type` shouldBe "integer"
+    stateChangesData.value shouldBe 0.01.waves
 
-    val stateChangeTransfers = stateChangeInfo.transfers.head
-    stateChangeInfo.transfers.length shouldBe 1
-    stateChangeTransfers.address shouldBe caller.address
-    stateChangeTransfers.amount shouldBe 1.49.waves
-    stateChangeTransfers.asset shouldBe None
+    val stateChangesTransfers = stateChangesInfo.get.transfers.head
+    stateChangesInfo.get.transfers.length shouldBe 1
+    stateChangesTransfers.address shouldBe caller.address
+    stateChangesTransfers.amount shouldBe 1.49.waves
+    stateChangesTransfers.asset shouldBe None
   }
 
 }

--- a/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/InvokeScriptTransactionStateChangesSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/InvokeScriptTransactionStateChangesSuite.scala
@@ -1,0 +1,148 @@
+package com.wavesplatform.it.sync.smartcontract
+
+import com.wavesplatform.common.utils.EitherExt2
+import com.wavesplatform.it.api
+import com.wavesplatform.it.api.{DataResponse, DebugStateChanges, StateChangesDetails, TransactionInfo}
+import com.wavesplatform.it.api.SyncHttpApi._
+import com.wavesplatform.it.sync.setScriptFee
+import com.wavesplatform.it.transactions.BaseTransactionSuite
+import com.wavesplatform.it.util._
+import com.wavesplatform.lang.v1.compiler.Terms.CONST_LONG
+import com.wavesplatform.state._
+import com.wavesplatform.transaction.smart.script.ScriptCompiler
+import org.scalatest.CancelAfterFailure
+
+class InvokeScriptTransactionStateChangesSuite extends BaseTransactionSuite with CancelAfterFailure {
+
+  private val contract = pkByAddress(firstAddress)
+  private val caller = pkByAddress(secondAddress)
+  private val recipient = pkByAddress(thirdAddress)
+
+  test("write") {
+    val simpleAsset = sender.issue(contract.address, "simple", "", 1000, 0)
+
+    val script = ScriptCompiler.compile(
+      """
+        |{-# STDLIB_VERSION 3 #-}
+        |{-# CONTENT_TYPE DAPP #-}
+        |{-# SCRIPT_TYPE ACCOUNT #-}
+        |
+        |@Callable(i)
+        |func write(text: String) = {
+        |    WriteSet([DataEntry("result", text)])
+        |}
+        |
+        |@Callable(i)
+        |func sendWaves(recipient: String, amount: Int) = {
+        |    TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, unit)])
+        |}
+        |
+        |@Callable(i)
+        |func sendAsset(recipient: String, amount: Int, assetId: String) = {
+        |    TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, assetId.fromBase58String())])
+        |}
+        |
+        |@Callable(i)
+        |func writeAndSendWaves(text: String, recipient: String, amount: Int) = {
+        |    ScriptResult(
+        |        WriteSet([DataEntry("result", text)]),
+        |        TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, unit)])
+        |    )
+        |}
+        |
+        |@Callable(i)
+        |func writeAndSendAsset(text: String, recipient: String, amount: Int, assetId: String) = {
+        |    ScriptResult(
+        |        WriteSet([DataEntry("result", text)]),
+        |        TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, assetId.fromBase58String())])
+        |    )
+        |}
+      """.stripMargin).explicitGet()._1.bytes().base64
+    sender.setScript(contract.address, Some(script), setScriptFee, waitForTx = true).id
+
+    val initCallerTxs = sender.transactionsByAddress(caller.address, 100).length
+    val initDAppTxs = sender.transactionsByAddress(contract.address, 100).length
+    val initCallerStateChanges = sender.debugStateChangesByAddress(caller.address, 100).length
+    val initDAppStateChanges = sender.debugStateChangesByAddress(contract.address, 100).length
+    initCallerTxs shouldBe initCallerStateChanges
+    initDAppTxs shouldBe initDAppStateChanges
+
+
+
+    val writeTx = sender.invokeScript(
+      caller.address,
+      contract.address,
+      func = Some("write"),
+      args = List(CONST_LONG(10)),
+      fee = 0.005.waves,
+      waitForTx = true
+    )
+
+    val txInfo = sender.transactionInfo(writeTx.id)
+    val callerTxs = sender.transactionsByAddress(caller.address, 100)
+    val dAppTxs = sender.transactionsByAddress(contract.address, 100)
+    val txStateChanges = sender.debugStateChanges(writeTx.id)
+    val callerStateChanges = sender.debugStateChangesByAddress(caller.address, 100)
+    val dAppStateChanges = sender.debugStateChangesByAddress(contract.address, 100)
+
+    callerTxs.length shouldBe initCallerTxs + 1
+    callerTxs.length shouldBe callerStateChanges.length
+    dAppTxs.length shouldBe initDAppTxs + 1
+    dAppTxs.length shouldBe dAppStateChanges.length
+
+    txInfoShouldBeEqual(txInfo, txStateChanges)
+
+    val expected = StateChangesDetails(Seq(DataResponse("string", 10, "result")), Seq())
+    txStateChanges.stateChanges.get.data shouldBe expected
+    callerStateChanges.head.stateChanges.get shouldBe expected
+    dAppStateChanges.head.stateChanges.get shouldBe expected
+  }
+
+  /*test("contract caller invokes a default function on a contract") {
+
+
+    val _ = sender.invokeScript(
+      caller.address,
+      contract.address,
+      func = None,
+      payment = Seq(),
+      fee = 1.waves,
+      waitForTx = true
+    )
+    sender.getData(contract.address, "a") shouldBe StringDataEntry("a", "b")
+    sender.getData(contract.address, "sender") shouldBe StringDataEntry("sender", "senderId")
+  }
+
+  test("verifier works") {
+
+    val tx =
+      DataTransaction
+        .create(
+          sender = contract,
+          data = List(StringDataEntry("a", "OOO")),
+          feeAmount = 1.waves,
+          timestamp = System.currentTimeMillis(),
+          proofs = Proofs.empty
+        )
+        .explicitGet()
+
+    val dataTxId = sender
+      .signedBroadcast(tx.json() + ("type" -> JsNumber(DataTransaction.typeId.toInt)))
+      .id
+
+    nodes.waitForHeightAriseAndTxPresent(dataTxId)
+
+    sender.getData(contract.address, "a") shouldBe StringDataEntry("a", "OOO")
+  }*/
+
+  def txInfoShouldBeEqual(info: TransactionInfo, stateChanges: DebugStateChanges) {
+    info.`type` shouldBe stateChanges.`type`
+    info.id shouldBe stateChanges.id
+    info.fee shouldBe stateChanges.fee
+    info.timestamp shouldBe stateChanges.timestamp
+    info.sender shouldBe stateChanges.sender
+    info.height shouldBe stateChanges.height
+    info.minSponsoredAssetFee shouldBe stateChanges.minSponsoredAssetFee
+    info.script shouldBe stateChanges.script
+  }
+}

--- a/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/InvokeScriptTransactionStateChangesSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/InvokeScriptTransactionStateChangesSuite.scala
@@ -92,8 +92,8 @@ class InvokeScriptTransactionStateChangesSuite extends BaseTransactionSuite with
 
     txInfoShouldBeEqual(txInfo, txStateChanges)
 
-    val expected = StateChangesDetails(Seq(DataResponse("string", 10, "result")), Seq())
-    txStateChanges.stateChanges.get.data shouldBe expected
+    val expected = StateChangesDetails(Seq(DataResponse("integer", 10, "result")), Seq())
+    txStateChanges.stateChanges.get shouldBe expected
     callerStateChanges.head.stateChanges.get shouldBe expected
     dAppStateChanges.head.stateChanges.get shouldBe expected
   }

--- a/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/InvokeScriptTransactionStateChangesSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/smartcontract/InvokeScriptTransactionStateChangesSuite.scala
@@ -47,11 +47,6 @@ class InvokeScriptTransactionStateChangesSuite extends BaseTransactionSuite with
         |}
         |
         |@Callable(i)
-        |func sendWaves(recipient: String, amount: Int) = {
-        |    TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, unit)])
-        |}
-        |
-        |@Callable(i)
         |func sendAsset(recipient: String, amount: Int, assetId: String) = {
         |    TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, assetId.fromBase58String())])
         |}
@@ -61,14 +56,6 @@ class InvokeScriptTransactionStateChangesSuite extends BaseTransactionSuite with
         |    ScriptResult(
         |        WriteSet([DataEntry("result", value)]),
         |        TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, unit)])
-        |    )
-        |}
-        |
-        |@Callable(i)
-        |func writeAndSendAsset(value: Int, recipient: String, amount: Int, assetId: String) = {
-        |    ScriptResult(
-        |        WriteSet([DataEntry("result", value)]),
-        |        TransferSet([ScriptTransfer(Address(recipient.fromBase58String()), amount, assetId.fromBase58String())])
         |    )
         |}
       """.stripMargin).explicitGet()._1.bytes().base64
@@ -151,8 +138,8 @@ class InvokeScriptTransactionStateChangesSuite extends BaseTransactionSuite with
     val writeTx = sender.invokeScript(
       caller.address,
       contract.address,
-      func = Some("writeAndSendAsset"),
-      args = List(CONST_LONG(7), CONST_STRING(caller.address), CONST_LONG(10), CONST_STRING(simpleAsset)),
+      func = Some("writeAndSendWaves"),
+      args = List(CONST_LONG(7), CONST_STRING(caller.address), CONST_LONG(10)),
       fee = 25,
       feeAssetId = Some(assetSponsoredByRecipient),
       waitForTx = true
@@ -178,7 +165,7 @@ class InvokeScriptTransactionStateChangesSuite extends BaseTransactionSuite with
 
     val expected = StateChangesDetails(
       Seq(DataResponse("integer", 7, "result")),
-      Seq(TransfersInfoResponse(caller.address, Some(simpleAsset), 10))
+      Seq(TransfersInfoResponse(caller.address, None, 10))
     )
     txStateChanges.stateChanges.get shouldBe expected
     callerStateChanges.head.stateChanges.get shouldBe expected

--- a/node-it/src/test/scala/com/wavesplatform/it/sync/transactions/SponsorshipSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/transactions/SponsorshipSuite.scala
@@ -110,14 +110,14 @@ class SponsorshipSuite extends FreeSpec with NodesFromDocker with Matchers with 
         miner.assertAssetBalance(bob.address, sponsorAssetId, 10 * Token)
 
         val aliceTx = alice.transactionsByAddress(alice.address, 100)
-        aliceTx.head.size shouldBe 3
-        aliceTx.head.count(tx => tx.sender.contains(alice.address) || tx.recipient.contains(alice.address)) shouldBe 3
-        aliceTx.head.map(_.id) should contain allElementsOf Seq(transferTxCustomFeeAlice, transferTxToAlice)
+        aliceTx.size shouldBe 3
+        aliceTx.count(tx => tx.sender.contains(alice.address) || tx.recipient.contains(alice.address)) shouldBe 3
+        aliceTx.map(_.id) should contain allElementsOf Seq(transferTxCustomFeeAlice, transferTxToAlice)
 
         val bobTx = alice.transactionsByAddress(bob.address, 100)
-        bobTx.head.size shouldBe 2
-        bobTx.head.count(tx => tx.sender.contains(bob.address) || tx.recipient.contains(bob.address)) shouldBe 2
-        bobTx.head.map(_.id) should contain(transferTxCustomFeeAlice)
+        bobTx.size shouldBe 2
+        bobTx.count(tx => tx.sender.contains(bob.address) || tx.recipient.contains(bob.address)) shouldBe 2
+        bobTx.map(_.id) should contain(transferTxCustomFeeAlice)
       }
 
       "check transactions by address" in {
@@ -127,7 +127,7 @@ class SponsorshipSuite extends FreeSpec with NodesFromDocker with Matchers with 
         val sponsorTx = sponsor.transactionsByAddress(sponsor.address, 100)
 //        sponsorTx.head.size shouldBe 4
 //        sponsorTx.head.count(tx => tx.sender.contains(sponsor.address) || tx.recipient.contains(sponsor.address)) shouldBe 4
-        sponsorTx.head.map(_.id) should contain allElementsOf Seq(sponsorId, transferTxToAlice, sponsorAssetId)
+        sponsorTx.map(_.id) should contain allElementsOf Seq(sponsorId, transferTxToAlice, sponsorAssetId)
       }
 
       "sponsor should receive sponsored asset as fee, waves should be written off" in {

--- a/node-it/src/test/scala/com/wavesplatform/it/sync/transactions/TransactionAPISuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/transactions/TransactionAPISuite.scala
@@ -70,7 +70,6 @@ class TransactionAPISuite extends FreeSpec with NodesFromDocker with Matchers wi
       val received =
         sender
           .transactionsByAddress(recipient.address, limit)
-          .flatten
           .map(_.id)
 
       expected shouldEqual received
@@ -98,7 +97,6 @@ class TransactionAPISuite extends FreeSpec with NodesFromDocker with Matchers wi
       val received =
         sender
           .transactionsByAddress(recipient.address, limit, afterParam)
-          .flatten
           .map(_.id)
 
       expected shouldEqual received
@@ -125,8 +123,8 @@ class TransactionAPISuite extends FreeSpec with NodesFromDocker with Matchers wi
 
   def loadAll(node: Node, address: String, limit: Int, maybeAfter: Option[String], acc: List[TransactionInfo]): List[TransactionInfo] = {
     val txs = maybeAfter match {
-      case None         => node.transactionsByAddress(address, limit).flatten.toList
-      case Some(lastId) => node.transactionsByAddress(address, limit, lastId).flatten.toList
+      case None         => node.transactionsByAddress(address, limit).toList
+      case Some(lastId) => node.transactionsByAddress(address, limit, lastId).toList
     }
 
     txs.lastOption match {

--- a/node/src/main/scala/com/wavesplatform/http/DebugApiRoute.scala
+++ b/node/src/main/scala/com/wavesplatform/http/DebugApiRoute.scala
@@ -369,18 +369,18 @@ case class DebugApiRoute(ws: WavesSettings,
 
   def stateChanges: Route = stateChangesById ~ stateChangesByAddress
 
-  @Path("/stateChanges/info/{transactionId}")
+  @Path("/stateChanges/info/{id}")
   @ApiOperation(value = "Transaction state changes", notes = "Returns state changes made by the transaction", httpMethod = "GET")
   @ApiImplicitParams(
     Array(
-      new ApiImplicitParam(name = "transactionId", value = "Transaction id", required = true, dataType = "string", paramType = "path")
+      new ApiImplicitParam(name = "id", value = "Transaction ID", required = true, dataType = "string", paramType = "path")
     ))
-  def stateChangesById: Route = (get & path("stateChanges" / "info" / B58Segment) & handleExceptions(jsonExceptionHandler)) { transactionId =>
-    blockchain.transactionInfo(transactionId) match {
-      case Some((_, tx: InvokeScriptTransaction)) =>
+  def stateChangesById: Route = (get & path("stateChanges" / "info" / B58Segment) & handleExceptions(jsonExceptionHandler)) { id =>
+    blockchain.transactionInfo(id) match {
+      case Some((h, tx: InvokeScriptTransaction)) =>
         val resultE = blockchain
           .invokeScriptResult(TransactionId(tx.id()))
-          .map(isr => Json.obj("transaction" -> tx, "stateChanges" -> isr))
+          .map(isr => tx.json.map(_ ++ Json.obj("height" -> h, "stateChanges" -> isr))())
         complete(resultE)
 
       case None =>
@@ -392,11 +392,18 @@ case class DebugApiRoute(ws: WavesSettings,
   }
 
   @Path("/stateChanges/address/{address}/limit/{limit}")
-  @ApiOperation(value = "Transactions by address state changes", notes = "Returns state changes made by the transaction", httpMethod = "GET")
+  @ApiOperation(value = "List of transactions by address with state changes",
+                notes = "Get list of transactions with state changes where specified address has been involved",
+                httpMethod = "GET")
   @ApiImplicitParams(
     Array(
       new ApiImplicitParam(name = "address", value = "Address", required = true, dataType = "string", paramType = "path"),
-      new ApiImplicitParam(name = "limit", value = "Limit", required = true, dataType = "integer", paramType = "path")
+      new ApiImplicitParam(name = "limit",
+                           value = "Number of transactions to be returned",
+                           required = true,
+                           dataType = "integer",
+                           paramType = "path"),
+      new ApiImplicitParam(name = "after", value = "Id of transaction to paginate after", required = false, dataType = "string", paramType = "query")
     ))
   def stateChangesByAddress: Route =
     (get & path("stateChanges" / "address" / AddrSegment / "limit" / IntNumber) & parameter('after.?) & handleExceptions(jsonExceptionHandler)) {


### PR DESCRIPTION
Additionally changed `/stateChanges/info` API: now `stateChanges` is field of transaction object as in `stateChanges/address`