### PR TITLE
NODE-2624 /utils/script/evaluate: do not parse bytes in expr

### DIFF
--- a/node/src/main/resources/swagger-ui/openapi.yaml
+++ b/node/src/main/resources/swagger-ui/openapi.yaml
@@ -5402,7 +5402,7 @@ components:
         expr:
           type: string
           example: "default()"
-          description: "Ride expression either as a Ride code, or as compiled in base64 representation"
+          description: "Ride expression"
         state:
           $ref: '#/components/schemas/BlockchainOverrides'
     RideInvocationRequest:

--- a/node/src/main/scala/com/wavesplatform/api/http/utils/UtilsEvaluationRequest.scala
+++ b/node/src/main/scala/com/wavesplatform/api/http/utils/UtilsEvaluationRequest.scala
@@ -13,7 +13,6 @@ import com.wavesplatform.lang.v1.compiler.Terms.EXPR
 import com.wavesplatform.lang.v1.compiler.{ExpressionCompiler, Terms}
 import com.wavesplatform.lang.v1.evaluator.ContractEvaluator.Invocation
 import com.wavesplatform.lang.v1.parser.Parser.LibrariesOffset.NoLibraries
-import com.wavesplatform.lang.v1.serialization.SerdeV1
 import com.wavesplatform.lang.v1.traits.domain.Recipient.Address as RideAddress
 import com.wavesplatform.lang.{ValidationError, utils}
 import com.wavesplatform.state.diffs.FeeValidation.{FeeConstants, FeeUnit}
@@ -44,13 +43,10 @@ object UtilsEvaluationRequest {
 }
 
 case class UtilsExprRequest(
-    expr: Either[ByteStr, String],
+    expr: String,
     state: Option[BlockchainOverrides] = None
 ) extends UtilsEvaluationRequest {
-  def parseCall(version: StdLibVersion): Either[GenericError, Terms.EXPR] = expr match {
-    case Left(binaryCall) => SerdeV1.deserialize(binaryCall.arr).bimap(GenericError(_), _._1)
-    case Right(textCall)  => compile(version, textCall)
-  }
+  def parseCall(version: StdLibVersion): Either[GenericError, Terms.EXPR] = compile(version, expr)
 
   private def compile(version: StdLibVersion, str: String): Either[GenericError, EXPR] =
     ExpressionCompiler
@@ -59,8 +55,6 @@ case class UtilsExprRequest(
 }
 
 object UtilsExprRequest {
-  implicit val byteStrReads: Reads[ByteStr]                   = com.wavesplatform.utils.byteStrFormat
-  implicit val exprReads: Reads[Either[ByteStr, String]]      = com.wavesplatform.api.http.eitherReads[ByteStr, String]
   implicit val utilsExprRequestReads: Reads[UtilsExprRequest] = Json.using[Json.WithDefaultValues].reads[UtilsExprRequest]
 }
 

--- a/ride-runner/src/main/resources/swagger-ui/openapi.yaml
+++ b/ride-runner/src/main/resources/swagger-ui/openapi.yaml
@@ -724,7 +724,7 @@ components:
         expr:
           type: string
           example: "default()"
-          description: "Ride expression either as a Ride code, or as compiled in base64 representation"
+          description: "Ride expression"
         state:
           $ref: '#/components/schemas/BlockchainOverrides'
     RideInvocationRequest:


### PR DESCRIPTION
- UtilsExprRequest.expr is a String instead of JsValue;
- Updated Open API specifications;
- Added a unit test with an access to a global contract constant 'x';
- Removed old tests.