### PR TITLE
Handle failure of Explorer startup

### DIFF
--- a/node/src/main/scala/com/wavesplatform/Explorer.scala
+++ b/node/src/main/scala/com/wavesplatform/Explorer.scala
@@ -106,7 +106,10 @@ object Explorer extends ScorexLogging {
     log.info(s"Blockchain height is $blockchainHeight")
     try {
 
-      val flag = args(1).toUpperCase
+      val flag = Try(args(1)).fold(e => {
+        log.error("Failed to resolve second startup argument.", e)
+        throw e
+      }, identity).toUpperCase
 
       flag match {
         case "B" =>


### PR DESCRIPTION
Dear maintainer!

I found the class Explorer. I've seen that the first command line argument is optional. When it is not defined then default is used.
```
val configFilename = Try(args(0)).toOption.getOrElse("waves-testnet.conf")
```
But the second command line argument is treated like required but what if it not provided?
```
val flag = Try(args(1)).fold(e => {
    log.error("Failed to resolve second startup argument.", e)
    throw e
}, identity).toUpperCase
```

I think it is good to log the case when second argument is not provided.