### PR TITLE
SC-393 Limit input byte vector size for sigVerify and rsaVerify funcs…

### DIFF
--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/BaseGlobal.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/BaseGlobal.scala
@@ -20,6 +20,7 @@ trait BaseGlobal {
   val MaxBase64String  = 44 * 1024
   val MaxLiteralLength = 12 * 1024
   val MaxAddressLength = 36
+  val MaxByteStrSizeForVerifyFuncs = 32 * 1024
 
   def base58Encode(input: Array[Byte]): Either[String, String]
   def base58Decode(input: String, limit: Int = MaxLiteralLength): Either[String, Array[Byte]]

--- a/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/CryptoContext.scala
+++ b/lang/shared/src/main/scala/com/wavesplatform/lang/v1/evaluator/ctx/impl/CryptoContext.scala
@@ -73,7 +73,7 @@ object CryptoContext {
                      ("pub", BYTESTR, "public key")) {
         case CONST_BYTESTR(msg: ByteStr) :: CONST_BYTESTR(sig: ByteStr) :: CONST_BYTESTR(pub: ByteStr) :: Nil
             if (contextVer != V1 && contextVer != V2 && msg.size > global.MaxByteStrSizeForVerifyFuncs) =>
-          Left(s"Invalid message size, must be not greater than ${global.MaxByteStrSizeForVerifyFuncs}KB")
+          Left(s"Invalid message size, must be not greater than ${global.MaxByteStrSizeForVerifyFuncs / 1024} KB")
         case CONST_BYTESTR(msg: ByteStr) :: CONST_BYTESTR(sig: ByteStr) :: CONST_BYTESTR(pub: ByteStr) :: Nil =>
           Right(CONST_BOOLEAN(global.curve25519verify(msg.arr, sig.arr, pub.arr)))
         case _ => ???
@@ -93,7 +93,7 @@ object CryptoContext {
       ) {
         case (digestAlg: CaseObj) :: CONST_BYTESTR(msg: ByteStr) :: CONST_BYTESTR(sig: ByteStr) :: CONST_BYTESTR(pub: ByteStr) :: Nil
             if (msg.size > global.MaxByteStrSizeForVerifyFuncs) =>
-          Left(s"Invalid message size, must be not greater than ${global.MaxByteStrSizeForVerifyFuncs}KB")
+          Left(s"Invalid message size, must be not greater than ${global.MaxByteStrSizeForVerifyFuncs / 1024} KB")
         case (digestAlg: CaseObj) :: CONST_BYTESTR(msg: ByteStr) :: CONST_BYTESTR(sig: ByteStr) :: CONST_BYTESTR(pub: ByteStr) :: Nil =>
           algFromCO(digestAlg) map { alg =>
             CONST_BOOLEAN(global.rsaVerify(alg, msg.arr, sig.arr, pub.arr))


### PR DESCRIPTION
… (RIDE)