### PR TITLE
build: add waves-ext project dependency to core build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,22 @@ lazy val `node-tests` = project
 lazy val `grpc-server` =
   project.dependsOn(node % "compile;runtime->provided", `node-testkit` % "test")
 
+lazy val `waves-ext` = project
+  .in(file("waves-ext"))
+  .dependsOn(node % "compile;runtime->provided", `grpc-server` % "compile->compile", `node-testkit` % "test")
+  .settings(
+    libraryDependencies ++= Dependencies.grpc ++ Seq(
+      "com.iheart" %% "ficus" % "1.5.2"
+    ),
+    inConfig(Compile)(
+      Seq(
+        PB.targets += scalapb.gen(flatPackage = true) -> sourceManaged.value,
+        PB.protoSources += baseDirectory.value / "src" / "main" / "protobuf",
+        PB.deleteTargetDirectory := false
+      )
+    )
+  )
+
 lazy val `ride-runner` = project.dependsOn(node, `grpc-server`, `node-testkit`)
 lazy val `node-it`     = project.dependsOn(`repl-jvm`, `grpc-server`, `node-testkit`)
 
@@ -164,6 +180,7 @@ lazy val `waves-node` = (project in file("."))
     `node-tests`,
     `node-generator`,
     `grpc-server`,
+    `waves-ext`,
     benchmark,
     `ride-runner`
   )


### PR DESCRIPTION
This change integrates the `waves-ext` project dependency directly into the root Waves platform SBT build. 

Key improvements:
- Declared the `waves-ext` lazy project, establishing explicit dependencies on the `node` (compile/runtime) and `grpc-server` modules.
- Added `waves-ext` to the root project's aggregate list, ensuring it compiles as part of the main Waves build and packaging flow.
- Configured proper source generators for Protobuf (`scalapb.gen`) under `waves-ext` to resolve the required schemas dynamically.
- Fixes classloader and linkage issues when loading custom dex extension modules alongside the node JVM in custom network environments.

Developer Contact:
- Email: diegoantunes2301@gmail.com
- WhatsApp: +5511974289097