### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/node/tests/src/test/scala/com/wavesplatform/network/peer/PeerDatabaseImplSpecification.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/network/peer/PeerDatabaseImplSpecification.scala
@@ -67,7 +67,7 @@ class PeerDatabaseImplSpecification extends FreeSpec {
       database.knownPeers.keys should contain(address1)
     }
 
-    "peer should should become obsolete after time" in withDatabase(settings1) { database =>
+    "peer should become obsolete after time" in withDatabase(settings1) { database =>
       database.touch(address1)
       database.knownPeers.keys should contain(address1)
       sleepLong()


### PR DESCRIPTION
remove redundant word in comment