### PR TITLE
CommitToGeneration signing and validation improvements

### DIFF
--- a/node/src/main/scala/com/wavesplatform/api/http/requests/CommitToGenerationRequest.scala
+++ b/node/src/main/scala/com/wavesplatform/api/http/requests/CommitToGenerationRequest.scala
@@ -38,10 +38,14 @@ case class CommitToGenerationRequest(
         case Some(r) => BlsSignature(r)
         case None    => Right(CommitToGenerationTransaction.mkPopSignature(defaultEndorserKp, exactGenerationPeriodStart))
       }
+      endorserPublicKey <- endorserPublicKey match {
+        case Some(endorserPublicKey) => BlsPublicKey(endorserPublicKey)
+        case None                    => Right(defaultEndorserKp.publicKey)
+      }
       tx <- CommitToGenerationTransaction.create(
         version.getOrElse(1.toByte),
         senderPk, // sender is address, we need a public key
-        endorserPublicKey.fold(defaultEndorserKp.publicKey)(BlsPublicKey.apply),
+        endorserPublicKey,
         exactGenerationPeriodStart,
         timestamp.getOrElse(defaultTimestamp),
         fee.getOrElse(FeeConstants(TransactionType.CommitToGeneration) * FeeUnit),
@@ -65,12 +69,13 @@ case class SignedCommitToGenerationRequest(
 ) {
   def toTx: Either[ValidationError, CommitToGenerationTransaction] =
     for {
-      _senderPk <- PublicKey.fromBase58String(senderPublicKey)
-      sig       <- BlsSignature(commitmentSignature)
+      _senderPk  <- PublicKey.fromBase58String(senderPublicKey)
+      sig        <- BlsSignature(commitmentSignature)
+      endorserPk <- BlsPublicKey(endorserPublicKey)
       t <- CommitToGenerationTransaction.create(
         version.getOrElse(1.toByte),
         _senderPk,
-        BlsPublicKey(endorserPublicKey),
+        endorserPk,
         Height(generationPeriodStart),
         timestamp,
         fee,

--- a/node/src/main/scala/com/wavesplatform/api/http/requests/CommitToGenerationRequest.scala
+++ b/node/src/main/scala/com/wavesplatform/api/http/requests/CommitToGenerationRequest.scala
@@ -2,7 +2,7 @@ package com.wavesplatform.api.http.requests
 
 import com.wavesplatform.account.*
 import com.wavesplatform.common.state.ByteStr
-import com.wavesplatform.crypto.bls.{BlsPublicKey, BlsSignature}
+import com.wavesplatform.crypto.bls.{BlsKeyPair, BlsPublicKey, BlsSignature}
 import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.state.Height
 import com.wavesplatform.state.diffs.FeeValidation.{FeeConstants, FeeUnit}
@@ -14,27 +14,43 @@ object CommitToGenerationRequest {
   given OFormat[SignedCommitToGenerationRequest] = Json.format
 }
 
+/** @param sender Address
+  */
 case class CommitToGenerationRequest(
     version: Option[TxVersion] = None,
     sender: Option[String],
+    endorserPublicKey: Option[ByteStr] = None,
     generationPeriodStart: Option[Height] = None,
     timestamp: Option[Long] = None,
+    fee: Option[Long] = None,
+    commitmentSignature: Option[ByteStr] = None,
     chainId: Option[Byte] = None
 ) {
-  def toTxFrom(sender: PublicKey, defaultGenerationPeriodStart: Height): Either[ValidationError, CommitToGenerationTransaction] =
+  def toTxFrom(
+      senderPk: PublicKey,
+      defaultEndorserKp: => BlsKeyPair,
+      defaultGenerationPeriodStart: Height,
+      defaultTimestamp: => Long
+  ): Either[ValidationError, CommitToGenerationTransaction] = {
+    val exactGenerationPeriodStart = generationPeriodStart.getOrElse(defaultGenerationPeriodStart)
     for {
+      commitmentSignature <- commitmentSignature match {
+        case Some(r) => BlsSignature(r)
+        case None    => Right(CommitToGenerationTransaction.mkPopSignature(defaultEndorserKp, exactGenerationPeriodStart))
+      }
       tx <- CommitToGenerationTransaction.create(
         version.getOrElse(1.toByte),
-        sender,
-        BlsPublicKey(Array.emptyByteArray),
-        generationPeriodStart.getOrElse(defaultGenerationPeriodStart),
-        timestamp.getOrElse(0L),
-        FeeConstants(TransactionType.CommitToGeneration) * FeeUnit,
-        commitmentSignature = BlsSignature.Empty,
+        senderPk, // sender is address, we need a public key
+        endorserPublicKey.fold(defaultEndorserKp.publicKey)(BlsPublicKey.apply),
+        exactGenerationPeriodStart,
+        timestamp.getOrElse(defaultTimestamp),
+        fee.getOrElse(FeeConstants(TransactionType.CommitToGeneration) * FeeUnit),
+        commitmentSignature,
         Proofs.empty,
         chainId.getOrElse(AddressScheme.current.chainId)
       )
     } yield tx
+  }
 }
 
 case class SignedCommitToGenerationRequest(

--- a/node/src/main/scala/com/wavesplatform/block/BlockEndorsement.scala
+++ b/node/src/main/scala/com/wavesplatform/block/BlockEndorsement.scala
@@ -9,7 +9,7 @@ case class BlockEndorsement(
     finalizedId: BlockId,
     finalizedHeight: Height,
     endorsedId: BlockId,
-    signature: BlsSignature.NonEmpty
+    signature: BlsSignature
 ) {
   def signatureValid(endorserPublicKey: BlsPublicKey): Boolean =
     BlsUtils.verifyBasic(signature.byteStr.arr, BlockEndorsement.mkMessage(finalizedId, finalizedHeight, endorsedId), endorserPublicKey.arr)
@@ -25,7 +25,7 @@ object BlockEndorsement {
   ): BlockEndorsement =
     BlockEndorsement(endorserIndex, finalizedId, finalizedHeight, endorsedId, sign(endorserAccount, finalizedId, finalizedHeight, endorsedId))
 
-  def sign(kp: BlsKeyPair, finalizedId: BlockId, finalizedHeight: Height, endorsedId: BlockId): BlsSignature.NonEmpty =
+  def sign(kp: BlsKeyPair, finalizedId: BlockId, finalizedHeight: Height, endorsedId: BlockId): BlsSignature =
     kp.sign(mkMessage(finalizedId, finalizedHeight, endorsedId))
 
   def mkMessage(finalizedId: BlockId, finalizedHeight: Height, endorsedId: BlockId): Array[Byte] =

--- a/node/src/main/scala/com/wavesplatform/block/FinalizationVoting.scala
+++ b/node/src/main/scala/com/wavesplatform/block/FinalizationVoting.scala
@@ -3,15 +3,17 @@ package com.wavesplatform.block
 import com.wavesplatform.crypto.bls.BlsSignature
 import com.wavesplatform.state.{GeneratorIndex, Height}
 
+/** @param aggregatedEndorsement Empty if there is no valid endorsement (except miner's one)
+  */
 case class FinalizationVoting(
     valid: Seq[GeneratorIndex],
     finalizedHeight: Height,
-    aggregatedEndorsement: BlsSignature,
+    aggregatedEndorsement: Option[BlsSignature],
     conflict: Seq[BlockEndorsement]
 ) {
-  def withValid(endorser: GeneratorIndex, signature: BlsSignature.NonEmpty): FinalizationVoting = copy(
+  def withValid(endorser: GeneratorIndex, signature: BlsSignature): FinalizationVoting = copy(
     valid = valid :+ endorser,
-    aggregatedEndorsement = aggregatedEndorsement.append(signature)
+    aggregatedEndorsement = Some(aggregatedEndorsement.fold(signature)(_.append(signature)))
   )
 
   def nonEmpty: Boolean = valid.nonEmpty || conflict.nonEmpty

--- a/node/src/main/scala/com/wavesplatform/block/serialization/BlockSerializer.scala
+++ b/node/src/main/scala/com/wavesplatform/block/serialization/BlockSerializer.scala
@@ -63,9 +63,9 @@ object BlockHeaderSerializer {
       case None => JsObject.empty
       case Some(fv) =>
         val builder = Json.newBuilder
-        if (fv.valid.nonEmpty) builder += "endorserIndexes"                                 -> GeneratorIndex.toInts(fv.valid)
-        if (fv.aggregatedEndorsement.isDefined) builder += "aggregatedEndorsementSignature" -> fv.aggregatedEndorsement.base58
-        if (fv.finalizedHeight > Height(0)) builder += "finalizedHeight"                    -> fv.finalizedHeight
+        if (fv.valid.nonEmpty) builder += "endorserIndexes" -> GeneratorIndex.toInts(fv.valid)
+        fv.aggregatedEndorsement.foreach(s => builder += "aggregatedEndorsementSignature" -> s.base58)
+        if (fv.finalizedHeight > Height(0)) builder += "finalizedHeight" -> fv.finalizedHeight
         if (fv.conflict.nonEmpty) builder += "conflictEndorsements" -> fv.conflict.map { c =>
           Json.obj(
             "endorserIndex"    -> c.endorserIndex.toInt,

--- a/node/src/main/scala/com/wavesplatform/crypto/bls/BlsKeyPair.scala
+++ b/node/src/main/scala/com/wavesplatform/crypto/bls/BlsKeyPair.scala
@@ -9,10 +9,8 @@ import java.util
 sealed trait BlsKeyPair {
   def publicKey: BlsPublicKey
 
-  // TODO: move to package?
-  def sign(message: Array[Byte]): BlsSignature.NonEmpty
-  // TODO: empty => false ?
-  def verify(message: Array[Byte], signature: BlsSignature.NonEmpty): Boolean = publicKey.verify(message, signature)
+  def sign(message: Array[Byte]): BlsSignature
+  def verify(message: Array[Byte], signature: BlsSignature): Boolean = publicKey.verify(message, signature)
 }
 
 object BlsKeyPair {
@@ -23,7 +21,7 @@ private final class BlsSeedKeyPair(private val wavesPrivateKey: Array[Byte]) ext
   private lazy val sk: blst.SecretKey = BlsUtils.mkBlsSecretKey(wavesPrivateKey)
   lazy val publicKey: BlsPublicKey    = BlsPublicKey(BlsUtils.mkBlsPublicKey(sk))
 
-  def sign(message: Array[Byte]): BlsSignature.NonEmpty = BlsSignature.NonEmpty.unsafe(ByteStr(BlsUtils.signBasic(sk, message)))
+  def sign(message: Array[Byte]): BlsSignature = BlsSignature.unsafe(ByteStr(BlsUtils.signBasic(sk, message)))
 
   override def equals(other: Any): Boolean = other match {
     case other: BlsSeedKeyPair => util.Arrays.equals(other.wavesPrivateKey, wavesPrivateKey)

--- a/node/src/main/scala/com/wavesplatform/crypto/bls/BlsKeyPair.scala
+++ b/node/src/main/scala/com/wavesplatform/crypto/bls/BlsKeyPair.scala
@@ -19,7 +19,7 @@ object BlsKeyPair {
 
 private final class BlsSeedKeyPair(private val wavesPrivateKey: Array[Byte]) extends BlsKeyPair {
   private lazy val sk: blst.SecretKey = BlsUtils.mkBlsSecretKey(wavesPrivateKey)
-  lazy val publicKey: BlsPublicKey    = BlsPublicKey(BlsUtils.mkBlsPublicKey(sk))
+  lazy val publicKey: BlsPublicKey    = BlsPublicKey.unsafe(ByteStr(BlsUtils.mkBlsPublicKey(sk)))
 
   def sign(message: Array[Byte]): BlsSignature = BlsSignature.unsafe(ByteStr(BlsUtils.signBasic(sk, message)))
 

--- a/node/src/main/scala/com/wavesplatform/crypto/bls/BlsPublicKey.scala
+++ b/node/src/main/scala/com/wavesplatform/crypto/bls/BlsPublicKey.scala
@@ -3,26 +3,26 @@ package com.wavesplatform.crypto.bls
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.transaction.TxValidationError.GenericError
 
-case class BlsPublicKey private (byteStr: ByteStr) extends AnyVal {
-  def arr: Array[Byte] = byteStr.arr
-
-  def verify(message: Array[Byte], signature: BlsSignature): Boolean =
-    BlsUtils.verifyBasic(signature.arr, message, arr)
-
-  def base58: String            = byteStr.toString
-  override def toString: String = byteStr.toString
-}
+opaque type BlsPublicKey = ByteStr
 
 object BlsPublicKey {
   val SizeInBytes = 48
 
-  private[bls] def unsafe(byteStr: ByteStr): BlsPublicKey = new BlsPublicKey(byteStr)
+  extension (self: BlsPublicKey) {
+    def byteStr: ByteStr = self
+    def arr: Array[Byte] = byteStr.arr
+
+    def verify(message: Array[Byte], signature: BlsSignature): Boolean = BlsUtils.verifyBasic(signature.arr, message, arr)
+
+    def base58: String = byteStr.toString
+  }
+
+  private[bls] def unsafe(byteStr: ByteStr): BlsPublicKey = byteStr
 
   def apply(arr: Array[Byte]): Either[GenericError, BlsPublicKey] = apply(ByteStr(arr))
-  def apply(byteStr: ByteStr): Either[GenericError, BlsPublicKey] =
-    Either.cond(
-      byteStr.arr.length == SizeInBytes,
-      new BlsPublicKey(byteStr),
-      GenericError(s"Unexpected BLS public key length: ${byteStr.arr.length}, expected: $SizeInBytes")
-    )
+  def apply(byteStr: ByteStr): Either[GenericError, BlsPublicKey] = Either.cond(
+    byteStr.arr.length == SizeInBytes,
+    byteStr,
+    GenericError(s"Unexpected BLS public key length: ${byteStr.arr.length}, expected: $SizeInBytes")
+  )
 }

--- a/node/src/main/scala/com/wavesplatform/crypto/bls/BlsPublicKey.scala
+++ b/node/src/main/scala/com/wavesplatform/crypto/bls/BlsPublicKey.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.common.state.ByteStr
 case class BlsPublicKey private (byteStr: ByteStr) extends AnyVal {
   def arr: Array[Byte] = byteStr.arr
 
-  def verify(message: Array[Byte], signature: BlsSignature.NonEmpty): Boolean =
+  def verify(message: Array[Byte], signature: BlsSignature): Boolean =
     BlsUtils.verifyBasic(signature.arr, message, arr)
 
   def base58: String            = byteStr.toString
@@ -16,6 +16,6 @@ object BlsPublicKey {
   val SizeInBytes = 48
 
   // TODO: check size
-  def apply(arr: Array[Byte]): BlsPublicKey = new BlsPublicKey(ByteStr(arr))
+  def apply(arr: Array[Byte]): BlsPublicKey = apply(ByteStr(arr))
   def apply(byteStr: ByteStr): BlsPublicKey = new BlsPublicKey(byteStr)
 }

--- a/node/src/main/scala/com/wavesplatform/crypto/bls/BlsPublicKey.scala
+++ b/node/src/main/scala/com/wavesplatform/crypto/bls/BlsPublicKey.scala
@@ -1,6 +1,7 @@
 package com.wavesplatform.crypto.bls
 
 import com.wavesplatform.common.state.ByteStr
+import com.wavesplatform.transaction.TxValidationError.GenericError
 
 case class BlsPublicKey private (byteStr: ByteStr) extends AnyVal {
   def arr: Array[Byte] = byteStr.arr
@@ -15,7 +16,13 @@ case class BlsPublicKey private (byteStr: ByteStr) extends AnyVal {
 object BlsPublicKey {
   val SizeInBytes = 48
 
-  // TODO: check size
-  def apply(arr: Array[Byte]): BlsPublicKey = apply(ByteStr(arr))
-  def apply(byteStr: ByteStr): BlsPublicKey = new BlsPublicKey(byteStr)
+  private[bls] def unsafe(byteStr: ByteStr): BlsPublicKey = new BlsPublicKey(byteStr)
+
+  def apply(arr: Array[Byte]): Either[GenericError, BlsPublicKey] = apply(ByteStr(arr))
+  def apply(byteStr: ByteStr): Either[GenericError, BlsPublicKey] =
+    Either.cond(
+      byteStr.arr.length == SizeInBytes,
+      new BlsPublicKey(byteStr),
+      GenericError(s"Unexpected BLS public key length: ${byteStr.arr.length}, expected: $SizeInBytes")
+    )
 }

--- a/node/src/main/scala/com/wavesplatform/crypto/bls/BlsSignature.scala
+++ b/node/src/main/scala/com/wavesplatform/crypto/bls/BlsSignature.scala
@@ -1,57 +1,30 @@
 package com.wavesplatform.crypto.bls
 
 import com.wavesplatform.common.state.ByteStr
-import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.transaction.TxValidationError.GenericError
 
-sealed abstract class BlsSignature(val byteStr: ByteStr) {
-  def arr: Array[Byte]          = byteStr.arr
-  def base58: String            = byteStr.toString
-  override def toString: String = byteStr.toString
-}
+opaque type BlsSignature = ByteStr
 
 object BlsSignature {
   val SizeInBytes = 96
 
-  object Empty extends BlsSignature(ByteStr.empty) {
-    override def toString: String = "empty"
-  }
+  extension (self: BlsSignature) {
+    def byteStr: ByteStr = self
+    def arr: Array[Byte] = byteStr.arr
+    def base58: String   = byteStr.toString
 
-  case class NonEmpty private (override val byteStr: ByteStr) extends BlsSignature(byteStr) {
     def verifyAgg(message: Array[Byte], blsPks: Iterable[BlsPublicKey]): Either[String, Boolean] =
       BlsUtils.verifyAgg(byteStr.arr, message, blsPks.map(_.arr))
+
+    def append(other: BlsSignature): BlsSignature = ByteStr(BlsUtils.aggSign(self.arr, other.arr))
   }
 
-  object NonEmpty {
-    // TODO: check size and add def unsafe for append
-    def apply(arr: Array[Byte]): NonEmpty               = new NonEmpty(ByteStr(arr))
-    def apply(byteStr: ByteStr): NonEmpty               = new NonEmpty(byteStr)
-    private[bls] def unsafe(byteStr: ByteStr): NonEmpty = NonEmpty(byteStr)
-  }
+  private[bls] def unsafe(byteStr: ByteStr): BlsSignature = byteStr
 
-  def apply(arr: Array[Byte]): Either[ValidationError, NonEmpty] = apply(ByteStr(arr))
-  def apply(byteStr: ByteStr): Either[ValidationError, NonEmpty] = Either.cond(
+  def apply(arr: Array[Byte]): Either[GenericError, BlsSignature] = apply(ByteStr(arr))
+  def apply(byteStr: ByteStr): Either[GenericError, BlsSignature] = Either.cond(
     byteStr.arr.length == SizeInBytes,
-    NonEmpty.unsafe(byteStr),
+    byteStr,
     GenericError(s"Unexpected BLS signature length: ${byteStr.arr.length}, expected: $SizeInBytes")
   )
-
-  def mayBeEmpty(arr: Array[Byte]): Either[ValidationError, BlsSignature] = mayBeEmpty(ByteStr(arr))
-  def mayBeEmpty(byteStr: ByteStr): Either[ValidationError, BlsSignature] =
-    if (byteStr.isEmpty) Right(BlsSignature.Empty)
-    else
-      Either.cond(
-        byteStr.arr.length == SizeInBytes,
-        NonEmpty.unsafe(byteStr),
-        GenericError(s"Unexpected BLS signature length: ${byteStr.arr.length}, expected: $SizeInBytes")
-      )
-
-  extension (self: BlsSignature) {
-    def isDefined: Boolean = self != Empty
-
-    def append(other: BlsSignature.NonEmpty): BlsSignature.NonEmpty = self match {
-      case Empty          => other
-      case self: NonEmpty => NonEmpty(ByteStr(BlsUtils.aggSign(self.arr, other.arr)))
-    }
-  }
 }

--- a/node/src/main/scala/com/wavesplatform/database/package.scala
+++ b/node/src/main/scala/com/wavesplatform/database/package.scala
@@ -379,7 +379,7 @@ package object database {
         val (addressIdBytes, blsPublicKeyBytes) = data.splitAt(addressSize)
         (
           Longs.fromByteArray(addressIdBytes),
-          BlsPublicKey(blsPublicKeyBytes)
+          BlsPublicKey(blsPublicKeyBytes).explicitGet()
         )
       }
       .toSeq

--- a/node/src/main/scala/com/wavesplatform/protobuf/PBSnapshots.scala
+++ b/node/src/main/scala/com/wavesplatform/protobuf/PBSnapshots.scala
@@ -173,7 +173,7 @@ object PBSnapshots {
       }.toMap
 
     val nextCommittedGenerators = pbSnapshot.generationCommitment.map { x =>
-      x.senderPublicKey.toPublicKey -> BlsPublicKey(x.endorserPublicKey.toByteArray)
+      x.senderPublicKey.toPublicKey -> BlsPublicKey(x.endorserPublicKey.toByteArray).explicitGet()
     }.toSeq
 
     (

--- a/node/src/main/scala/com/wavesplatform/protobuf/block/PBEndorseBlocks.scala
+++ b/node/src/main/scala/com/wavesplatform/protobuf/block/PBEndorseBlocks.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.protobuf.*
 import com.wavesplatform.state.{GeneratorIndex, Height}
 
 object PBEndorseBlocks {
-  def vanilla(x: PBEndorseBlock, sig: BlsSignature.NonEmpty): BlockEndorsement = BlockEndorsement(
+  def vanilla(x: PBEndorseBlock, sig: BlsSignature): BlockEndorsement = BlockEndorsement(
     GeneratorIndex(x.endorserIndex),
     x.finalizedBlockId.toByteStr,
     Height(x.finalizedBlockHeight),

--- a/node/src/main/scala/com/wavesplatform/protobuf/block/PBFinalizationVotings.scala
+++ b/node/src/main/scala/com/wavesplatform/protobuf/block/PBFinalizationVotings.scala
@@ -1,5 +1,6 @@
 package com.wavesplatform.protobuf.block
 
+import com.google.protobuf.ByteString
 import com.wavesplatform.common.utils.EitherExt2.explicitGet
 import com.wavesplatform.crypto.bls.BlsSignature
 import com.wavesplatform.protobuf.*
@@ -10,8 +11,8 @@ import scala.util.Try
 object PBFinalizationVotings {
   def vanilla(pb: PBFinalizationVoting): Try[VanillaFinalizationVoting] = Try {
     val aggSig =
-      if (pb.aggregatedEndorsementSignature.isEmpty) BlsSignature.Empty
-      else BlsSignature(pb.aggregatedEndorsementSignature.toByteArray).explicitGet()
+      if (pb.aggregatedEndorsementSignature.isEmpty) None
+      else Option(BlsSignature(pb.aggregatedEndorsementSignature.toByteArray).explicitGet())
 
     VanillaFinalizationVoting(
       GeneratorIndex.seq(pb.endorserIndexes),
@@ -29,7 +30,7 @@ object PBFinalizationVotings {
   def protobuf(v: VanillaFinalizationVoting): PBFinalizationVoting = PBFinalizationVoting.of(
     GeneratorIndex.toInts(v.valid),
     v.finalizedHeight.toInt,
-    v.aggregatedEndorsement.byteStr.toByteString,
+    v.aggregatedEndorsement.fold(ByteString.EMPTY)(_.byteStr.toByteString),
     v.conflict.map(PBEndorseBlocks.protobuf)
   )
 }

--- a/node/src/main/scala/com/wavesplatform/protobuf/package.scala
+++ b/node/src/main/scala/com/wavesplatform/protobuf/package.scala
@@ -3,7 +3,6 @@ package com.wavesplatform
 import com.google.protobuf.ByteString
 import com.wavesplatform.account.{Address, AddressScheme, PublicKey}
 import com.wavesplatform.common.state.ByteStr
-import com.wavesplatform.crypto.bls.BlsPublicKey
 import com.wavesplatform.protobuf.transaction.PBRecipients
 import com.wavesplatform.state.TransactionId
 import com.wavesplatform.transaction.Asset
@@ -34,7 +33,6 @@ package object protobuf {
       PBRecipients
         .toAddress(bs.toByteArray, chainId)
         .fold(ve => throw new IllegalArgumentException(ve.toString), identity)
-    def toBlsPublicKey: BlsPublicKey     = BlsPublicKey(bs.toByteArray)
     def toIssuedAsset: Asset.IssuedAsset = Asset.IssuedAsset(toByteStr)
   }
 }

--- a/node/src/main/scala/com/wavesplatform/protobuf/transaction/PBTransactions.scala
+++ b/node/src/main/scala/com/wavesplatform/protobuf/transaction/PBTransactions.scala
@@ -618,7 +618,7 @@ object PBTransactions {
           Height(generationPeriodStart),
           timestamp,
           TxPositiveAmount.unsafeFrom(feeAmount),
-          BlsSignature.mayBeEmpty(commitmentSignature.toByteStr).explicitGet(),
+          BlsSignature(commitmentSignature.toByteStr).explicitGet(),
           proofs,
           chainId
         )

--- a/node/src/main/scala/com/wavesplatform/protobuf/transaction/PBTransactions.scala
+++ b/node/src/main/scala/com/wavesplatform/protobuf/transaction/PBTransactions.scala
@@ -332,7 +332,7 @@ object PBTransactions {
           tx <- CommitToGenerationTransaction.create(
             version.toByte,
             sender.toPublicKey,
-            BlsPublicKey(endorserPublicKey.toByteStr),
+            BlsPublicKey(endorserPublicKey.toByteStr).explicitGet(),
             Height(generationPeriodStart),
             timestamp,
             feeAmount,
@@ -614,7 +614,7 @@ object PBTransactions {
         CommitToGenerationTransaction(
           version.toByte,
           sender.toPublicKey,
-          BlsPublicKey(endorserPublicKey.toByteStr),
+          BlsPublicKey(endorserPublicKey.toByteStr).explicitGet(),
           Height(generationPeriodStart),
           timestamp,
           TxPositiveAmount.unsafeFrom(feeAmount),

--- a/node/src/main/scala/com/wavesplatform/state/EndorsementStorage.scala
+++ b/node/src/main/scala/com/wavesplatform/state/EndorsementStorage.scala
@@ -43,7 +43,7 @@ object EndorsementStorage {
     private val sharedWithNeighbors     = mutable.HashSet.empty[EndorseBlock]
     private val processedValidEndorsers = mutable.HashSet.empty[GeneratorIndex]
 
-    private var valid    = immutable.IntMap.empty[BlsSignature.NonEmpty]
+    private var valid    = immutable.IntMap.empty[BlsSignature]
     private var conflict = immutable.IntMap.empty[BlockEndorsement]
 
     private var latestResult = FinalizationResult.empty
@@ -59,7 +59,7 @@ object EndorsementStorage {
         _             <- Either.raiseWhen(msg.endorserIndex >= filter.endorsers.size)(s"There are only ${filter.endorsers.size} endorsers")
         endorserIndex <- GeneratorIndex.checked(msg.endorserIndex).toRight(s"Invalid endorser index: ${msg.endorserIndex}")
         (_, endorserPk, _) = filter.endorsers(msg.endorserIndex)
-        sig <- verifySig(msg, endorserPk).toRight("Invalid signature")
+        sig <- verifySig(msg, endorserPk)
       } yield
         if (sharedWithNeighbors.contains(msg) || conflict.isDefinedAt(msg.endorserIndex) || filter.conflict.contains(endorserIndex)) false
         else {
@@ -143,7 +143,7 @@ object EndorsementStorage {
       val votingWithoutValid = FinalizationVoting(
         valid = Seq.empty,
         finalizedHeight = currentFilter.finalizedHeight,
-        aggregatedEndorsement = BlsSignature.Empty,
+        aggregatedEndorsement = None,
         conflict = conflict.values.toIndexedSeq
       )
 
@@ -154,10 +154,12 @@ object EndorsementStorage {
       FinalizationResult(simulationResult.reachedFinalization, voting)
     }
 
-    private def verifySig(msg: EndorseBlock, pk: BlsPublicKey): Option[BlsSignature.NonEmpty] =
+    private def verifySig(msg: EndorseBlock, pk: BlsPublicKey): Either[String, BlsSignature] =
       for {
-        sig <- BlsSignature(msg.signature).toOption
-        _   <- Option.when(pk.verify(BlockEndorsement.mkMessage(msg.finalizedId, msg.finalizedHeight, msg.endorsedId), sig))(sig)
+        sig <- BlsSignature(msg.signature).leftMap(_.err)
+        _ <- Either.raiseUnless(pk.verify(BlockEndorsement.mkMessage(msg.finalizedId, msg.finalizedHeight, msg.endorsedId), sig)) {
+          "BLS signature is invalid"
+        }
       } yield sig
   }
 
@@ -169,7 +171,7 @@ object EndorsementStorage {
         FinalizationVoting(
           valid = Seq.empty,
           finalizedHeight = GenesisBlockHeight,
-          aggregatedEndorsement = BlsSignature.Empty,
+          aggregatedEndorsement = None,
           conflict = IndexedSeq.empty
         )
       )

--- a/node/src/main/scala/com/wavesplatform/state/appender/package.scala
+++ b/node/src/main/scala/com/wavesplatform/state/appender/package.scala
@@ -380,9 +380,9 @@ package object appender {
           conflictingEndorsers            = fv.conflict.map(_.endorserIndex).toSet
           nonConflictingGeneratorBalances = validGeneratorBalances.filterNot(x => conflictingEndorsers.contains(x.index))
           _ <- fv.aggregatedEndorsement match {
-            case None => Either.raiseWhen(fv.valid.nonEmpty)("No endorsements are included, but aggregated endorsement signature is non-empty")
+            case None => Either.raiseWhen(validEndorsers.nonEmpty)("No endorsements are included, but aggregated endorsement signature is non-empty")
             case Some(aggregatedEndorsement) =>
-              if (fv.valid.isEmpty) Left("Endorsements are included, but aggregated endorsement signature is empty")
+              if (validEndorsers.isEmpty) Left("Endorsements are included, but aggregated endorsement signature is empty")
               else
                 for {
                   finalizedBlockId <- blockchain.blockId(fv.finalizedHeight.toInt).toRight(s"Unable to get block ID at height ${fv.finalizedHeight}")

--- a/node/src/main/scala/com/wavesplatform/state/appender/package.scala
+++ b/node/src/main/scala/com/wavesplatform/state/appender/package.scala
@@ -379,23 +379,23 @@ package object appender {
             )
           conflictingEndorsers            = fv.conflict.map(_.endorserIndex).toSet
           nonConflictingGeneratorBalances = validGeneratorBalances.filterNot(x => conflictingEndorsers.contains(x.index))
-          _ <-
-            if (fv.valid.isEmpty)
-              Either.raiseUnless(fv.aggregatedEndorsement.arr.isEmpty)(
-                "No endorsements are included, but aggregated endorsement signature is non-empty"
-              )
-            else
-              for {
-                finalizedBlockId <- blockchain.blockId(fv.finalizedHeight.toInt).toRight(s"Unable to get block ID at height ${fv.finalizedHeight}")
-                _ <-
-                  if (validEndorsers.isEmpty) Right(())
-                  else
-                    BlsUtils.verifyAgg(
-                      fv.aggregatedEndorsement.arr,
-                      BlockEndorsement.mkMessage(finalizedBlockId, fv.finalizedHeight, block.header.reference),
-                      validEndorsers.view.map(_._2.arr)
-                    )
-              } yield ()
+          _ <- fv.aggregatedEndorsement match {
+            case None => Either.raiseWhen(fv.valid.nonEmpty)("No endorsements are included, but aggregated endorsement signature is non-empty")
+            case Some(aggregatedEndorsement) =>
+              if (fv.valid.isEmpty) Left("Endorsements are included, but aggregated endorsement signature is empty")
+              else
+                for {
+                  finalizedBlockId <- blockchain.blockId(fv.finalizedHeight.toInt).toRight(s"Unable to get block ID at height ${fv.finalizedHeight}")
+                  _ <-
+                    if (validEndorsers.isEmpty) Either.unit
+                    else
+                      BlsUtils.verifyAgg(
+                        aggregatedEndorsement.arr,
+                        BlockEndorsement.mkMessage(finalizedBlockId, fv.finalizedHeight, block.header.reference),
+                        validEndorsers.view.map(_._2.arr)
+                      )
+                } yield ()
+          }
         } yield nonConflictingGeneratorBalances
       }
       .leftMap(s => BlockAppendError(s, block))

--- a/node/src/main/scala/com/wavesplatform/transaction/CommitToGenerationTransaction.scala
+++ b/node/src/main/scala/com/wavesplatform/transaction/CommitToGenerationTransaction.scala
@@ -44,13 +44,8 @@ object CommitToGenerationTransaction {
 
   implicit val validator: TxValidator[CommitToGenerationTransaction] = CommitToGenerationTxValidator
 
-  implicit def signed(tx: CommitToGenerationTransaction, privateKey: PrivateKey): CommitToGenerationTransaction = {
-    val blsKP  = BlsKeyPair(privateKey)
-    val blsSig = mkPopSignature(blsKP, tx.generationPeriodStart)
-
-    val txWithBlsSig = tx.copy(endorserPublicKey = blsKP.publicKey, commitmentSignature = blsSig)
-    txWithBlsSig.copy(proofs = Proofs(crypto.sign(privateKey, txWithBlsSig.bodyBytes())))
-  }
+  implicit def signed(tx: CommitToGenerationTransaction, privateKey: PrivateKey): CommitToGenerationTransaction =
+    tx.copy(proofs = Proofs(crypto.sign(privateKey, tx.bodyBytes())))
 
   def withBls(tx: CommitToGenerationTransaction, blsKeyPair: BlsKeyPair): CommitToGenerationTransaction = {
     val blsSig = mkPopSignature(blsKeyPair, tx.generationPeriodStart)
@@ -95,17 +90,9 @@ object CommitToGenerationTransaction {
       generationPeriodStart: Height,
       timestamp: TxTimestamp,
       feeInWaves: Long,
+      commitmentSignature: BlsSignature,
       chainId: Byte = AddressScheme.current.chainId
   ): Either[ValidationError, CommitToGenerationTransaction] =
-    create(
-      version,
-      sender.publicKey,
-      endorserPublicKey,
-      generationPeriodStart,
-      timestamp,
-      feeInWaves,
-      commitmentSignature = BlsSignature.Empty,
-      Proofs.empty,
-      chainId
-    ).map(signed(_, sender.privateKey))
+    create(version, sender.publicKey, endorserPublicKey, generationPeriodStart, timestamp, feeInWaves, commitmentSignature, Proofs.empty, chainId)
+      .map(signed(_, sender.privateKey))
 }

--- a/node/src/main/scala/com/wavesplatform/transaction/CommitToGenerationTransaction.scala
+++ b/node/src/main/scala/com/wavesplatform/transaction/CommitToGenerationTransaction.scala
@@ -47,11 +47,6 @@ object CommitToGenerationTransaction {
   implicit def signed(tx: CommitToGenerationTransaction, privateKey: PrivateKey): CommitToGenerationTransaction =
     tx.copy(proofs = Proofs(crypto.sign(privateKey, tx.bodyBytes())))
 
-  def withBls(tx: CommitToGenerationTransaction, blsKeyPair: BlsKeyPair): CommitToGenerationTransaction = {
-    val blsSig = mkPopSignature(blsKeyPair, tx.generationPeriodStart)
-    tx.copy(endorserPublicKey = blsKeyPair.publicKey, commitmentSignature = blsSig)
-  }
-
   def mkPopSignature(blsKeyPair: BlsKeyPair, generationPeriodStart: Height): BlsSignature.NonEmpty = {
     val blsMessage = blsKeyPair.publicKey.arr ++ generationPeriodStart.toByteArray
     blsKeyPair.sign(blsMessage)

--- a/node/src/main/scala/com/wavesplatform/transaction/CommitToGenerationTransaction.scala
+++ b/node/src/main/scala/com/wavesplatform/transaction/CommitToGenerationTransaction.scala
@@ -47,7 +47,7 @@ object CommitToGenerationTransaction {
   implicit def signed(tx: CommitToGenerationTransaction, privateKey: PrivateKey): CommitToGenerationTransaction =
     tx.copy(proofs = Proofs(crypto.sign(privateKey, tx.bodyBytes())))
 
-  def mkPopSignature(blsKeyPair: BlsKeyPair, generationPeriodStart: Height): BlsSignature.NonEmpty = {
+  def mkPopSignature(blsKeyPair: BlsKeyPair, generationPeriodStart: Height): BlsSignature = {
     val blsMessage = blsKeyPair.publicKey.arr ++ generationPeriodStart.toByteArray
     blsKeyPair.sign(blsMessage)
   }

--- a/node/src/main/scala/com/wavesplatform/transaction/TransactionFactory.scala
+++ b/node/src/main/scala/com/wavesplatform/transaction/TransactionFactory.scala
@@ -8,6 +8,7 @@ import com.wavesplatform.api.http.requests.InvokeExpressionRequest.*
 import com.wavesplatform.api.http.requests.SponsorFeeRequest.*
 import com.wavesplatform.api.http.versionReads
 import com.wavesplatform.common.state.ByteStr
+import com.wavesplatform.crypto.bls.BlsKeyPair
 import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.lang.script.Script
 import com.wavesplatform.lang.script.v1.ExprScript
@@ -288,10 +289,8 @@ class TransactionFactory(wallet: Wallet, time: Time, currentPeriod: Option[Gener
         case None         => Left(GenericError("invalid.sender"))
       }
       signer <- wallet.findPrivateKey(signerAddress)
-      tx     <- request.copy(timestamp = request.timestamp.orElse(Some(time.getTimestamp()))).toTxFrom(sender.publicKey, defaultPeriod.start)
-    } yield {
-      tx.signWith(signer.privateKey)
-    }
+      tx     <- request.toTxFrom(sender.publicKey, BlsKeyPair(signer.privateKey), defaultPeriod.start, time.getTimestamp())
+    } yield tx.signWith(signer.privateKey)
   }
 
   def parseRequestAndSign(signerAddress: String, jsv: JsObject): Either[ValidationError, Transaction] = {

--- a/node/src/main/scala/com/wavesplatform/transaction/validation/impl/CommitToGenerationTxValidator.scala
+++ b/node/src/main/scala/com/wavesplatform/transaction/validation/impl/CommitToGenerationTxValidator.scala
@@ -1,12 +1,10 @@
 package com.wavesplatform.transaction.validation.impl
 
+import cats.data.Validated.Valid
 import com.wavesplatform.transaction.CommitToGenerationTransaction
 import com.wavesplatform.transaction.validation.*
 
 object CommitToGenerationTxValidator extends TxValidator[CommitToGenerationTransaction] {
-  override def validate(tx: CommitToGenerationTransaction): ValidatedV[CommitToGenerationTransaction] = {
-    V.seq(tx)(
-      V.cond(true, ???) // TODO: Check PK
-    )
-  }
+  override def validate(tx: CommitToGenerationTransaction): ValidatedV[CommitToGenerationTransaction] =
+    Valid(tx) // Nothing to validate
 }

--- a/node/testkit/src/main/scala/com/wavesplatform/transaction/TxHelpers.scala
+++ b/node/testkit/src/main/scala/com/wavesplatform/transaction/TxHelpers.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.account.*
 import com.wavesplatform.block.Block.BlockId
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.common.utils.EitherExt2.*
-import com.wavesplatform.crypto.bls.{BlsKeyPair, BlsPublicKey}
+import com.wavesplatform.crypto.bls.BlsKeyPair
 import com.wavesplatform.crypto.{DigestLength, SignatureLength}
 import com.wavesplatform.lang.directives.values.*
 import com.wavesplatform.lang.script.ContractScript.ContractScriptImpl
@@ -468,22 +468,25 @@ object TxHelpers {
   def commitToGeneration(
       generationPeriodStart: Height,
       sender: KeyPair = defaultSigner,
-      endorserPublicKey: BlsPublicKey = BlsKeyPair(defaultSigner.privateKey).publicKey,
       timestamp: TxTimestamp = timestamp,
       fee: Long = TestValues.commitToGenerationFee,
       chainId: Byte = AddressScheme.current.chainId,
       version: TxVersion = TxVersion.V1
-  ): CommitToGenerationTransaction = CommitToGenerationTransaction
-    .selfSigned(
-      version,
-      sender,
-      endorserPublicKey,
-      generationPeriodStart,
-      timestamp,
-      fee,
-      chainId
-    )
-    .explicitGet()
+  ): CommitToGenerationTransaction = {
+    val endorserKp = BlsKeyPair(sender.privateKey)
+    CommitToGenerationTransaction
+      .selfSigned(
+        version,
+        sender,
+        endorserKp.publicKey,
+        generationPeriodStart,
+        timestamp,
+        fee,
+        CommitToGenerationTransaction.mkPopSignature(endorserKp, generationPeriodStart),
+        chainId
+      )
+      .explicitGet()
+  }
 
   def ciFee(sc: Int = 0, nonNftIssue: Int = 0, freeCall: Boolean = false): Long =
     invokeFee(freeCall) + (sc + 1) * ScriptExtraFee - 1 + nonNftIssue * FeeConstants(TransactionType.Issue) * FeeUnit

--- a/node/tests/src/test/scala/com/wavesplatform/finalization/BaseFinalizationSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/finalization/BaseFinalizationSpec.scala
@@ -17,9 +17,8 @@ trait BaseFinalizationSpec extends FreeSpec, WithDomain, WithResourceManager, Ei
   protected def mkFinalizationVoting(
       valid: Seq[GeneratorIndex] = Nil,
       finalizedHeight: Height = GenesisBlockHeight,
-      aggregatedEndorsement: BlsSignature = BlsSignature.Empty,
       conflict: Seq[BlockEndorsement] = Nil
-  ): FinalizationVoting = FinalizationVoting(valid, finalizedHeight, aggregatedEndorsement, conflict)
+  ): FinalizationVoting = FinalizationVoting(valid, finalizedHeight, aggregatedEndorsement = None, conflict)
 
   protected def mkConflictEndorsement(
       wavesAcc: KeyPair,
@@ -48,15 +47,19 @@ trait BaseFinalizationSpec extends FreeSpec, WithDomain, WithResourceManager, Ei
     ): FinalizationVoting = self.copy(conflict = self.conflict :+ mkConflictEndorsement(wavesAcc, idx, endorsedId, finalizedHeight, finalizedId))
 
     def signed(endorsedId: BlockId, finalizedId: BlockId, validEndorsers: KeyPair*): FinalizationVoting = {
-      val aggSig = validEndorsers.foldLeft(BlsSignature.Empty: BlsSignature) { case (r, kp) =>
-        val sig = BlockEndorsement.sign(
-          BlsKeyPair(kp.privateKey),
-          finalizedId = finalizedId,
-          finalizedHeight = GenesisBlockHeight,
-          endorsedId = endorsedId
-        )
-        r.append(sig)
-      }
+      val aggSig = validEndorsers
+        .map { kp =>
+          BlockEndorsement.sign(
+            BlsKeyPair(kp.privateKey),
+            finalizedId = finalizedId,
+            finalizedHeight = GenesisBlockHeight,
+            endorsedId = endorsedId
+          )
+        }
+        .foldLeft(Option.empty[BlsSignature]) {
+          case (None, s)    => Some(s)
+          case (Some(r), s) => Some(r.append(s))
+        }
 
       self.copy(aggregatedEndorsement = aggSig)
     }

--- a/node/tests/src/test/scala/com/wavesplatform/finalization/BlockValidationAfterFinalizationSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/finalization/BlockValidationAfterFinalizationSpec.scala
@@ -19,6 +19,19 @@ class BlockValidationAfterFinalizationSpec extends BaseFinalizationSpec {
       )
     )
 
+  "should append a valid block" - {
+    "with finalization voting" in new BaseTest {
+      override def continue(d: Domain): Unit = {
+        val block3WithVotes = d.createBlock(
+          mkFinalizationVoting(valid = Seq(committedGenerator2Idx))
+            .signed(endorsedId = d.lastBlockId, finalizedId = d.blockchain.blockHeader(GenesisBlockHeight.toInt).value.id(), committedGenerator2)
+        )
+
+        d.appender.appendBlockWithoutFallback(block3WithVotes) should beRight
+      }
+    }.run()
+  }
+
   "should not append an invalid block" - {
     "voting for finalized block" in new BaseTest {
       override def continue(d: Domain): Unit = {
@@ -29,6 +42,30 @@ class BlockValidationAfterFinalizationSpec extends BaseFinalizationSpec {
         )
 
         d.appender.appendBlockWithoutFallback(block3WithVotes) should produce("Voting for finalized block")
+      }
+    }.run()
+
+    "nonempty aggregated signature, but empty valid endorsers" in new BaseTest {
+      override def continue(d: Domain): Unit = {
+        val block3WithVotes = d.createBlock(
+          mkFinalizationVoting()
+            .withConflict(committedGenerator2, committedGenerator2Idx, d.lastBlock.id(), GenesisBlockHeight)
+            .signed(endorsedId = d.lastBlockId, finalizedId = d.blockchain.blockHeader(GenesisBlockHeight.toInt).value.id(), committedGenerator3)
+        )
+
+        d.appender.appendBlockWithoutFallback(block3WithVotes) should produce(
+          "Endorsements are included, but aggregated endorsement signature is empty"
+        )
+      }
+    }.run()
+
+    "empty aggregated signature, but nonempty valid endorsers" in new BaseTest {
+      override def continue(d: Domain): Unit = {
+        val block3WithVotes = d.createBlock(mkFinalizationVoting(valid = Seq(committedGenerator2Idx)))
+
+        d.appender.appendBlockWithoutFallback(block3WithVotes) should produce(
+          "No endorsements are included, but aggregated endorsement signature is non-empty"
+        )
       }
     }.run()
 
@@ -84,10 +121,14 @@ class BlockValidationAfterFinalizationSpec extends BaseFinalizationSpec {
     val committedGenerator2Addr = committedGenerator2.toAddress
     val committedGenerator2Idx  = GeneratorIndex(1)
 
-    val notCommittedGenerator     = TxHelpers.signer(2)
+    val committedGenerator3     = TxHelpers.signer(2)
+    val committedGenerator3Addr = committedGenerator3.toAddress
+    val committedGenerator3Idx  = GeneratorIndex(2)
+
+    val notCommittedGenerator     = TxHelpers.signer(3)
     val notCommittedGeneratorAddr = notCommittedGenerator.toAddress
 
-    val committedGenerators = Seq(committedGenerator1, committedGenerator2)
+    val committedGenerators = Seq(committedGenerator1, committedGenerator2, committedGenerator3)
     val allGenerators       = notCommittedGenerator +: committedGenerators
 
     def continue(d: Domain): Unit

--- a/node/tests/src/test/scala/com/wavesplatform/http/BlocksApiRouteSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/http/BlocksApiRouteSpec.scala
@@ -8,6 +8,7 @@ import com.wavesplatform.api.http.{BlocksApiRoute, CustomJson, RouteTimeout}
 import com.wavesplatform.block.serialization.BlockHeaderSerializer
 import com.wavesplatform.block.{Block, BlockEndorsement, BlockHeader, FinalizationVoting}
 import com.wavesplatform.common.state.ByteStr
+import com.wavesplatform.common.utils.EitherExt2.explicitGet
 import com.wavesplatform.crypto.bls.BlsSignature
 import com.wavesplatform.db.WithDomain
 import com.wavesplatform.db.WithState.AddrWithBalance
@@ -104,7 +105,7 @@ class BlocksApiRouteSpec
         finalizationVoting = Some(
           FinalizationVoting(
             valid = GeneratorIndex.unsafeSeq(Seq(1, 0)),
-            aggregatedEndorsement = BlsSignature.NonEmpty(Array.fill[Byte](BlsSignature.SizeInBytes)(1)),
+            aggregatedEndorsement = Some(BlsSignature(Array.fill[Byte](BlsSignature.SizeInBytes)(1)).explicitGet()),
             finalizedHeight = Height(1),
             conflict = Vector(
               BlockEndorsement(
@@ -112,7 +113,7 @@ class BlocksApiRouteSpec
                 finalizedId = testBlock2.id(),
                 finalizedHeight = Height(1),
                 endorsedId = testBlock1.id(),
-                signature = BlsSignature.NonEmpty(Array.fill[Byte](BlsSignature.SizeInBytes)(2))
+                signature = BlsSignature(Array.fill[Byte](BlsSignature.SizeInBytes)(2)).explicitGet()
               )
             )
           )

--- a/node/tests/src/test/scala/com/wavesplatform/http/GeneratorsApiRouteSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/http/GeneratorsApiRouteSpec.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.api.common.CommonGeneratorsApi
 import com.wavesplatform.api.http.{GeneratorsApiRoute, RouteTimeout}
 import com.wavesplatform.block.{Block, BlockEndorsement, FinalizationVoting}
 import com.wavesplatform.common.state.ByteStr
-import com.wavesplatform.crypto.bls.{BlsKeyPair, BlsSignature}
+import com.wavesplatform.crypto.bls.BlsKeyPair
 import com.wavesplatform.db.WithState
 import com.wavesplatform.db.WithState.AddrWithBalance
 import com.wavesplatform.settings.{WalletSettings, WavesSettings}
@@ -93,7 +93,7 @@ class GeneratorsApiRouteSpec extends RouteSpec("/generators") with RestAPISettin
         FinalizationVoting(
           valid = Nil,
           finalizedHeight = Height(1),
-          aggregatedEndorsement = BlsSignature.Empty,
+          aggregatedEndorsement = None,
           conflict = Vector(
             BlockEndorsement.signed(
               BlsKeyPair(generator2.privateKey),

--- a/node/tests/src/test/scala/com/wavesplatform/http/TransactionsRouteSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/http/TransactionsRouteSpec.scala
@@ -870,8 +870,10 @@ class TransactionsRouteSpec
       )
 
       Post(routePath("/sign"), unsignedTxnJson) ~> ApiKeyHeader ~> route ~> check {
-        status shouldEqual StatusCodes.OK
         val jsObject = responseAs[JsObject]
+        withClue(s"$jsObject ") {
+          status shouldEqual StatusCodes.OK
+        }
         (jsObject \ "generationPeriodStart").as[Int] shouldBe 3001
         (jsObject \ "senderPublicKey").as[String] shouldBe sender.publicKey.toString
         (jsObject \ "endorserPublicKey").as[String] shouldBe blsKP.publicKey.base58
@@ -1063,7 +1065,10 @@ class TransactionsRouteSpec
     "CommitToGeneration transaction" in {
       val txn = TxHelpers.commitToGeneration(Height(settings.blockchainSettings.functionalitySettings.generationPeriodLength + 1))
       Post(routePath("/broadcast"), txn.json()) ~> route ~> check {
-        status shouldEqual StatusCodes.OK
+        val jsObject = responseAs[JsObject]
+        withClue(s"$jsObject ") {
+          status shouldEqual StatusCodes.OK
+        }
       }
     }
   }

--- a/node/tests/src/test/scala/com/wavesplatform/lagonaki/unit/MicroBlockSpecification.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/lagonaki/unit/MicroBlockSpecification.scala
@@ -66,7 +66,7 @@ class MicroBlockSpecification extends FunSuite with MockFactory {
 
     val transactions = Seq(tr, tr2)
 
-    val aggregatedEndorsement = BlsSignature.NonEmpty(Array.fill(BlsSignature.SizeInBytes)(1.toByte))
+    val aggregatedEndorsement = Some(BlsSignature(Array.fill(BlsSignature.SizeInBytes)(1.toByte)).explicitGet())
 
     val finalizedHeight = Height(5)
     val finalizedId     = ByteStr(Array.fill(Block.BlockIdLength)(2.toByte))
@@ -108,12 +108,12 @@ class MicroBlockSpecification extends FunSuite with MockFactory {
 
     val referenceId = decode("37ex9gonRZtUddDHgSzSes5Ds9UeQyS74DyAXtGFrDpJnEg7sjGdi2ncaV4rVpZnLboQmid3whcbZUWS49FV3ZCs")
     val endorsedId  = decode("5GszB5vY2KTxLvYq4zAFQvRkJxv5Rt5BcuTGHZrxgSLTzPtni7eY5k1DN1mJ7mY4ixP5fiHD9z1AfM99AA8yxhjg")
-    val aggregatedSig = BlsSignature.NonEmpty(
+    val aggregatedSig = BlsSignature(
       decode("nBWfaRLW7EdcwxhDMaXuZZFMhHyowAxY7476rkBsUUeguTXrMSNuTVkuWLmZjRmRfgMXEGuvdHiu1V7joRFSLz3X6MQBF8m88kHJEj6Tc2ktBnMTzihh2JMGpuuWBLSK8rv")
-    )
-    val conflictSig = BlsSignature.NonEmpty(
+    ).explicitGet()
+    val conflictSig = BlsSignature(
       decode("RNMTkL736x3TmXfjQufKnxSgySaaoec3WYnxmujcum9BHEmCdjmwvjoUehghqYCWJcNj5CNfb9QdnujV9o2DRitbLgq2bnLdTU5s1DLBWBkVx8mBayvdfx7rPZ3mtUWeh5L")
-    )
+    ).explicitGet()
 
     val conflictFinalizedHeight = 12345
     val conflictEndorsement = BlockEndorsement(
@@ -127,7 +127,7 @@ class MicroBlockSpecification extends FunSuite with MockFactory {
     val finalizationVoting = FinalizationVoting(
       valid = Seq(GeneratorIndex(1), GeneratorIndex(2), GeneratorIndex(3)),
       finalizedHeight = GenesisBlockHeight,
-      aggregatedEndorsement = aggregatedSig,
+      aggregatedEndorsement = Some(aggregatedSig),
       conflict = IndexedSeq(conflictEndorsement)
     )
 
@@ -142,12 +142,12 @@ class MicroBlockSpecification extends FunSuite with MockFactory {
 
     val referenceId = decode("37ex9gonRZtUddDHgSzSes5Ds9UeQyS74DyAXtGFrDpJnEg7sjGdi2ncaV4rVpZnLboQmid3whcbZUWS49FV3ZCs")
     val endorsedId  = decode("5GszB5vY2KTxLvYq4zAFQvRkJxv5Rt5BcuTGHZrxgSLTzPtni7eY5k1DN1mJ7mY4ixP5fiHD9z1AfM99AA8yxhjg")
-    val aggregatedSig = BlsSignature.NonEmpty(
+    val aggregatedSig = BlsSignature(
       decode("nBWfaRLW7EdcwxhDMaXuZZFMhHyowAxY7476rkBsUUeguTXrMSNuTVkuWLmZjRmRfgMXEGuvdHiu1V7joRFSLz3X6MQBF8m88kHJEj6Tc2ktBnMTzihh2JMGpuuWBLSK8rv")
-    )
-    val conflictSig = BlsSignature.NonEmpty(
+    ).explicitGet()
+    val conflictSig = BlsSignature(
       decode("RNMTkL736x3TmXfjQufKnxSgySaaoec3WYnxmujcum9BHEmCdjmwvjoUehghqYCWJcNj5CNfb9QdnujV9o2DRitbLgq2bnLdTU5s1DLBWBkVx8mBayvdfx7rPZ3mtUWeh5L")
-    )
+    ).explicitGet()
 
     val conflictFinalizedHeight = 12345
     val conflictEndorsement = BlockEndorsement(
@@ -161,7 +161,7 @@ class MicroBlockSpecification extends FunSuite with MockFactory {
     val finalizationVoting = FinalizationVoting(
       valid = Seq(GeneratorIndex(1), GeneratorIndex(2), GeneratorIndex(3)),
       finalizedHeight = GenesisBlockHeight,
-      aggregatedEndorsement = aggregatedSig,
+      aggregatedEndorsement = Some(aggregatedSig),
       conflict = IndexedSeq(conflictEndorsement)
     )
 

--- a/node/tests/src/test/scala/com/wavesplatform/state/BlockChallengeTest.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/state/BlockChallengeTest.scala
@@ -291,7 +291,7 @@ class BlockChallengeTest
           FinalizationVoting(
             valid = Seq(GeneratorIndex(1)),
             finalizedHeight = finalizedHeight,
-            aggregatedEndorsement = aggSig,
+            aggregatedEndorsement = Some(aggSig),
             conflict = Vector.empty
           )
         )
@@ -372,7 +372,7 @@ class BlockChallengeTest
           FinalizationVoting(
             valid = Seq(GeneratorIndex(1)),
             finalizedHeight = finalizedHeight,
-            aggregatedEndorsement = aggSig,
+            aggregatedEndorsement = Some(aggSig),
             conflict = Vector.empty
           )
         )

--- a/node/tests/src/test/scala/com/wavesplatform/state/EndorsementStorageSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/state/EndorsementStorageSpec.scala
@@ -70,7 +70,7 @@ class EndorsementStorageSpec extends FreeSpec with EitherValues {
 
         "a wrong signature" in test(
           EndorseBlock(activeGeneratorIndex.toInt, expectedFinalizedId, expectedFinalizedHeight, expectedEndorsedId, ByteStr.empty),
-          "Invalid signature"
+          "Unexpected BLS signature length: 0, expected: 96"
         )
 
         "an unexpected finalized height" in test(
@@ -283,18 +283,19 @@ class EndorsementStorageSpec extends FreeSpec with EitherValues {
           withClue("conflict: ") {
             v.conflict.map(_.endorserIndex) should contain theSameElementsAs conflict
           }
-          v.aggregatedEndorsement match {
-            case BlsSignature.Empty =>
-              if (valid.nonEmpty) fail(s"Signature can't be empty if endorsers nonempty: [${valid.mkString(", ")}]")
-            case aggEnd: BlsSignature.NonEmpty =>
-              withClue("signature: ") {
-                aggEnd
-                  .verifyAgg(
-                    BlockEndorsement.mkMessage(expectedFinalizedId, expectedFinalizedHeight, endorsedId),
-                    valid.map(generators(_).blsKp.publicKey)
-                  )
-                  .value shouldBe true
-              }
+          withClue("signature and valid endorsements: ") {
+            v.aggregatedEndorsement match {
+              case None => if (valid.nonEmpty) fail(s"Signature can't be empty if endorsers nonempty: [${valid.mkString(", ")}]")
+              case Some(aggEnd) =>
+                if (valid.isEmpty) fail(s"Signature must be empty if endorsers empty: $aggEnd, [${valid.mkString(", ")}]")
+                else
+                  aggEnd
+                    .verifyAgg(
+                      BlockEndorsement.mkMessage(expectedFinalizedId, expectedFinalizedHeight, endorsedId),
+                      valid.map(generators(_).blsKp.publicKey)
+                    )
+                    .value shouldBe true
+            }
           }
         case _ =>
       }

--- a/node/tests/src/test/scala/com/wavesplatform/state/diffs/smart/predef/TransactionBindingsTest.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/state/diffs/smart/predef/TransactionBindingsTest.scala
@@ -6,7 +6,6 @@ import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.common.utils.Base58
 import com.wavesplatform.common.utils.EitherExt2.*
 import com.wavesplatform.crypto
-import com.wavesplatform.crypto.bls.BlsKeyPair
 import com.wavesplatform.db.WithDomain
 import com.wavesplatform.db.WithState.AddrWithBalance
 import com.wavesplatform.features.BlockchainFeatures
@@ -879,8 +878,7 @@ class TransactionBindingsTest extends PropSpec with PathMockFactory with EitherV
        """.stripMargin
 
     val account = accountGen.sample.get
-    val blsKp   = BlsKeyPair(account.privateKey)
-    val tx      = TxHelpers.commitToGeneration(Height(3001), account, blsKp.publicKey, timestamp = Random.nextLong())
+    val tx      = TxHelpers.commitToGeneration(Height(3001), account, timestamp = Random.nextLong())
 
     runScriptWithCustomContext[CONST_BOOLEAN](script(tx), tx, V9) shouldBe evaluated(true)
   }

--- a/node/tests/src/test/scala/com/wavesplatform/transaction/ChainIdSpecification.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/transaction/ChainIdSpecification.scala
@@ -6,7 +6,6 @@ import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.common.utils.Base58
 import com.wavesplatform.common.utils.EitherExt2.*
 import com.wavesplatform.crypto
-import com.wavesplatform.crypto.bls.BlsKeyPair
 import com.wavesplatform.protobuf.transaction.{PBTransactions, SignedTransaction as PBSignedTransaction}
 import com.wavesplatform.state.{Height, StringDataEntry}
 import com.wavesplatform.test.PropSpec
@@ -398,17 +397,14 @@ class ChainIdSpecification extends PropSpec {
   property("CommitToGenerationTransaction validation") {
     forAll(addressOrAliasWithVersion) { case (_, version, sender, _, fee, ts) =>
       validateFromOtherNetwork(
-        CommitToGenerationTransaction
-          .selfSigned(
-            version,
-            sender,
-            BlsKeyPair(sender.privateKey).publicKey,
-            Height(3001),
-            ts,
-            fee.value,
-            otherChainId
-          )
-          .explicitGet()
+        TxHelpers.commitToGeneration(
+          generationPeriodStart = Height(3001),
+          sender = sender,
+          timestamp = ts,
+          fee = fee.value,
+          chainId = otherChainId,
+          version = version
+        )
       )
     }
   }

--- a/node/tests/src/test/scala/com/wavesplatform/transaction/CommitToGenerationTransactionsSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/transaction/CommitToGenerationTransactionsSpec.scala
@@ -164,7 +164,8 @@ class CommitToGenerationTransactionsSpec extends FreeSpec with WithDomain {
   }
 
   "Can't commit with invalid commitment signature" in {
-    val newGenerator = TxHelpers.signer(1006)
+    val newGenerator     = TxHelpers.signer(1006)
+    val otherGeneratorKp = BlsKeyPair(TxHelpers.signer(1007).privateKey)
     withDomain(
       DeterministicFinality,
       Seq(
@@ -172,8 +173,11 @@ class CommitToGenerationTransactionsSpec extends FreeSpec with WithDomain {
         AddrWithBalance(newGenerator.toAddress, 10000.waves)
       )
     ) { d =>
-      val unsignedTx = TxHelpers.commitToGeneration(Height(3001), newGenerator).copy(commitmentSignature = BlsSignature.Empty)
-      val signedTx   = unsignedTx.copy(proofs = Proofs(crypto.sign(newGenerator.privateKey, unsignedTx.bodyBytes())))
+      val periodStart = Height(3001)
+      val unsignedTx = TxHelpers
+        .commitToGeneration(periodStart, newGenerator)
+        .copy(commitmentSignature = CommitToGenerationTransaction.mkPopSignature(otherGeneratorKp, periodStart))
+      val signedTx = unsignedTx.copy(proofs = Proofs(crypto.sign(newGenerator.privateKey, unsignedTx.bodyBytes())))
 
       d.appendBlockE(unsignedTx) should produce("Proof doesn't validate as signature")
       d.appendBlockE(signedTx) should produce("Invalid commitment signature")

--- a/node/tests/src/test/scala/com/wavesplatform/transaction/CommitToGenerationTransactionsSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/transaction/CommitToGenerationTransactionsSpec.scala
@@ -22,7 +22,7 @@ class CommitToGenerationTransactionsSpec extends FreeSpec with WithDomain {
   private val origTx = CommitToGenerationTransaction(
     version = TxVersion.V1,
     sender = PublicKey.fromBase58String("FM5ojNqW7e9cZ9zhPYGkpSP1Pcd8Z3e3MNKYVS5pGJ8Z").explicitGet(),
-    endorserPublicKey = BlsPublicKey(Base58.decode("6CagLT3FjEcaNHPYCaG2dcfEfzDj6ynVeZbxbLHkHdfzvbfBmBMkkatTYcBXD9cHMU")),
+    endorserPublicKey = BlsPublicKey(Base58.decode("6CagLT3FjEcaNHPYCaG2dcfEfzDj6ynVeZbxbLHkHdfzvbfBmBMkkatTYcBXD9cHMU")).explicitGet(),
     generationPeriodStart = Height(3000),
     timestamp = 1526287561757L,
     fee = TxPositiveAmount.unsafeFrom(100000000),

--- a/node/tests/src/test/scala/com/wavesplatform/transaction/CommitToGenerationTransactionsSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/transaction/CommitToGenerationTransactionsSpec.scala
@@ -125,9 +125,14 @@ class CommitToGenerationTransactionsSpec extends FreeSpec with WithDomain {
   }
 
   "Can't commit public BLS key twice" in withDomain(DeterministicFinality, AddrWithBalance.enoughBalances(sender, TxHelpers.secondSigner)) { d =>
-    def mkTx(sender: KeyPair, blsKP: BlsKeyPair): CommitToGenerationTransaction = {
-      val unsigned = CommitToGenerationTransaction.withBls(TxHelpers.commitToGeneration(Height(3001), sender), blsKP)
-      unsigned.copy(proofs = Proofs(crypto.sign(sender.privateKey, unsigned.bodyBytes())))
+    def mkTx(sender: KeyPair, blsKp: BlsKeyPair): CommitToGenerationTransaction = {
+      val baseTx = TxHelpers.commitToGeneration(Height(3001), sender)
+      val withPop = baseTx.copy(
+        endorserPublicKey = blsKp.publicKey,
+        commitmentSignature = CommitToGenerationTransaction.mkPopSignature(blsKp, baseTx.generationPeriodStart)
+      )
+
+      withPop.copy(proofs = Proofs(crypto.sign(sender.privateKey, withPop.bodyBytes())))
     }
 
     log.debug("First")

--- a/node/tests/src/test/scala/com/wavesplatform/transaction/ProtoVersionTransactionsSpec.scala
+++ b/node/tests/src/test/scala/com/wavesplatform/transaction/ProtoVersionTransactionsSpec.scala
@@ -4,7 +4,6 @@ import com.wavesplatform.account.KeyPair
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.common.utils.Base64
 import com.wavesplatform.common.utils.EitherExt2.*
-import com.wavesplatform.crypto.bls.BlsKeyPair
 import com.wavesplatform.lang.v1.FunctionHeader.User
 import com.wavesplatform.lang.v1.compiler.Terms.{CONST_LONG, FUNCTION_CALL}
 import com.wavesplatform.protobuf.transaction.{PBSignedTransaction, PBTransactions}
@@ -204,11 +203,9 @@ class ProtoVersionTransactionsSpec extends FreeSpec {
     }
 
     "CommitToGenerationTransaction" in {
-      val blsKp         = BlsKeyPair(Account.privateKey)
-      val sponsorshipTx = CommitToGenerationTransaction.selfSigned(TxVersion.V1, Account, blsKp.publicKey, Height(3001), Now, MinFee).explicitGet()
-      val base64Str     = Base64.encode(PBUtils.encodeDeterministic(PBTransactions.protobuf(sponsorshipTx)))
-
-      decode(base64Str) shouldBe sponsorshipTx
+      val tx        = TxHelpers.commitToGeneration(Height(3001), Account, Now, MinFee)
+      val base64Str = Base64.encode(PBUtils.encodeDeterministic(PBTransactions.protobuf(tx)))
+      decode(base64Str) shouldBe tx
     }
 
     def decode(base64Str: String): Transaction = {


### PR DESCRIPTION
- More optional fields during CommitToGeneration signing
- PoP signature outside `CommitToGenerationTransaction.signed`
- Nothing to validate in `CommitToGenerationTxValidator`
- `BlsSignature` and `BlsPublicKey` are opaque types