### PR TITLE
ExchangeTransactionGrpcSuite fix

### DIFF
--- a/node-it/src/test/scala/com/wavesplatform/it/api/SyncHttpApi.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/api/SyncHttpApi.scala
@@ -698,7 +698,7 @@ object SyncHttpApi extends Assertions {
     }
 
     def wavesBalance(address: ByteString): WavesBalances = {
-      sync(async(n).grpc.wavesBalance(address))
+      accounts.getBalances(BalancesRequest.of(address, Seq(ByteString.EMPTY))).next().getWaves
     }
 
     def getTransaction(id: String): PBSignedTransaction = {


### PR DESCRIPTION
1) Fixed blinking ExchangeTransactionGrpcSuite by rewriting wavesBalance() in SyncHttpApi so it uses blockingStub instead of syncing async wavesBalance()