### PR TITLE
Ability to disable time synchronization

### DIFF
--- a/benchmark/src/test/scala/com/wavesplatform/RollbackBenchmark.scala
+++ b/benchmark/src/test/scala/com/wavesplatform/RollbackBenchmark.scala
@@ -12,7 +12,7 @@ import com.wavesplatform.state.{Portfolio, StateSnapshot}
 import com.wavesplatform.transaction.Asset.IssuedAsset
 import com.wavesplatform.transaction.assets.IssueTransaction
 import com.wavesplatform.transaction.{GenesisTransaction, Proofs, TxDecimals, TxPositiveAmount}
-import com.wavesplatform.utils.{NTP, ScorexLogging}
+import com.wavesplatform.utils.{NTP, ScorexLogging, SystemTime, Time}
 
 import java.io.File
 import scala.collection.immutable.VectorMap
@@ -21,7 +21,7 @@ object RollbackBenchmark extends ScorexLogging {
   def main(args: Array[String]): Unit = {
     val settings      = Application.loadApplicationConfig(Some(new File(args(0))))
     val rdb           = RDB.open(settings.dbSettings)
-    val time          = new NTP(settings.ntpServer)
+    val time          = settings.ntpServer.fold[Time](SystemTime)(new NTP(_))
     val rocksDBWriter = RocksDBWriter(rdb, settings.blockchainSettings, settings.dbSettings, settings.enableLightMode)
 
     val issuer = KeyPair(new Array[Byte](32))

--- a/node/src/main/scala/com/wavesplatform/Application.scala
+++ b/node/src/main/scala/com/wavesplatform/Application.scala
@@ -63,7 +63,7 @@ import scala.concurrent.duration.*
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
-class Application(val actorSystem: ActorSystem, val settings: WavesSettings, configRoot: ConfigObject, time: NTP) extends ScorexLogging {
+class Application(val actorSystem: ActorSystem, val settings: WavesSettings, configRoot: ConfigObject, time: Time) extends ScorexLogging {
   app =>
 
   import Application.*
@@ -660,7 +660,7 @@ object Application extends ScorexLogging {
       SystemInformationReporter.report(settings.config)
     }
 
-    val time = new NTP(settings.ntpServer)
+    val time = settings.ntpServer.fold[Time](SystemTime)(new NTP(_))
     Metrics.start(settings.metrics, time)
 
     def dumpMinerConfig(): Unit = {

--- a/node/src/main/scala/com/wavesplatform/Exporter.scala
+++ b/node/src/main/scala/com/wavesplatform/Exporter.scala
@@ -43,7 +43,7 @@ object Exporter extends ScorexLogging {
         val settings = Application.loadApplicationConfig(configFile)
 
         Using.resources(
-          new NTP(settings.ntpServer),
+          settings.ntpServer.fold[Time](SystemTime)(new NTP(_)),
           RDB.open(settings.dbSettings)
         ) { (time, rdb) =>
           val (blockchain, rdbWriter) = StorageFactory(settings, rdb, time, BlockchainUpdateTriggers.noop)

--- a/node/src/main/scala/com/wavesplatform/Importer.scala
+++ b/node/src/main/scala/com/wavesplatform/Importer.scala
@@ -121,7 +121,7 @@ object Importer extends ScorexLogging {
       appenderScheduler: Scheduler,
       extensionTime: Time,
       utxPool: UtxPool,
-      rdb: RDB,
+      rdb: RDB
   ): Seq[Extension] =
     if (wavesSettings.extensions.isEmpty) Seq.empty
     else {
@@ -308,7 +308,7 @@ object Importer extends ScorexLogging {
               case _ =>
                 counter = counter + 1
             }
-          } else if (!quit){
+          } else if (!quit) {
             log.warn(s"Block $block is not a child of the last block ${blockchain.lastBlockId.get}")
           }
         }
@@ -343,9 +343,9 @@ object Importer extends ScorexLogging {
     }
 
     val scheduler = Schedulers.singleThread("appender")
-    val time      = new NTP(settings.ntpServer)
+    val time      = settings.ntpServer.fold[Time](SystemTime)(new NTP(_))
 
-    val rdb         = RDB.open(settings.dbSettings)
+    val rdb = RDB.open(settings.dbSettings)
     val (blockchainUpdater, rdbWriter) =
       StorageFactory(settings, rdb, time, BlockchainUpdateTriggers.combined(triggers))
     val utxPool = new UtxPoolImpl(time, blockchainUpdater, settings.utxSettings, settings.maxTxErrorLogSize, settings.minerSettings.enable)

--- a/node/src/main/scala/com/wavesplatform/settings/WavesSettings.scala
+++ b/node/src/main/scala/com/wavesplatform/settings/WavesSettings.scala
@@ -8,7 +8,7 @@ import pureconfig.generic.auto.*
 
 case class WavesSettings(
     directory: String,
-    ntpServer: String,
+    ntpServer: Option[String],
     maxTxErrorLogSize: Int,
     dbSettings: DBSettings,
     extensions: Seq[String],
@@ -33,7 +33,7 @@ object WavesSettings {
     val wavesConfigSource = ConfigSource.fromConfig(waves)
 
     val directory                 = wavesConfigSource.at("directory").loadOrThrow[String]
-    val ntpServer                 = wavesConfigSource.at("ntp-server").loadOrThrow[String]
+    val ntpServer                 = wavesConfigSource.at("ntp-server").loadOrThrow[Option[String]]
     val maxTxErrorLogSize         = wavesConfigSource.at("max-tx-error-log-size").loadOrThrow[Int]
     val dbSettings                = wavesConfigSource.at("db").loadOrThrow[DBSettings]
     val extensions                = wavesConfigSource.at("extensions").loadOrThrow[Seq[String]]

--- a/node/src/main/scala/com/wavesplatform/utils/Time.scala
+++ b/node/src/main/scala/com/wavesplatform/utils/Time.scala
@@ -9,9 +9,15 @@ import org.apache.commons.net.ntp.NTPUDPClient
 import java.time.Duration
 import scala.concurrent.duration.DurationInt
 
-trait Time {
+trait Time extends AutoCloseable {
   def correctedTime(): Long
   def getTimestamp(): Long
+  override def close(): Unit = {}
+}
+
+object SystemTime extends Time {
+  def correctedTime(): Long = System.currentTimeMillis()
+  def getTimestamp(): Long  = System.currentTimeMillis()
 }
 
 class NTP(ntpServer: String) extends Time with ScorexLogging with AutoCloseable {

--- a/node/src/main/scala/com/wavesplatform/utils/UtilApp.scala
+++ b/node/src/main/scala/com/wavesplatform/utils/UtilApp.scala
@@ -233,7 +233,7 @@ object UtilApp {
   private[this] final class NodeState(c: Command) {
     lazy val settings = Application.loadApplicationConfig(c.configFile.map(new File(_)))
     lazy val wallet   = Wallet(settings.walletSettings)
-    lazy val time     = new NTP(settings.ntpServer)
+    lazy val time     = settings.ntpServer.fold[Time](SystemTime)(new NTP(_))
   }
 
   private[this] object Actions {

--- a/node/tests/src/test/scala/com/wavesplatform/http/UtilsRouteEvaluateSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/http/UtilsRouteEvaluateSpec.scala
@@ -20,7 +20,7 @@ import com.wavesplatform.test.NumericExt
 import com.wavesplatform.transaction.Asset.IssuedAsset
 import com.wavesplatform.transaction.TxHelpers.*
 import com.wavesplatform.transaction.{Asset, AssetIdLength, TxHelpers}
-import com.wavesplatform.utils.{Schedulers, Time}
+import com.wavesplatform.utils.{Schedulers, SystemTime}
 import io.netty.util.HashedWheelTimer
 import monix.execution.schedulers.SchedulerService
 import org.scalamock.scalatest.PathMockFactory
@@ -44,10 +44,7 @@ class UtilsRouteEvaluateSpec
     "rest-time-limited"
   )
   private val utilsApi: UtilsApiRoute = UtilsApiRoute(
-    new Time {
-      def correctedTime(): Long = System.currentTimeMillis()
-      def getTimestamp(): Long  = System.currentTimeMillis()
-    },
+    SystemTime,
     restAPISettings,
     Int.MaxValue,
     () => ScriptEstimatorV3.latest,

--- a/node/tests/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/http/UtilsRouteSpec.scala
@@ -26,7 +26,7 @@ import com.wavesplatform.settings.TestSettings
 import com.wavesplatform.state.Blockchain
 import com.wavesplatform.state.diffs.FeeValidation
 import com.wavesplatform.transaction.smart.script.ScriptCompiler
-import com.wavesplatform.utils.{Schedulers, Time}
+import com.wavesplatform.utils.{Schedulers, SystemTime}
 import io.netty.util.HashedWheelTimer
 import monix.execution.schedulers.SchedulerService
 import org.scalacheck.Gen
@@ -38,7 +38,7 @@ import play.api.libs.json.*
 import scala.concurrent.duration.*
 
 class UtilsRouteSpec extends RouteSpec("/utils") with RestAPISettingsHelper with PropertyChecks with PathMockFactory with Inside with WithDomain {
-  private val estimator = ScriptEstimatorV2
+  private val estimator                                              = ScriptEstimatorV2
   protected override implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(20.seconds)
 
   private val timeBounded: SchedulerService = Schedulers.timeBoundedFixedPool(
@@ -48,11 +48,7 @@ class UtilsRouteSpec extends RouteSpec("/utils") with RestAPISettingsHelper with
     "rest-time-limited"
   )
   private val utilsApi: UtilsApiRoute = UtilsApiRoute(
-    new Time {
-      def correctedTime(): Long = System.currentTimeMillis()
-
-      def getTimestamp(): Long = System.currentTimeMillis()
-    },
+    SystemTime,
     restAPISettings,
     Int.MaxValue,
     () => estimator,

--- a/node/tests/src/test/scala/com/wavesplatform/settings/WavesSettingsSpecification.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/settings/WavesSettingsSpecification.scala
@@ -52,7 +52,7 @@ class WavesSettingsSpecification extends FlatSpec {
 
     settings.directory should be("/xxx")
     settings.dbSettings.directory should be("/xxx/data")
-    settings.ntpServer should be("example.com")
+    settings.ntpServer should be(Some("example.com"))
     settings.networkSettings.file should be(Some(new File("/xxx/peers.dat")))
     settings.walletSettings.file should be(Some(new File("/xxx/wallet/wallet.dat")))
   }


### PR DESCRIPTION
This is useful during testing in a local environment with multiple Waves nodes in Docker. The system time will be used with disabled NTP setting: `waves.ntp-server = null`