### PR TITLE
NODE-1925: Limit UTX processing time

### DIFF
--- a/node/src/main/scala/com/wavesplatform/network/UtxPoolSynchronizer.scala
+++ b/node/src/main/scala/com/wavesplatform/network/UtxPoolSynchronizer.scala
@@ -5,6 +5,7 @@ import com.google.common.cache.CacheBuilder
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.settings.SynchronizationSettings.UtxSynchronizerSettings
+import com.wavesplatform.transaction.TxValidationError.GenericError
 import com.wavesplatform.transaction.smart.script.trace.TracedResult
 import com.wavesplatform.transaction.{LastBlockInfo, Transaction}
 import com.wavesplatform.utils.ScorexLogging
@@ -13,16 +14,25 @@ import io.netty.channel.Channel
 import io.netty.channel.group.ChannelGroup
 import monix.execution.{AsyncQueue, CancelableFuture, Scheduler}
 import monix.reactive.Observable
-import com.wavesplatform.utils.Tap
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.util.Success
 
 trait UtxPoolSynchronizer {
   def tryPublish(tx: Transaction, source: Channel): Unit
   def publish(tx: Transaction): TracedResult[ValidationError, Boolean]
 }
 
-class UtxPoolSynchronizerImpl(utx: UtxPool, val settings: UtxSynchronizerSettings, allChannels: ChannelGroup, blockSource: Observable[LastBlockInfo])(
+class UtxPoolSynchronizerImpl(
+    val settings: UtxSynchronizerSettings,
+    putIfNew: Transaction => TracedResult[ValidationError, Boolean],
+    broadcast: (Transaction, Option[Channel]) => Unit,
+    blockSource: Observable[LastBlockInfo]
+)(
     implicit val scheduler: Scheduler
 ) extends UtxPoolSynchronizer
+    with ScorexLogging
     with AutoCloseable {
 
   val queue = AsyncQueue.bounded[(Transaction, Channel)](settings.maxQueueSize)
@@ -49,26 +59,32 @@ class UtxPoolSynchronizerImpl(utx: UtxPool, val settings: UtxSynchronizerSetting
     queue.tryOffer(tx -> source)
   }
 
-  override def publish(tx: Transaction): TracedResult[ValidationError, Boolean] = {
-    utx.putIfNew(tx).tap(_.resultE.foreach(isNew => if (isNew || settings.allowTxRebroadcasting) allChannels.broadcast(tx)))
-  }
+  private def validateFuture(tx: Transaction, allowRebroadcast: Boolean, source: Option[Channel]): Future[TracedResult[ValidationError, Boolean]] =
+    Future(putIfNew(tx))(scheduler)
+      .recover {
+        case t =>
+          log.warn(s"Error validating transaction ${tx.id()}", t)
+          TracedResult(Left(GenericError(t)))
+      }
+      .andThen {
+        case Success(TracedResult(Right(isNew), _)) if isNew || allowRebroadcast => broadcast(tx, source)
+      }
+
+  override def publish(tx: Transaction): TracedResult[ValidationError, Boolean] =
+    Await.result(validateFuture(tx, settings.allowTxRebroadcasting, None), Duration.Inf)
 
   override def close(): Unit = cancelableFuture.cancel()
 
-  private def pollTransactions(): CancelableFuture[Unit] = queue.poll().flatMap { case (tx, source) =>
-    scheduler.execute { () =>
-      utx.putIfNew(tx).resultE match {
-        case Right(true) => allChannels.broadcast(tx, Some(source))
-        case _ => // either tx is not new or is invalid
-      }
-    }
-    pollTransactions()
+  private def pollTransactions(): CancelableFuture[Unit] = queue.poll().flatMap {
+    case (tx, source) =>
+      validateFuture(tx, allowRebroadcast = false, Some(source))
+      pollTransactions()
   }
 }
 
 object UtxPoolSynchronizer extends ScorexLogging {
   def apply(utx: UtxPool, settings: UtxSynchronizerSettings, allChannels: ChannelGroup, blockSource: Observable[LastBlockInfo])(
       implicit sc: Scheduler
-  ): UtxPoolSynchronizer = new UtxPoolSynchronizerImpl(utx, settings, allChannels, blockSource)
+  ): UtxPoolSynchronizer = new UtxPoolSynchronizerImpl(settings, tx => utx.putIfNew(tx), (tx, ch) => allChannels.broadcast(tx, ch), blockSource)
 
 }

--- a/node/src/main/scala/com/wavesplatform/utils/Schedulers.scala
+++ b/node/src/main/scala/com/wavesplatform/utils/Schedulers.scala
@@ -3,8 +3,11 @@ package com.wavesplatform.utils
 import java.util.concurrent.ThreadPoolExecutor.DiscardOldestPolicy
 import java.util.concurrent._
 
+import io.netty.util.{Timeout, Timer}
 import monix.execution.schedulers.{ExecutorScheduler, SchedulerService}
 import monix.execution.{ExecutionModel, Features, UncaughtExceptionReporter}
+
+import scala.concurrent.duration._
 
 /** Helper methods to create schedulers with custom DiscardPolicy */
 object Schedulers {
@@ -35,14 +38,12 @@ object Schedulers {
   }
 
   private[this] def threadFactory(name: String, daemonic: Boolean, reporter: UncaughtExceptionReporter): ThreadFactory = { r: Runnable =>
-    {
-      val thread = new Thread(r)
-      thread.setName(name + "-" + thread.getId)
-      thread.setDaemon(daemonic)
-      thread.setUncaughtExceptionHandler((_: Thread, e: Throwable) => reporter.reportFailure(e))
+    val thread = new Thread(r)
+    thread.setName(name + "-" + thread.getId)
+    thread.setDaemon(daemonic)
+    thread.setUncaughtExceptionHandler((_: Thread, e: Throwable) => reporter.reportFailure(e))
 
-      thread
-    }
+    thread
   }
 
   def singleThread(
@@ -69,6 +70,58 @@ object Schedulers {
     val factory = threadFactory(name, daemonic = true, reporter)
     val executor = new ScheduledThreadPoolExecutor(poolSize, factory, rejectedExecutionHandler) with AdaptedThreadPoolExecutorMixin {
       override def reportFailure(t: Throwable): Unit = reporter.reportFailure(t)
+    }
+
+    ExecutorScheduler(executor, reporter, executionModel, Features.empty)
+  }
+
+  private[this] val m = classOf[Thread].getDeclaredMethod("stop0", classOf[java.lang.Object])
+  m.setAccessible(true)
+
+  private class TimedWrapper[V](timer: Timer, timeout: FiniteDuration, delegate: RunnableScheduledFuture[V]) extends RunnableScheduledFuture[V] {
+    private[this] var maybeScheduledTimeout     = Option.empty[Timeout]
+    override def isPeriodic: Boolean            = delegate.isPeriodic
+    override def getDelay(unit: TimeUnit): Long = delegate.getDelay(unit)
+    override def compareTo(o: Delayed): Int     = delegate.compareTo(o)
+    override def run(): Unit = {
+      val workerThread = Thread.currentThread()
+      maybeScheduledTimeout = Some(
+        timer.newTimeout(
+          (t: Timeout) => if (!t.isCancelled) m.invoke(workerThread, new TimeoutException("Timeout executing task")),
+          timeout.toMillis,
+          MILLISECONDS
+        )
+      )
+      delegate.run()
+      maybeScheduledTimeout.foreach(_.cancel())
+      maybeScheduledTimeout = None
+    }
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      maybeScheduledTimeout.foreach(_.cancel())
+      delegate.cancel(mayInterruptIfRunning)
+    }
+    override def isCancelled: Boolean                  = delegate.isCancelled
+    override def isDone: Boolean                       = delegate.isDone
+    override def get(): V                              = delegate.get()
+    override def get(timeout: Long, unit: TimeUnit): V = delegate.get(timeout, unit)
+  }
+
+  def timeBoundedFixedPool(
+      timer: Timer,
+      timeout: FiniteDuration,
+      poolSize: Int,
+      name: String,
+      reporter: UncaughtExceptionReporter = UncaughtExceptionReporter.default,
+      executionModel: ExecutionModel = ExecutionModel.Default,
+      rejectedExecutionHandler: RejectedExecutionHandler = new DiscardOldestPolicy
+  ): SchedulerService = {
+    val factory = threadFactory(name, daemonic = true, reporter)
+    val executor = new ScheduledThreadPoolExecutor(poolSize, factory, rejectedExecutionHandler) with AdaptedThreadPoolExecutorMixin {
+      override def reportFailure(t: Throwable): Unit = reporter.reportFailure(t)
+      override def decorateTask[V](runnable: Runnable, task: RunnableScheduledFuture[V]): RunnableScheduledFuture[V] =
+        new TimedWrapper(timer, timeout, task)
+      override def decorateTask[V](callable: Callable[V], task: RunnableScheduledFuture[V]): RunnableScheduledFuture[V] =
+        new TimedWrapper(timer, timeout, task)
     }
 
     ExecutorScheduler(executor, reporter, executionModel, Features.empty)

--- a/node/src/test/scala/com/wavesplatform/network/UtxPoolSynchronizerSpec.scala
+++ b/node/src/test/scala/com/wavesplatform/network/UtxPoolSynchronizerSpec.scala
@@ -1,0 +1,66 @@
+package com.wavesplatform.network
+import java.util.concurrent.CountDownLatch
+
+import com.wavesplatform.account.PublicKey
+import com.wavesplatform.common.state.diffs.ProduceError._
+import com.wavesplatform.common.utils.EitherExt2
+import com.wavesplatform.lang.ValidationError
+import com.wavesplatform.settings.SynchronizationSettings.UtxSynchronizerSettings
+import com.wavesplatform.transaction.smart.script.trace.TracedResult
+import com.wavesplatform.transaction.{GenesisTransaction, Transaction}
+import com.wavesplatform.utils.Schedulers
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.util.HashedWheelTimer
+import monix.execution.atomic.AtomicInt
+import monix.reactive.Observable
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+import scala.concurrent.duration._
+
+class UtxPoolSynchronizerSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
+  private[this] val timer     = new HashedWheelTimer
+  private[this] val scheduler = Schedulers.timeBoundedFixedPool(timer, 1.second, 2, "test-utx-sync")
+
+  "UtxPoolSynchronizer" - {
+    def sleep(millis: Int)(tx: Transaction): TracedResult[ValidationError, Boolean] = {
+      while (true) {}
+      TracedResult(Right(true))
+    }
+
+    "rejects transactions which take too long to validate" in withUPS(sleep(Int.MaxValue)) { ups =>
+      ups.publish(GenesisTransaction.create(PublicKey(Array.emptyByteArray), 10L, 0L).explicitGet()).resultE should produce("Timeout executing task")
+    }
+
+    val latch   = new CountDownLatch(5)
+    val counter = AtomicInt(10)
+
+    def countTransactions(tx: Transaction): TracedResult[ValidationError, Boolean] = {
+      if (counter.getAndDecrement() > 5) {
+        while (true) {}
+      }
+      latch.countDown()
+      TracedResult(Right(true))
+    }
+
+    "accepts only those transactions from network which can be validated quickly" in withUPS(countTransactions) { ups =>
+      1 to 10 foreach { i =>
+        ups.tryPublish(GenesisTransaction.create(PublicKey(Array.emptyByteArray), i * 10L, 0L).explicitGet(), new EmbeddedChannel)
+      }
+      latch.await()
+      counter.get() shouldEqual 0
+    }
+  }
+
+  private def withUPS(putIfNew: Transaction => TracedResult[ValidationError, Boolean])(f: UtxPoolSynchronizer => Unit): Unit = {
+    val ups = new UtxPoolSynchronizerImpl(UtxSynchronizerSettings(1000, 2, 1000, true), putIfNew, { (_, _) =>
+    }, Observable.empty)(scheduler)
+    f(ups)
+    ups.close()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    scheduler.shutdown()
+    timer.stop()
+  }
+}


### PR DESCRIPTION
A special time-bounded scheduler decorates all runnables and callables with a  `TimedWrapper` which kills current thread if a task takes too long to execute. This scheduler can be used with `Task`s and `Future`s. Do note however, that when you intend to run a task on this scheduler, you need to explicitly specify an async boundary (and probably also force async execution mode):
```
val future = Task(println(5)).runToFuture(scheduler, forceAsync = true)
```