### PR TITLE
UpdateAssetInfo tests: increase timeout in waitForHeight

### DIFF
--- a/node-it/src/test/scala/com/wavesplatform/it/sync/grpc/UpdateAssetInfoTransactionGrpcSuite.scala
+++ b/node-it/src/test/scala/com/wavesplatform/it/sync/grpc/UpdateAssetInfoTransactionGrpcSuite.scala
@@ -50,7 +50,7 @@ class UpdateAssetInfoTransactionGrpcSuite extends GrpcBaseTransactionSuite with 
 
   test("able to update name/description of issued asset") {
     val nextTerm = issueHeight + updateInterval + 1
-    sender.waitForHeight(nextTerm)
+    sender.waitForHeight(nextTerm, 2.minutes)
     val updateAssetInfoTxId =
       PBTransactions
         .vanilla(


### PR DESCRIPTION
With the Go node the default value of 50 seconds does not seem to be enough.
It always takes 1 minute.