### PR TITLE
DEX-319 MatcherActor back-pressure

### DIFF
--- a/src/main/scala/com/wavesplatform/matcher/WatchDistributedCompletionActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/WatchDistributedCompletionActor.scala
@@ -8,7 +8,7 @@ class WatchDistributedCompletionActor(workers: Set[ActorRef], completionReceiver
   override def receive: Receive = state(workers)
 
   private def state(rest: Set[ActorRef]): Receive = {
-    case x if x == workCompleted =>
+    case `workCompleted` =>
       val updatedRest = rest - sender()
       if (updatedRest.isEmpty) {
         completionReceiver ! workCompleted

--- a/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/OrderBookActor.scala
@@ -87,6 +87,8 @@ class OrderBookActor(owner: ActorRef,
           }
       }
 
+    case MatcherActor.Ping => sender() ! MatcherActor.Pong
+
     case ForceStartOrderBook(p) if p == assetPair =>
       sender() ! OrderBookCreated(assetPair)
 

--- a/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
+++ b/src/main/scala/com/wavesplatform/matcher/queue/MatcherQueue.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 trait MatcherQueue {
-  def startConsume(fromOffset: QueueEventWithMeta.Offset, process: QueueEventWithMeta => Unit): Unit
+  def startConsume(fromOffset: QueueEventWithMeta.Offset, process: Seq[QueueEventWithMeta] => Future[Unit]): Unit
 
   /**
     * @return Depending on settings and result:
@@ -13,6 +13,8 @@ trait MatcherQueue {
     *         Future.failed(error)       if storing is enabled and it was failed
     */
   def storeEvent(payload: QueueEvent): Future[Option[QueueEventWithMeta]]
+
+  def lastProcessedOffset: QueueEventWithMeta.Offset
 
   /**
     * @return -1 if topic is empty or even it doesn't exist


### PR DESCRIPTION
* KafkaMatcherQueue, LocalMatcherQueue support backpressure;
* LocalMatcherQueue correctly reports the number of processed events;

MatcherQueue:
* startConsume.process must return Future[Unit] to know that all previous requests were processed to continue processing;
* Added lastProcessedOffset;